### PR TITLE
don't update feed on start if the autoupdate is disabled

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -130,14 +130,19 @@ node_set_subscription (nodePtr node, subscriptionPtr subscription)
 void
 node_update_subscription (nodePtr node, gpointer user_data) 
 {
+	gint interval;
 	if (node->source->root == node) {
 		node_source_update (node);
 		return;
 	}
 	
-	if (node->subscription)
+	if (node->subscription) {
+	    interval = subscription_get_update_interval (node->subscription);
+	    if (-2 != interval) {
 		subscription_update (node->subscription, GPOINTER_TO_UINT (user_data));
-		
+	    }
+	}
+
 	node_foreach_child_data (node, node_update_subscription, user_data);
 }
 


### PR DESCRIPTION
Hi, 

the title is pretty self explanatory I think, but I should mention: this works for me, but I'm not sure if I should check interval only for -2, I'm confused by the comment in subscription.c:subscription_set_update_interval

```
    interval = -1;  /* This is evil, I know, but when this method
               is called to set the update interval to 0
               we mean "never updating". The updating logic
               expects -1 for "never updating" and 0 for
               updating according to the global update
               interval... */
```

It seems I should check for -1 instead, but it's not the case
