### PR TITLE
Show all enclosures

### DIFF
--- a/src/enclosure.c
+++ b/src/enclosure.c
@@ -81,7 +81,7 @@ enclosure_from_string (const gchar *str)
 		return enclosure;
 	}
 	
-	fields = g_regex_split_simple ("^enc:([01]?):([^:]+):(\\d+):(.*)", str, 0, 0);
+	fields = g_regex_split_simple ("^enc:([01]?):([^:]*):(\\d+):(.*)", str, 0, 0);
 	if (6 > g_strv_length (fields)) {
 		debug2 (DEBUG_PARSING, "Dropping incorrectly encoded enclosure: >>>%s<<< (nr of fields=%d)\n", str, g_strv_length (fields));
 		return NULL;
@@ -109,7 +109,7 @@ enclosure_values_to_string (const gchar *url, const gchar *mime, gssize size, gb
 		size = 0;
 		
 	safeUrl = common_uri_escape (url);
-	result = g_strdup_printf ("enc:%s:%s:%" G_GSSIZE_FORMAT ":%s", downloaded?"1":"0", mime, size, safeUrl);
+	result = g_strdup_printf ("enc:%s:%s:%" G_GSSIZE_FORMAT ":%s", downloaded?"1":"0", mime?mime:"", size, safeUrl);
 	g_free (safeUrl);
 	
 	return result;

--- a/src/enclosure.c
+++ b/src/enclosure.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file enclosure.c enclosures/podcast support
  *
  * Copyright (C) 2007-2012 Lars Windolf <lars.windolf@gmx.de>

--- a/src/enclosure.h
+++ b/src/enclosure.h
@@ -21,6 +21,8 @@
 #ifndef _ENCLOSURE_H
 #define _ENCLOSURE_H
 
+#include <glib.h>
+
 /** structure describing the preferences for a MIME type or file extension */
 typedef struct encType {
 	gchar		*mime;		/**< either mime or extension is set */
@@ -110,7 +112,7 @@ void enclosure_free (enclosurePtr enclosure);
  *
  * @returns list of encType structures
  */
-const GSList const * enclosure_mime_types_get (void);
+const GSList * enclosure_mime_types_get (void);
 
 /**
  * enclosure_mime_type_add:

--- a/src/enclosure.h
+++ b/src/enclosure.h
@@ -23,56 +23,53 @@
 
 #include <glib.h>
 
-/** structure describing the preferences for a MIME type or file extension */
+/* structure describing the preferences for a MIME type or file extension */
 typedef struct encType {
-	gchar		*mime;		/**< either mime or extension is set */
+	gchar		*mime;		/*<< either mime or extension is set */
 	gchar		*extension;
-	gchar		*cmd;		/**< the command to launch the enclosure type */
-	gboolean	permanent;	/**< if TRUE definition is deleted after opening and 
+	gchar		*cmd;		/*<< the command to launch the enclosure type */
+	gboolean	permanent;	/*<< if TRUE definition is deleted after opening and
 					     not added to the permanent list of type configs */
 } *encTypePtr;
 
-/** structure describing an enclosure and its states */
+/* structure describing an enclosure and its states */
 typedef struct enclosure {
-	gchar		*url;		/**< enclosure download URI (absolute path) */
-	gchar		*mime;		/**< enclosure MIME type (optional, can be NULL) */
-	gssize		size;		/**< enclosure size (optional, can be 0, but also -1) */
-	gboolean	downloaded;	/**< flag indicating we have downloaded the enclosure */
+	gchar		*url;		/*<< enclosure download URI (absolute path) */
+	gchar		*mime;		/*<< enclosure MIME type (optional, can be NULL) */
+	gssize		size;		/*<< enclosure size (optional, can be 0, but also -1) */
+	gboolean	downloaded;	/*<< flag indicating we have downloaded the enclosure */
 } *enclosurePtr;
 
 /**
  * enclosure_from_string: (skip)
+ * @str:	the enclosure description
  *
  * Parses enclosure description.
  *
- * @param str		the enclosure description
- *
- * @returns new enclosure structure (to be free'd using enclosure_free)
+ * Returns: (transfer full): new enclosure structure (to be free'd using enclosure_free)
  */
 enclosurePtr enclosure_from_string (const gchar *str);
 
 /**
  * enclosure_values_to_string:
+ * @url:		the enclosure URL
+ * @mime:		the MIME type (optional, can be NULL)
+ * @size:	  	the enclosure size (optional, can be 0, and also -1)
+ * @downloaded:	downloading state (TRUE=downloaded)
  *
  * Serialize enclosure infos to string.
  *
- * @param url		the enclosure URL
- * @param mime		the MIME type (optional, can be NULL)
- * @param size  	the enclosure size (optional, can be 0, and also -1)
- * @param downloaded	downloading state (TRUE=downloaded)
- *
- * @returns new string (to be free'd using g_free)
+ * Returns: (transfer full): new string (to be free'd using g_free)
  */
 gchar * enclosure_values_to_string (const gchar *url, const gchar *mime, gssize size, gboolean downloaded);
 
 /**
  * enclosure_to_string:
+ * @enclosure:		the enclosure
  *
  * Serialize enclosure to string.
  *
- * @param enclosure	the enclosure
- *
- * @returns new string (to be free'd using g_free)
+ * Returns: (transfer full): new string (to be free'd using g_free)
  */
 gchar * enclosure_to_string (const enclosurePtr enclosure);
 
@@ -82,7 +79,7 @@ gchar * enclosure_to_string (const enclosurePtr enclosure);
  *
  * Get URL from enclosure string
  *
- * Return value: (transfer full): URL string, free after use
+ * Returns: (transfer full): URL string, free after use
  */
 gchar * enclosure_get_url (const gchar *str);
 
@@ -92,16 +89,15 @@ gchar * enclosure_get_url (const gchar *str);
  *
  * Get MIME type from enclosure string
  *
- * Return value: (transfer full): MIME type string, free after use
+ * Returns: (transfer full): MIME type string, free after use
  */
 gchar * enclosure_get_mime (const gchar *str);
 
 /**
  * enclosure_free:
+ * @enclosure:	the enclosure
  *
  * Free all memory associated with the enclosure.
- *
- * @oparam enclosure	the enclosure
  */
 void enclosure_free (enclosurePtr enclosure);
 
@@ -110,26 +106,24 @@ void enclosure_free (enclosurePtr enclosure);
  *
  * Returns all configured enclosure types.
  *
- * @returns list of encType structures
+ * Returns: (transfer none): list of encType structures
  */
 const GSList * enclosure_mime_types_get (void);
 
 /**
  * enclosure_mime_type_add:
+ * @type:	the new definition
  *
  * Adds a new MIME type handling definition.
- *
- * @param type	the new definition
  */
 void enclosure_mime_type_add (encTypePtr type);
 
 /**
  * enclosure_mime_type_remove:
+ * @type:	the definition to remove
  *
  * Removes an existing MIME type handling definition.
  * The definition will be free'd by this function.
- *
- * @param type	the definition to remove
  */
 void enclosure_mime_type_remove (encTypePtr type);
 

--- a/src/ui/enclosure_list_view.c
+++ b/src/ui/enclosure_list_view.c
@@ -498,7 +498,7 @@ on_popup_open_enclosure (gpointer callback_data)
 				etp_found = etp_tmp;
 				break;
 			}
-		} else {
+		} else if (etp_tmp->extension) {
 			/* match known file extensions and keep looking for matching MIME type */
 			if (!strcmp(typestr, etp_tmp->extension)) {
 				etp_found = etp_tmp;

--- a/src/ui/enclosure_list_view.c
+++ b/src/ui/enclosure_list_view.c
@@ -378,7 +378,7 @@ on_selectcmd_pressed (GtkButton *button, gpointer user_data)
 	utfname = gtk_entry_get_text (GTK_ENTRY (liferea_dialog_lookup (dialog,"enc_cmd_entry")));
 	name = g_filename_from_utf8 (utfname, -1, NULL, NULL, NULL);
 	if (name) {
-		ui_choose_file (_("Choose File"), "document-open", FALSE, on_selectcmdok_clicked, name, NULL, NULL, NULL, dialog);
+		ui_choose_file (_("Choose File"), "gtk-open", FALSE, on_selectcmdok_clicked, name, NULL, NULL, NULL, dialog);
 		g_free (name);
 	}
 }

--- a/src/ui/enclosure_list_view.c
+++ b/src/ui/enclosure_list_view.c
@@ -186,7 +186,6 @@ enclosure_list_view_new ()
 	elv->priv->treeview = gtk_tree_view_new ();
 	gtk_container_add (GTK_CONTAINER (widget), elv->priv->treeview);
 	gtk_widget_show (elv->priv->treeview);
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (elv->priv->treeview), TRUE);
 	
 	elv->priv->treestore = gtk_tree_store_new (ES_LEN,
 	                                           G_TYPE_STRING,	/* ES_NAME_STR */

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -712,7 +712,6 @@ item_list_view_create (gboolean wide)
 	gtk_container_add (GTK_CONTAINER (ilscrolledwindow), GTK_WIDGET (ilv->priv->treeview));
 	gtk_widget_show (GTK_WIDGET (ilv->priv->treeview));
 	gtk_widget_set_name (GTK_WIDGET (ilv->priv->treeview), "itemlist");
-	gtk_tree_view_set_rules_hint (ilv->priv->treeview, TRUE);
 
 	item_list_view_set_tree_store (ilv, item_list_view_create_tree_store ());
 


### PR DESCRIPTION
I have multiple feeds that show the icon indicating enclosures, but no enclosures are listed because they don't have a audio or video MIME type. It looks like there is no problem opening them with the way Liferea currently associate a command with a MIME type or file extension.

I also did other small changes as separate commits if you want to cherry-pick. I'm using Archlinux and Gtk 3.20 where the "rules-hint" property doesn't do anything, and it's been like that for a while, but it may still be supported by some version of Ubuntu for some time ...