### PR TITLE
Drop redundant code from Atom parser

### DIFF
--- a/src/parsers/atom10.c
+++ b/src/parsers/atom10.c
@@ -246,10 +246,9 @@ atom10_parse_person_construct (xmlNodePtr cur)
 		}
 		cur = cur->next;
 	}
-	if (!name) {
+
+	if (!name)
 		invalid = TRUE;
-		name = g_strdup (_("Invalid Atom feed: unknown author"));
-	}
 
 	if (!invalid)
 		tmp = g_strdup_printf ("%s%s%s", name, uri?uri:"", email?email:"");


### PR DESCRIPTION
There is no point in putting anything in `name` after setting `invalid` to `TRUE`, since `name` is then not going to be used anyway, and is only going to be deallocated again a few lines later.
