### PR TITLE
Make new WebKit related code compile on Debian 8

### DIFF
--- a/src/webkit/liferea_web_view.c
+++ b/src/webkit/liferea_web_view.c
@@ -34,7 +34,12 @@
 struct _LifereaWebView {
 	WebKitWebView		parent;
 
+	GActionGroup            *menu_action_group;
 	GDBusConnection 	*dbus_connection;
+};
+
+struct _LifereaWebViewClass {
+	WebKitWebViewClass parent_class;
 };
 
 G_DEFINE_TYPE (LifereaWebView, liferea_web_view, WEBKIT_TYPE_WEB_VIEW)
@@ -72,7 +77,7 @@ can_copy_callback (GObject *web_view, GAsyncResult *result, gpointer user_data)
 		return;
 	}
 
-	action_group = gtk_widget_get_action_group (GTK_WIDGET (web_view), "liferea_web_view");
+	action_group = LIFEREA_WEB_VIEW (web_view)->menu_action_group;
 	copy_action = G_SIMPLE_ACTION (g_action_map_lookup_action (G_ACTION_MAP (action_group), "CopySelection"));
 	g_simple_action_set_enabled (copy_action, enabled);
 }
@@ -621,8 +626,6 @@ liferea_webkit_load_status_changed (WebKitWebView *view, WebKitLoadEvent event, 
 static void
 liferea_web_view_init(LifereaWebView *self)
 {
-	GActionGroup *actions;
-
 	self->dbus_connection = NULL;
 
 	g_signal_connect (
@@ -633,9 +636,9 @@ liferea_web_view_init(LifereaWebView *self)
 	);
 
 	/* Context menu actions */
-	actions = G_ACTION_GROUP (g_simple_action_group_new ());
-	g_action_map_add_action_entries (G_ACTION_MAP(actions), liferea_web_view_gaction_entries, G_N_ELEMENTS (liferea_web_view_gaction_entries), self);
-	gtk_widget_insert_action_group (GTK_WIDGET (self), "liferea_web_view", actions);
+	self->menu_action_group = G_ACTION_GROUP (g_simple_action_group_new ());
+	g_action_map_add_action_entries (G_ACTION_MAP(self->menu_action_group), liferea_web_view_gaction_entries, G_N_ELEMENTS (liferea_web_view_gaction_entries), self);
+	gtk_widget_insert_action_group (GTK_WIDGET (self), "liferea_web_view", self->menu_action_group);
 
 
 	g_signal_connect (

--- a/src/webkit/liferea_web_view.h
+++ b/src/webkit/liferea_web_view.h
@@ -25,7 +25,16 @@
 
 #define LIFEREA_TYPE_WEB_VIEW liferea_web_view_get_type ()
 
-G_DECLARE_FINAL_TYPE (LifereaWebView, liferea_web_view, LIFEREA, WEB_VIEW, WebKitWebView)
+#define LIFEREA_WEB_VIEW(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), LIFEREA_TYPE_WEB_VIEW, LifereaWebView))
+#define IS_LIFEREA_WEB_VIEW(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), LIFEREA_TYPE_WEB_VIEW))
+#define LIFEREA_WEB_VIEW_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), LIFEREA_TYPE_WEB_VIEW, LifereaWebViewClass))
+#define IS_LIFEREA_WEB_VIEW_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), LIFEREA_TYPE_WEB_VIEW))
+#define LIFEREA_WEB_VIEW_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), LIFEREA_TYPE_WEB_VIEW, LifereaWebViewClass))
+
+typedef struct _LifereaWebView LifereaWebView;
+typedef struct _LifereaWebViewClass LifereaWebViewClass;
+
+GType liferea_web_view_get_type (void);
 
 LifereaWebView *
 liferea_web_view_new (void);

--- a/src/webkit/web_extension/liferea_web_extension.c
+++ b/src/webkit/web_extension/liferea_web_extension.c
@@ -34,6 +34,10 @@ struct _LifereaWebExtension {
 	gboolean 		initialized;
 };
 
+struct _LifereaWebExtensionClass {
+	GObjectClass parent_class;
+};
+
 G_DEFINE_TYPE (LifereaWebExtension, liferea_web_extension, G_TYPE_OBJECT)
 
 static const char introspection_xml[] =

--- a/src/webkit/web_extension/liferea_web_extension.h
+++ b/src/webkit/web_extension/liferea_web_extension.h
@@ -26,7 +26,17 @@
 
 #define LIFEREA_TYPE_WEB_EXTENSION liferea_web_extension_get_type ()
 
-G_DECLARE_FINAL_TYPE (LifereaWebExtension, liferea_web_extension, LIFEREA, WEB_EXTENSION, GObject)
+#define LIFEREA_WEB_EXTENSION(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), LIFEREA_TYPE_WEB_EXTENSION, LifereaWebExtension))
+#define IS_LIFEREA_WEB_EXTENSION(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), LIFEREA_TYPE_WEB_EXTENSION))
+#define LIFEREA_WEB_EXTENSION_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), LIFEREA_TYPE_WEB_EXTENSION, LifereaWebExtensionClass))
+#define IS_LIFEREA_WEB_EXTENSION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), LIFEREA_TYPE_WEB_EXTENSION))
+#define LIFEREA_WEB_EXTENSION_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), LIFEREA_TYPE_WEB_EXTENSION, LifereaWebExtensionClass))
+
+typedef struct _LifereaWebExtension LifereaWebExtension;
+
+typedef struct _LifereaWebExtensionClass LifereaWebExtensionClass;
+
+GType liferea_web_extension_get_type (void);
 
 LifereaWebExtension* liferea_web_extension_get (void);
 void liferea_web_extension_initialize (LifereaWebExtension *extension, WebKitWebExtension *webkit_extension,  const gchar *server_address);

--- a/src/webkit/webkit.c
+++ b/src/webkit/webkit.c
@@ -37,15 +37,24 @@
 
 #define LIFEREA_TYPE_WEBKIT_IMPL liferea_webkit_impl_get_type ()
 
-G_DECLARE_FINAL_TYPE (LifereaWebKitImpl, liferea_webkit_impl, LIFEREA, WEBKIT_IMPL, GObject)
+#define LIFEREA_WEBKIT_IMPL(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), LIFEREA_TYPE_WEBKIT_IMPL, LifereaWebKitImpl))
+#define IS_LIFEREA_WEBKIT_IMPL(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), LIFEREA_TYPE_WEBKIT_IMPL))
+#define LIFEREA_WEBKIT_IMPL_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), LIFEREA_TYPE_WEBKIT_IMPL, LifereaWebKitImplClass))
+#define IS_LIFEREA_WEBKIT_IMPL_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), LIFEREA_TYPE_WEBKIT_IMPL))
+#define LIFEREA_WEBKIT_IMPL_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), LIFEREA_TYPE_WEBKIT_IMPL, LifereaWebKitImplClass))
 
-struct _LifereaWebKitImpl {
+
+typedef struct _LifereaWebKitImpl {
 	GObject parent;
 
 	WebKitSettings 	*settings;
 	GDBusServer 	*dbus_server;
 	GList 		*dbus_connections;
-};
+} LifereaWebKitImpl;
+
+typedef struct _LifereaWebKitImplClass {
+	GObjectClass parent_class;
+} LifereaWebKitImplClass;
 
 G_DEFINE_TYPE (LifereaWebKitImpl, liferea_webkit_impl, G_TYPE_OBJECT)
 


### PR DESCRIPTION
Debian 8 has Glib 2.42 and Gtk 3.14.

- Replace Glib 2.44 GType macros by previous style.
- Avoid use of gtk_widget_get_action_group which is new to Gtk 3.16.

@lwindolf I saw you mentioned Debian 8 on the blog post. Now it really works on Debian 8 :)