### PR TITLE
Add GeoRSS info on header

### DIFF
--- a/xslt/item.xml.in
+++ b/xslt/item.xml.in
@@ -243,7 +243,29 @@
      </span></b>
    </td>
  </tr>
-</xsl:if>  
+</xsl:if>
+
+<xsl:if test="attributes/attribute[ @name = 'point' ]">
+ <tr>
+   <td valign="top" class='point'>
+     <_span>Coordinates</_span>
+     <b><span class='point'>
+     <xsl:value-of select="substring-before(attributes/attribute[ @name = 'point' ],' ')" />,
+     <xsl:value-of select="substring-after(attributes/attribute[ @name = 'point' ],' ')" />
+     </span></b>
+   </td>
+ </tr>
+  <tr>
+   <td valign="top" class='point'>
+     <_span>Map</_span>
+     <b><span class='point'>
+     <xsl:variable name="lat" select="substring-before(attributes/attribute[ @name = 'point' ],' ')"/>
+     <xsl:variable name="lng" select="substring-after(attributes/attribute[ @name = 'point' ],' ')"/>
+     <a href="https://www.openstreetmap.org/?mlat={$lat}&amp;mlon={$lng}#map=12/{$lat}/{$lng}">OpenStreeMap</a>
+     </span></b>
+   </td>
+ </tr>
+</xsl:if>
 
 </table> <!-- end of header metadata -->
 

--- a/xslt/item.xml.in
+++ b/xslt/item.xml.in
@@ -246,21 +246,18 @@
 </xsl:if>
 
 <xsl:if test="attributes/attribute[ @name = 'point' ]">
+ <xsl:variable name="lat" select="substring-before(attributes/attribute[ @name = 'point' ],' ')"/>
+ <xsl:variable name="lng" select="substring-after(attributes/attribute[ @name = 'point' ],' ')"/>
  <tr>
    <td valign="top" class='point'>
      <_span>Coordinates</_span>
-     <b><span class='point'>
-     <xsl:value-of select="substring-before(attributes/attribute[ @name = 'point' ],' ')" />,
-     <xsl:value-of select="substring-after(attributes/attribute[ @name = 'point' ],' ')" />
-     </span></b>
+     <b><span class='point'><xsl:value-of select="$lat"/>, <xsl:value-of select="$lng"/></span></b>
    </td>
  </tr>
   <tr>
    <td valign="top" class='point'>
      <_span>Map</_span>
      <b><span class='point'>
-     <xsl:variable name="lat" select="substring-before(attributes/attribute[ @name = 'point' ],' ')"/>
-     <xsl:variable name="lng" select="substring-after(attributes/attribute[ @name = 'point' ],' ')"/>
      <a href="https://www.openstreetmap.org/?mlat={$lat}&amp;mlon={$lng}#map=12/{$lat}/{$lng}">OpenStreeMap</a>
      </span></b>
    </td>


### PR DESCRIPTION
In https://github.com/lwindolf/liferea/commit/5f92f23ed977759de6e5b0147d039ea92605770b and https://github.com/lwindolf/liferea/commit/19a674be74bfa2e49e30333d95ab7c07bf1af774 GeoRSS map support is removed for security reasons because it depends on an external service. 

This patch adds the coordinates info and a link to OpenStreetMap if the feed has GeoRSS information on it.