### PR TITLE
Check URI to check if it has user:password or not

### DIFF
--- a/xslt/feed.xml.in
+++ b/xslt/feed.xml.in
@@ -177,7 +177,15 @@
 <xsl:template name="strippwd">
    <xsl:param name="string"/>
    <xsl:choose>
-       <xsl:when test="contains($string, '@')"><xsl:value-of select="substring-before($string, '://')"/>://<xsl:value-of select="substring-after($string, '@')"/></xsl:when>
+       <xsl:when test="contains($string, '@')">
+       <xsl:choose>
+             <!-- between "://" and "@" only user:pass is allowed, so check if it has "/" to remove or not confidential data -->
+             <xsl:when test="contains(substring-after(substring-before($string, '@'), '://'), '/')">
+                <xsl:value-of select="$string"/>
+             </xsl:when>
+             <xsl:otherwise><xsl:value-of select="substring-before($string, '://')"/>://<xsl:value-of select="substring-after($string, '@')"/></xsl:otherwise>
+       </xsl:choose>
+       </xsl:when>
        <xsl:otherwise><xsl:value-of select="$string"/></xsl:otherwise>
    </xsl:choose>
 </xsl:template>


### PR DESCRIPTION
#384 URI can't contain other than user:password between :// and @ so if it has a / then it has no user/password and print full URI.

It doesn't check if it has user:password and an extra @ char (password protected medium source for example).