### PR TITLE
Fix proxy settings

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -197,7 +197,7 @@ conf_proxy_reset_settings_cb (GSettings *settings,
 		  proxyusername != NULL ? proxyusername : "NULL",
 		  proxypassword != NULL ? proxypassword : "NULL");
 
-	network_set_proxy (proxyname, proxyport, proxyusername, proxypassword);
+	network_set_proxy (proxydetectmode, proxyname, proxyport, proxyusername, proxypassword);
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/net.h
+++ b/src/net.h
@@ -23,6 +23,7 @@
 #define _NET_H
 
 #include <glib.h>
+
 #include "update.h"
 
 /* Simple glue layer to abstract network code */
@@ -37,17 +38,30 @@ void network_init (void);
  */
 void network_deinit (void);
 
+typedef enum {
+	PROXY_DETECT_MODE_AUTO = 0, 	/* Use system settings */
+	PROXY_DETECT_MODE_NONE,		/* No Proxy */
+	PROXY_DETECT_MODE_MANUAL	/* Manually configured proxy */
+} ProxyDetectMode;
+
 /**
  * Configures the network client to use the given proxy
  * settings. If the host name is NULL then no proxy will
  * be used.
  *
+ * @param mode		indicate whether to use the system setting, no proxy or the following parameters.
  * @param host		the new proxy host
  * @param port		the new proxy port
  * @param user		the new proxy username or NULL
  * @param password	the new proxy password or NULL
  */
-void network_set_proxy (gchar *host, guint port, gchar *user, gchar *password);
+void network_set_proxy (ProxyDetectMode mode, gchar *host, guint port, gchar *user, gchar *password);
+
+/**
+ * Returns the proxy detect mode.
+ *
+ */
+ProxyDetectMode network_get_proxy_detect_mode (void);
 
 /**
  * Returns the currently configured proxy host.

--- a/src/ui/liferea_htmlview.c
+++ b/src/ui/liferea_htmlview.c
@@ -36,7 +36,6 @@
 #include "enclosure.h"
 #include "feed.h"
 #include "feedlist.h"
-#include "net.h"
 #include "net_monitor.h"
 #include "social.h"
 #include "render.h"
@@ -270,7 +269,8 @@ liferea_htmlview_proxy_changed (NetworkMonitor *nm, gpointer userdata)
 {
 	LifereaHtmlView *htmlview = LIFEREA_HTMLVIEW (userdata);
 
-	(RENDERER (htmlview)->setProxy) (network_get_proxy_host (),
+	(RENDERER (htmlview)->setProxy) (network_get_proxy_detect_mode (),
+					 network_get_proxy_host (),
 	                                 network_get_proxy_port (),
 	                                 network_get_proxy_username (),
 	                                 network_get_proxy_password ());
@@ -299,10 +299,8 @@ liferea_htmlview_new (gboolean forceInternalBrowsing)
 	                  G_CALLBACK (liferea_htmlview_proxy_changed),
 	                  htmlview);
 
-	if (NULL != network_get_proxy_host ()) {
-		debug0 (DEBUG_NET, "Setting initial HTML widget proxy...");
-		liferea_htmlview_proxy_changed (network_monitor_get (), htmlview);
-	}
+	debug0 (DEBUG_NET, "Setting initial HTML widget proxy...");
+	liferea_htmlview_proxy_changed (network_monitor_get (), htmlview);
 	
 	return htmlview;
 }

--- a/src/ui/liferea_htmlview.h
+++ b/src/ui/liferea_htmlview.h
@@ -23,6 +23,8 @@
 
 #include <gtk/gtk.h>
 
+#include "net.h"
+
 G_BEGIN_DECLS
 
 #define LIFEREA_HTMLVIEW_TYPE		(liferea_htmlview_get_type ())
@@ -220,7 +222,7 @@ typedef struct htmlviewImpl {
 	gboolean	(*hasSelection)		(GtkWidget *widget);
 	void		(*copySelection)	(GtkWidget *widget);
 	gboolean	(*scrollPagedown)	(GtkWidget *widget);
-	void		(*setProxy)		(const gchar *hostname, guint port, const gchar *username, const gchar *password);
+	void		(*setProxy)		(ProxyDetectMode mode, const gchar *hostname, guint port, const gchar *username, const gchar *password);
 	void		(*setOffLine)		(gboolean offline);
 } *htmlviewImplPtr;
 


### PR DESCRIPTION
Both proxy settings "Auto Detect" and "No Proxy" result in a NULL
proxy hostname, which result in the default proxy being used at the
start with both options, and no proxy being used after changing to
either option.

This modifies functions to pass the proxy setting mode along with other
proxy settings and to set the SoupSession "proxy-uri" or
"proxy-resolver" properties depending on the setting mode, for both
network and webkit.

Requires libsoup >= 2.42 for the "proxy-resolver" property.