### PR TITLE
check for libtool in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -12,6 +12,12 @@ if [ "$tmp" = "" ]; then
 	exit 1
 fi
 
+tmp=`which libtoolize`
+if [ "$tmp" = "" ]; then
+	echo "ERROR: You need to install libtool!"
+	exit 1
+fi
+
 autoreconf -i
 intltoolize
 if test -z "$NOCONFIGURE"; then


### PR DESCRIPTION
Since libtool it isn't listed anywhere in the dependencies here's a simple change to check for libtool to autogen.sh before trying to run autoreconf.
