### PR TITLE
Add symbolic icon suitable for HighContrast.

### DIFF
--- a/pixmaps/scalable/Makefile.am
+++ b/pixmaps/scalable/Makefile.am
@@ -1,6 +1,8 @@
 themedir = $(datadir)/icons/hicolor
 size = scalable
 context = apps
-EXTRA_DIST = liferea.svg
+EXTRA_DIST = \
+	liferea.svg \
+	liferea-symbolic.svg
 lifereadistpixdir = $(themedir)/$(size)/$(context)
 lifereadistpix_DATA = $(EXTRA_DIST)

--- a/pixmaps/scalable/liferea-symbolic.svg
+++ b/pixmaps/scalable/liferea-symbolic.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" height="16" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" width="16" xmlns="http://www.w3.org/2000/svg">
+  <metadata id="metadata90">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title>Gnome Symbolic Icon Theme</title>
+  <g transform="translate(-561,-301.00012)">
+    <path cx="323.0625" cy="97.1875" d="m 325.0625,97.1875 a 2,3.236068 0 1 1 -4,0 2,3.236068 0 1 1 4,0 z" id="path4983" rx="2" ry="3.236068" style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69602728;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new" transform="matrix(1.0000007,0,0,0.61803426,241.93747,252.93479)"/>
+    <path d="m 563.0002,303 0,1 c 0,0.55016 0.45347,1 1,1 4.97056,0 9,4.02944 9,9 0,0.55016 0.45347,1 1,1 l 1,0 0,-1 c 0,-6.07513 -4.92487,-11 -11,-11 l -1,0 z m 0,4 0,1 c 0,0.55016 0.45347,1 1,1 2.76143,0 5,2.23857 5,5 0,0.55016 0.45347,1 1,1 l 1,0 0,-1 c 0,-3.866 -3.134,-7 -7,-7 l -1,0 z" id="path5814" style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333492;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new"/>
+  </g>
+</svg>


### PR DESCRIPTION
How the hell do we attach a pull request to an existing discussion..? it’s for the #148 one…

So. Things have been developed from the GNOME side, and they finally decided that HighContrast theme users will use the hicolor (classic theme) symbolic icon, and that this icon will also be used in the Shell top-bar for all users, if found. Here is *I think* what have to be done. I didn’t removed the scalable/liferea.svg icon, but it could be (some applications like Polari [did that](https://git.gnome.org/browse/polari/commit/?id=0d8fb22f3237409c92b82914f490adbdeccb20d1)).

It uses the classic RSS icon, as found in the mimetype theme, as suggested by @stevanov.