### PR TITLE
Restore pane proportions after restoring window.

### DIFF
--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -1109,18 +1109,6 @@ liferea_shell_restore_state (const gchar *overrideWindowState)
 	
 	liferea_shell_restore_position ();
 
-	debug0 (DEBUG_GUI, "Loading pane proportions");
-		
-	conf_get_int_value (LAST_VPANE_POS, &last_vpane_pos);
-	if (last_vpane_pos)
-		gtk_paned_set_position (GTK_PANED (liferea_shell_lookup ("leftpane")), last_vpane_pos);
-	conf_get_int_value (LAST_HPANE_POS, &last_hpane_pos);
-	if (last_hpane_pos)
-		gtk_paned_set_position (GTK_PANED (liferea_shell_lookup ("normalViewPane")), last_hpane_pos);
-	conf_get_int_value (LAST_WPANE_POS, &last_wpane_pos);
-	if (last_wpane_pos)
-		gtk_paned_set_position (GTK_PANED (liferea_shell_lookup ("wideViewPane")), last_wpane_pos);
-
 	conf_get_bool_value (SHOW_TRAY_ICON, &show_tray_icon);
 	conf_get_bool_value (START_IN_TRAY, &start_in_tray);
 
@@ -1175,6 +1163,19 @@ liferea_shell_restore_state (const gchar *overrideWindowState)
 			debug0 (DEBUG_GUI, "Restoring window state 'shown'");
 			gtk_widget_show (GTK_WIDGET (shell->priv->window));
 	}
+
+	debug0 (DEBUG_GUI, "Loading pane proportions");
+
+	/* This only works after the window has been restored, so we do it last. */
+	conf_get_int_value (LAST_VPANE_POS, &last_vpane_pos);
+	if (last_vpane_pos)
+		gtk_paned_set_position (GTK_PANED (liferea_shell_lookup ("leftpane")), last_vpane_pos);
+	conf_get_int_value (LAST_HPANE_POS, &last_hpane_pos);
+	if (last_hpane_pos)
+		gtk_paned_set_position (GTK_PANED (liferea_shell_lookup ("normalViewPane")), last_hpane_pos);
+	conf_get_int_value (LAST_WPANE_POS, &last_wpane_pos);
+	if (last_wpane_pos)
+		gtk_paned_set_position (GTK_PANED (liferea_shell_lookup ("wideViewPane")), last_wpane_pos);
 }
 
 void


### PR DESCRIPTION
Attempting to restore pane proportions too early caused some panes to forget
their saved positions whenever the application started with its main window
hidden.  Basically, everyone who exited or logged out while liferea was hidden
in the system tray would find their pane layout reset next time they opened it.

Probably fixes #140 and #158.