### PR TITLE
Set A-IM in more conditions

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -157,11 +157,17 @@ network_process_request (const updateJobPtr const job)
 		soup_date_free (date);
 	}
 
-	/* Set the If-None-Match: and A-IM: headers */
+	/* Set the If-None-Match header */
 	if (job->request->updateState && update_state_get_etag (job->request->updateState)) {
 		soup_message_headers_append(msg->request_headers,
 					    "If-None-Match",
 					    update_state_get_etag (job->request->updateState));
+	}
+
+	/* Set the I-AM header */
+	if (job->request->updateState &&
+	    (update_state_get_lastmodified (job->request->updateState) ||
+	     update_state_get_etag (job->request->updateState))) {
 		soup_message_headers_append(msg->request_headers,
 					    "A-IM",
 					    "feed");


### PR DESCRIPTION
Change to set the A-IM header if either the If-None-Match or the If-Modified-Since headers are set.

My mistake for only setting it for If-None-Match in [my first implementation](https://github.com/lwindolf/liferea/pull/434). I have later learned that other implementations support both, and that is the most flexible option anyway.