### PR TITLE
Partial RFC3229+feed support for bandwidth savings

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -157,11 +157,14 @@ network_process_request (const updateJobPtr const job)
 		soup_date_free (date);
 	}
 
-	/* Set the If-None-Match: header */
+	/* Set the If-None-Match: and A-IM: headers */
 	if (job->request->updateState && update_state_get_etag (job->request->updateState)) {
 		soup_message_headers_append(msg->request_headers,
 					    "If-None-Match",
 					    update_state_get_etag (job->request->updateState));
+		soup_message_headers_append(msg->request_headers,
+					    "A-IM",
+					    "feed");
 	}
 
 	/* Support HTTP content negotiation */


### PR DESCRIPTION
The `If-None-Match` header combined with the `A-IM: feed` header instructs compatible servers to only send the feed entries that have been added or changed since the feed was last updated. (As determined using the ETag sent by the server which is later returned by the If-None-Match header.)

Nothing else is really required by Liferea to partially support RFC3229+feed. There are no known implementers of the `f-range` header, so I’m not bothering with that. ExpressionEngine and Textpattern already supports this. I hope to submit patches to WordPress soon as well.

Can be tested by subscribing to this feed: https://www.geeky.software/tools/feed-header-echo.php Note how the second item in the feed isn’t returned after applying this patch. Liferea doesn’t store ETags between sessions, so this effect will only be shown the second time the feed is updated.