### PR TITLE
Fix of date format with 2 digit year never reached

### DIFF
--- a/src/date.c
+++ b/src/date.c
@@ -348,10 +348,10 @@ date_parse_RFC822 (const gchar *date)
 	setlocale (LC_TIME, "C");
 	
 	/* standard format with seconds and 4 digit year */
-	if (NULL != (pos = strptime ((const char *)date, " %d %b %Y %T", &tm)))
+	if (NULL != (pos = strptime ((const char *)date, " %d %b %Y %T", &tm)) && tm.tm_year > 0)
 		success = TRUE;
 	/* non-standard format without seconds and 4 digit year */
-	else if (NULL != (pos = strptime ((const char *)date, " %d %b %Y %H:%M", &tm)))
+	else if (NULL != (pos = strptime ((const char *)date, " %d %b %Y %H:%M", &tm)) && tm.tm_year > 0)
 		success = TRUE;
 	/* non-standard format with seconds and 2 digit year */
 	else if (NULL != (pos = strptime ((const char *)date, " %d %b %y %T", &tm)))


### PR DESCRIPTION
4 digit year sucseeded with negative tm.tm_year.
For example, if date is "Wed, 01 Apr 15 11:39:23 +0300", then tm_year became negative.
Date format taken from http://vesti-ukr.com/feed/53-glavnye-vesti-strany.rss.