### PR TITLE
Correct autosizing images

### DIFF
--- a/css/liferea.css
+++ b/css/liferea.css
@@ -76,7 +76,8 @@ dd {
 img {
 	border:0;
 	margin:2px;
-	max-width:100%
+	max-width:100%;
+	height:auto;
 }
 
 img.gravatar {


### PR DESCRIPTION
"height" must be used in conjunction with "max-width" to maintain aspect ratio
