### PR TITLE
Adding -Wno-extra-portability argument to automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_CANONICAL_HOST
 AC_CONFIG_SRCDIR([src/feedlist.c])
 
 AC_CONFIG_HEADERS([config.h])
-AM_INIT_AUTOMAKE([1.11 foreign std-options -Wall -Werror])
+AM_INIT_AUTOMAKE([1.11 foreign std-options -Wall -Werror -Wno-extra-portability])
 AM_SILENT_RULES([yes])
 
 AC_PREREQ(2.59)


### PR DESCRIPTION
Version starting at 1.12 include warnings for extra-portability in -Wall as
described in https://lists.gnu.org/archive/html/bug-automake/2012-05/msg00009.html
