### PR TITLE
Fix dialog ui load with latest gtkbuilder

### DIFF
--- a/src/ui/liferea_dialog.c
+++ b/src/ui/liferea_dialog.c
@@ -113,7 +113,7 @@ liferea_dialog_new (const gchar *filename, gchar *name)
 	gchar	*objs[] = { "adjustment1", "adjustment2", "adjustment3",
 			    "adjustment4", "adjustment5", "adjustment6",
 			    "liststore1", "liststore2", "liststore3",
-			    "liststore4", "liststore5",
+			    "liststore4", "liststore5", "liststore6",
 			    "refreshIntervalSpinButton", name, NULL };
 
 	ld = LIFEREA_DIALOG (g_object_new (LIFEREA_DIALOG_TYPE, NULL));


### PR DESCRIPTION
With recent gtk3 loading the feed preferences dialog fails with:
/usr/share/liferea/liferea.ui:519:65 Object with ID liststore6 not found
Add liststore6 to the explicit objects loaded.