### PR TITLE
Prevent node-updated event in case of non sucess http status

### DIFF
--- a/src/subscription.c
+++ b/src/subscription.c
@@ -251,7 +251,7 @@ subscription_process_update_result (const struct updateResult * const result, gp
 	db_subscription_update (subscription);
 	db_node_update (subscription->node);
 
-	if (subscription->node->newCount > 0) {
+	if (processing && subscription->node->newCount > 0) {
 		feedlist_new_items (node->newCount);
 		feedlist_node_was_updated (node);
 	}


### PR DESCRIPTION
A simple way to reproduce the problem of not checking the http status is this: add a new feed source with n elements, then node->newCount == n. Now suppose in the next update the feed doesn't change, the newCount still will be n, so the node-updated event will be fired (and if you are using libnotify plugin, a notification will appear). Using this patch, the http status 304 will prevent a lot of this scenarios.