### PR TITLE
Fixes a random crash on startup

### DIFF
--- a/src/ui/feed_list_node.c
+++ b/src/ui/feed_list_node.c
@@ -311,7 +311,7 @@ feed_list_node_update (const gchar *nodeId)
         	      NODE_CAPABILITY_SHOW_ITEM_COUNT);
 
 	if (node->unreadCount == 0 && (labeltype & NODE_CAPABILITY_SHOW_UNREAD_COUNT))
-		labeltype -= NODE_CAPABILITY_SHOW_UNREAD_COUNT;
+		labeltype &= ~NODE_CAPABILITY_SHOW_UNREAD_COUNT;
 
 	label = g_markup_escape_text (node_get_title (node), -1);
 	switch (labeltype) {


### PR DESCRIPTION
The `count` in feed_list_node.c/feed_list_node_update() could get
uninitialized when `labeltype` contain garbage.