### PR TITLE
Minor documention fixes

### DIFF
--- a/doc/html/onlineservices_en.html
+++ b/doc/html/onlineservices_en.html
@@ -101,9 +101,9 @@
 	<p>Liferea 1.10 and later supports TinyTinyRSS versions starting with
 	version 1.5.3.</p>
 
-	<p>TinyTinyRSS muss vom Benutzer selbst auf einem eigenen Server
-	installiert werden. Das erfordert Kenntnisse in Serveradministration!
-	Einmal installiert verhälft sich TinyTinyRSS aber wie andere Online-Dienste.</p>
+	<p>TinyTinyRSS must be installed on your own server, which requires server
+	adminstration knowledge. Once installed, TinyTinyRSS behaves as any other
+	online service.</p>
 		
 	<!-- navigation footer start -->
 	<hr />

--- a/doc/html/topics_de.html
+++ b/doc/html/topics_de.html
@@ -17,7 +17,7 @@
 	<!-- navigation header end -->
 
 <p>
-Dies ist die Endnutzerdokumentation für Liferea 1.10.
+Dies ist die Endnutzerdokumentation für Liferea 1.12.
 </p>
 
 <h3>Hilfe Themen</h3>

--- a/doc/html/topics_en.html
+++ b/doc/html/topics_en.html
@@ -16,7 +16,7 @@
 	<!-- navigation header end -->
 
 <p>
-This user documentation applies for Liferea 1.10.
+This user documentation applies for Liferea 1.12.
 </p>
 
 <h3>Help Topics</h3>


### PR DESCRIPTION
I spotted some minor glitches in the documentation: one English page contained German text and the version number mentioned on the starting page was still 1.10.