### PR TITLE
Add an option to use bold text for feeds/folders with unread items

### DIFF
--- a/net.sf.liferea.gschema.xml.in
+++ b/net.sf.liferea.gschema.xml.in
@@ -127,6 +127,11 @@
       <summary>Determines the style of the toolbar buttons</summary>
       <description>Determines the style of the toolbar buttons locally, overriding the GNOME settings. Valid values are "both", "both-horiz", "icons", and "text". If empty or not specified, the GNOME settings are used.</description>
     </key>
+    <key name="feedlist-unread-items-bold" type="b">
+      <default>false</default>
+      <summary>Use bold text for feeds/folders with unread items</summary>
+      <description>Use bold text for the labels of feeds/folders with unread items in the feed list view.</description>
+    </key>
     <key name="trayicon" type="b">
       <default>true</default>
       <summary>Determines if the system tray icon is to be shown</summary>

--- a/src/conf.h
+++ b/src/conf.h
@@ -52,6 +52,7 @@
 #define FOLDER_DISPLAY_MODE		"folder-display-mode"
 #define FOLDER_DISPLAY_HIDE_READ	"folder-display-hide-read"
 #define REDUCED_FEEDLIST		"reduced-feedlist"
+#define FEEDLIST_UNREAD_ITEMS_BOLD	"feedlist-unread-items-bold"
 
 /* GUI settings and persistency values */
 #define DISABLE_TOOLBAR			"disable-toolbar"

--- a/src/ui/feed_list_node.c
+++ b/src/ui/feed_list_node.c
@@ -22,6 +22,7 @@
 #include "ui/feed_list_node.h"
 
 #include "common.h"
+#include "conf.h"
 #include "debug.h"
 #include "feedlist.h"
 #include "fl_sources/node_source.h"
@@ -288,6 +289,7 @@ feed_list_node_update (const gchar *nodeId)
 	nodePtr		node;
 
 	static gchar	*countColor = NULL;
+	gboolean        unread_label_bold;
 
 	node = node_from_id (nodeId);
 	iter = feed_list_node_to_iter (nodeId);
@@ -313,18 +315,22 @@ feed_list_node_update (const gchar *nodeId)
 	if (node->unreadCount == 0 && (labeltype & NODE_CAPABILITY_SHOW_UNREAD_COUNT))
 		labeltype &= ~NODE_CAPABILITY_SHOW_UNREAD_COUNT;
 
-	label = g_markup_escape_text (node_get_title (node), -1);
 	switch (labeltype) {
 		case NODE_CAPABILITY_SHOW_UNREAD_COUNT |
 		     NODE_CAPABILITY_SHOW_ITEM_COUNT:
 	     		/* treat like show unread count */
 		case NODE_CAPABILITY_SHOW_UNREAD_COUNT:
+			conf_get_bool_value (FEEDLIST_UNREAD_ITEMS_BOLD, &unread_label_bold);
+
+			label = g_markup_printf_escaped ("<span weight='%s'>%s</span>", unread_label_bold?"bold":"normal", node_get_title (node));
 			count = g_strdup_printf ("<span weight='bold' %s> %u </span>", countColor?countColor:"", node->unreadCount);
 			break;
 		case NODE_CAPABILITY_SHOW_ITEM_COUNT:
+			label = g_markup_escape_text (node_get_title (node), -1);
 			count = g_strdup_printf ("<span weight='bold' %s> %u </span>", countColor?countColor:"", node->itemCount);
 		     	break;
 		default:
+			label = g_markup_escape_text (node_get_title (node), -1);
 			break;
 	}
 


### PR DESCRIPTION
This allows to have back the old 1.10 look of the feed list, where
feeds/folders with unread items had bold text.

As highlighted in https://github.com/lwindolf/liferea/issues/29 some
users prefer the old look because it suits better their environment,
however liferea does not support it "publicly" anymore, the option is
provided only for backward compatibility.

Users who wanted the old behavior have to set the GSettings value
"feedlist-unread-items-bold" to true by themselves, using dconf-editor
or with a command like the following:

  $ gsettings set net.sf.liferea feedlist-unread-items-bold true