### PR TITLE
Include git compile instructions in INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -41,14 +41,21 @@ a newer version of `autoconf'.
 
 The simplest way to compile this package is:
 
-  1. `cd' to the directory containing the package's source code and type
+  1.A. Compiling from a Tarball release
+  
+     `cd' to the directory containing the package's source code and type
      `./configure' to configure the package for your system.  If you're
      using `csh' on an old version of System V, you might need to type
      `sh ./configure' instead to prevent `csh' from trying to execute
      `configure' itself.
 
-     Running `configure' takes awhile.  While running, it prints some
-     messages telling which features it is checking for.
+  1.B. Or compiling from Git
+  
+     `cd' to the directory containing the package's source code and type
+     `./autogen.sh' to configure the package for your system.
+  
+Running `configure' or 'autogen.sh' may take a while. While running, it
+prints some messages telling which features it is checking for.
 
   2. Type `make' to compile the package.
 


### PR DESCRIPTION
It almost feels wrong to change an 11-year old file, but I always look in INSTALL first for these kind of instructions.