### PR TITLE
Vertically expand the source selector

### DIFF
--- a/glade/node_source.ui
+++ b/glade/node_source.ui
@@ -84,6 +84,7 @@
               <object class="GtkScrolledWindow" id="scrolledwindow1">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="vexpand">True</property>
                 <property name="hscrollbar_policy">never</property>
                 <property name="shadow_type">in</property>
                 <child>


### PR DESCRIPTION
Resizing the source selector window will also expand the scrolled window. Without this change the scrolled window remains the same height no matter how tall the window is.