### PR TITLE
Fixes #83 segfault when sorting feeds in folder

### DIFF
--- a/src/ui/feed_list_view.c
+++ b/src/ui/feed_list_view.c
@@ -217,8 +217,16 @@ feed_list_view_sort_folder_compare (gconstpointer a, gconstpointer b)
 void
 feed_list_view_sort_folder (nodePtr folder)
 {
+	GtkTreeView             *treeview;
+
+	treeview = GTK_TREE_VIEW (liferea_shell_lookup ("feedlist"));
+	/* Unset the model from the view before clearing it and rebuilding it.*/
+	gtk_tree_view_set_model (treeview, NULL);
 	folder->children = g_slist_sort (folder->children, feed_list_view_sort_folder_compare);
 	feed_list_node_reload_feedlist ();
+	/* Reduce mode didn't actually change but we need to set the
+	 * correct model according to the setting in the same way : */
+	feed_list_view_reduce_mode_changed ();
 	feedlist_foreach (feed_list_view_restore_folder_expansion);
 	feedlist_schedule_save ();
 }


### PR DESCRIPTION
Unsets the model from the treeview while it is being cleared and rebuilt, and so avoids the selection "changed" signal from being emitted in the middle of gtk_tree_store_clear.