### PR TITLE
Making skimming articles work and Do Not Track support

### DIFF
--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -360,13 +360,7 @@ itemview_find_unread_item (gulong startId)
 void
 itemview_scroll (void)
 {
-	/* We try to scroll the HTML view, but if we are already at the
-	   bottom of the item view the scrolling will return FALSE and 
-	   we trigger Next-Unread to realize easy headline skimming. */
-	if (liferea_htmlview_scroll (itemview->priv->htmlview) == FALSE)
-		on_next_unread_item_activate (NULL, NULL);
-		
-	/* Note the above condition is duplicated in mozilla/mozsupport.cpp! */
+	liferea_htmlview_scroll (itemview->priv->htmlview);
 }
 
 void

--- a/src/ui/liferea_htmlview.c
+++ b/src/ui/liferea_htmlview.c
@@ -504,10 +504,10 @@ liferea_htmlview_get_zoom (LifereaHtmlView *htmlview)
 	return (RENDERER (htmlview)->zoomLevelGet) (htmlview->priv->renderWidget);
 }
 
-gboolean
+void
 liferea_htmlview_scroll (LifereaHtmlView *htmlview)
 {
-	return (RENDERER (htmlview)->scrollPagedown) (htmlview->priv->renderWidget);
+	(RENDERER (htmlview)->scrollPagedown) (htmlview->priv->renderWidget);
 }
 
 void

--- a/src/ui/liferea_htmlview.h
+++ b/src/ui/liferea_htmlview.h
@@ -179,10 +179,8 @@ gfloat liferea_htmlview_get_zoom (LifereaHtmlView *htmlview);
  *
  * @param htmlview	htmlview to scroll
  *
- * @return FALSE if the scrolled window vertical scroll position is at
- * the maximum and TRUE if the vertical adjustment was increased.
  */
-gboolean liferea_htmlview_scroll (LifereaHtmlView *htmlview);
+void liferea_htmlview_scroll (LifereaHtmlView *htmlview);
 
 /**
  * liferea_htmlview_prepare_context_menu:
@@ -221,8 +219,8 @@ typedef struct htmlviewImpl {
 	void		(*zoomLevelSet)		(GtkWidget *widget, gfloat zoom);
 	gboolean	(*hasSelection)		(GtkWidget *widget);
 	void		(*copySelection)	(GtkWidget *widget);
-	gboolean	(*scrollPagedown)	(GtkWidget *widget);
 	void		(*setProxy)		(ProxyDetectMode mode, const gchar *hostname, guint port, const gchar *username, const gchar *password);
+	void		(*scrollPagedown)	(GtkWidget *widget);
 	void		(*setOffLine)		(gboolean offline);
 } *htmlviewImplPtr;
 

--- a/src/webkit/web_extension/liferea_web_extension.c
+++ b/src/webkit/web_extension/liferea_web_extension.c
@@ -47,10 +47,6 @@ static const char introspection_xml[] =
   "   <arg type='t' name='page_id' direction='in'/>"
   "   <arg type='b' name='scrolled' direction='out'/>"
   "  </method>"
-  "  <method name='HasSelection'>"
-  "   <arg type='t' name='page_id' direction='in'/>"
-  "   <arg type='b' name='has_selection' direction='out'/>"
-  "  </method>"
   "  <signal name='PageCreated'>"
   "   <arg type='t' name='page_id' direction='out'/>"
   "  </signal>"
@@ -96,7 +92,7 @@ liferea_web_extension_get_dom_window (LifereaWebExtension *self, guint64 page_id
 	return window;
 }
 
-/**
+/*
  * \returns TRUE if scrolling happened, FALSE if the end was reached
  */
 static gboolean
@@ -113,24 +109,6 @@ liferea_web_extension_scroll_page_down (LifereaWebExtension *self, guint64 page_
 	new_scroll_y = webkit_dom_dom_window_get_scroll_y (window);
 
 	return (new_scroll_y > old_scroll_y);
-}
-
-/**
- * \returns TRUE if text is selected.
- */
-static gboolean
-liferea_web_extension_has_selection (LifereaWebExtension *self, guint64 page_id)
-{
-	WebKitDOMDOMWindow *window;
-	WebKitDOMDOMSelection *selection;
-	gboolean is_collapsed;
-
-	window = liferea_web_extension_get_dom_window (self, page_id);
-	selection = webkit_dom_dom_window_get_selection (window);
-	g_object_get (selection, "is_collapsed", &is_collapsed, NULL);
-	g_object_unref (selection);
-
-	return (!is_collapsed);
 }
 
 static gboolean
@@ -178,13 +156,6 @@ handle_dbus_method_call (GDBusConnection 	*connection,
 		g_variant_get (parameters, "(t)", &page_id);
 		scrolled = liferea_web_extension_scroll_page_down (LIFEREA_WEB_EXTENSION (user_data), page_id);
 		g_dbus_method_invocation_return_value (invocation, g_variant_new ("(b)", scrolled));
-	} else if (g_strcmp0 (method_name, "HasSelection") == 0) {
-		guint64 page_id;
-		gboolean has_selection;
-
-		g_variant_get (parameters, "(t)", &page_id);
-		has_selection = liferea_web_extension_has_selection (LIFEREA_WEB_EXTENSION (user_data), page_id);
-		g_dbus_method_invocation_return_value (invocation, g_variant_new ("(b)", has_selection));
 	}
 }
 


### PR DESCRIPTION
I unbroke article skimming, some changes to scroll functions had been lost. Apparently C programs don't mind much using the return value from a void function.

I also added the "do not track" setting support in the web extension.