### PR TITLE
Stop calling Atom person constructs w/ URI invalid

### DIFF
--- a/src/parsers/atom10.c
+++ b/src/parsers/atom10.c
@@ -234,7 +234,7 @@ atom10_parse_person_construct (xmlNodePtr cur)
 			}
 			
 			if (xmlStrEqual(cur->name, BAD_CAST"uri")) {
-				if (!uri)
+				if (uri)
 					invalid = TRUE;
 				g_free (uri);
 				tmp = (gchar *)xmlNodeListGetString (cur->doc, cur->xmlChildrenNode, 1);


### PR DESCRIPTION
If I am reading the code right, then the conditional I have patched is supposed to do the same thing as the one in the block that parses `email` elements.

Namely, the `email` variable is initialised to `NULL`, so if it already had an allocation when an `<email>` element is encountered, then there must have been another `<email>` element in the person construct before, and this second `<email>` constitutes an error per RFC 4287.

RFC 4287 specifies the same arity for the `<uri>` element, i.e. zero or one `<uri>` elements. The code also initialises the `uri` variable to `NULL` just like the `email` variable.

But the block that parses `<uri>` elements checks if the `uri` variable is **not** `NULL`. If my reading of the code is right, this check will _always_ be true when the _first_ `<uri>` element is encountered, so _any_ person construct that contains a URI will be declared invalid.

This is a bug. The condition needs to be negated.

I noticed this because I recently finally upgraded from 1.8.x, and in many of my feeds, the author metadata suddenly stopped showing up. If this is not the cause of the problem (which it sure seems to be), then there must still be a bug somewhere else.
