### PR TITLE
Removing GtkDoc warnings

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -27,8 +27,8 @@
 #include <libpeas/peas-extension-set.h>
 
 // FIXME: This should be a member of some object!
-static PeasExtensionSet *extensions = NULL;	/**< Plugin management */
-static gint		count = 0;		/**< Number of active auth plugins */
+static PeasExtensionSet *extensions = NULL;	/*<< Plugin management */
+static gint		count = 0;		/*<< Number of active auth plugins */
 
 static void
 on_extension_added (PeasExtensionSet *extensions,

--- a/src/enclosure.h
+++ b/src/enclosure.h
@@ -64,7 +64,7 @@ enclosurePtr enclosure_from_string (const gchar *str);
 gchar * enclosure_values_to_string (const gchar *url, const gchar *mime, gssize size, gboolean downloaded);
 
 /**
- * enclosure_to_string:
+ * enclosure_to_string: (skip)
  * @enclosure:		the enclosure
  *
  * Serialize enclosure to string.
@@ -94,7 +94,7 @@ gchar * enclosure_get_url (const gchar *str);
 gchar * enclosure_get_mime (const gchar *str);
 
 /**
- * enclosure_free:
+ * enclosure_free: (skip)
  * @enclosure:	the enclosure
  *
  * Free all memory associated with the enclosure.
@@ -111,7 +111,7 @@ void enclosure_free (enclosurePtr enclosure);
 const GSList * enclosure_mime_types_get (void);
 
 /**
- * enclosure_mime_type_add:
+ * enclosure_mime_type_add: (skip)
  * @type:	the new definition
  *
  * Adds a new MIME type handling definition.
@@ -119,7 +119,7 @@ const GSList * enclosure_mime_types_get (void);
 void enclosure_mime_type_add (encTypePtr type);
 
 /**
- * enclosure_mime_type_remove:
+ * enclosure_mime_type_remove: (skip)
  * @type:	the definition to remove
  *
  * Removes an existing MIME type handling definition.
@@ -128,14 +128,14 @@ void enclosure_mime_type_add (encTypePtr type);
 void enclosure_mime_type_remove (encTypePtr type);
 
 /**
- * enclosure_mime_types_save:
+ * enclosure_mime_types_save: (skip)
  *
  * Save all MIME type definitions.
  */
 void enclosure_mime_types_save (void);
 
 /**
- * enclosure_download:
+ * enclosure_download: (skip)
  * @type:		ULL or pointer to type structure
  * @url:		valid HTTP URL
  * @interactive:	TRUE if triggered by user interaction

--- a/src/feedlist.c
+++ b/src/feedlist.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file feedlist.c  subscriptions as an hierarchic tree
  *
  * Copyright (C) 2005-2013 Lars Windolf <lars.windolf@gmx.de>
@@ -45,22 +45,22 @@ static void feedlist_save	(void);
 #define FEEDLIST_GET_PRIVATE(object)(G_TYPE_INSTANCE_GET_PRIVATE ((object), FEEDLIST_TYPE, FeedListPrivate))
 
 struct FeedListPrivate {
-	guint		newCount;	/**< overall new item count */
+	guint		newCount;	/*<< overall new item count */
 
-	nodePtr		rootNode;	/**< the feed list root node */
-	nodePtr		selectedNode;	/**< matches the node selected in the feed list tree view, which
+	nodePtr		rootNode;	/*<< the feed list root node */
+	nodePtr		selectedNode;	/*<< matches the node selected in the feed list tree view, which
 					     is not necessarily the displayed one (e.g. folders without recursive
 					     display enabled) */
 
-	guint		saveTimer;	/**< timer id for delayed feed list saving */
-	guint		autoUpdateTimer; /**< timer id for auto update */
+	guint		saveTimer;	/*<< timer id for delayed feed list saving */
+	guint		autoUpdateTimer; /*<< timer id for auto update */
 
-	gboolean	loading;	/**< prevents the feed list being saved before it is completely loaded */
+	gboolean	loading;	/*<< prevents the feed list being saved before it is completely loaded */
 };
 
 enum {
-	NEW_ITEMS,		/**< node has new items after update */
-	NODE_UPDATED,		/**< node display info (title, unread count) has changed */
+	NEW_ITEMS,		/*<< node has new items after update */
+	NODE_UPDATED,		/*<< node display info (title, unread count) has changed */
 	LAST_SIGNAL
 };
 

--- a/src/feedlist.h
+++ b/src/feedlist.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file feedlist.h  subscriptions as an hierarchic tree
  *
  * Copyright (C) 2005-2014 Lars Windolf <lars.windolf@gmx.de>
@@ -57,56 +57,70 @@ struct FeedListClass
 GType feedlist_get_type (void);
 
 /**
+ * feedlist_create: (skip)
+ *
  * Set up the feed list.
  *
- * @returns the feed list instance
+ * Returns: (transfer full): the feed list instance
  */
 FeedList * feedlist_create (void);
 
 /**
+ * feedlist_get_selected: (skip)
+ *
  * Get currently selected feed list node 
  *
- * @returns selected node (or NULL)
+ * Returns: (transfer none) (nullable): selected node (or NULL)
  */
 nodePtr feedlist_get_selected (void);
 
 /**
+ * feedlist_get_unread_item_count:
+ *
  * Query overall number of of unread items.
  *
- * @returns overall number of unread items.
+ * Returns: overall number of unread items.
  */
 guint feedlist_get_unread_item_count (void);
 
 /**
+ * feedlist_get_new_item_count:
+ *
  * Query overall number of new items.
  *
  * Note: result might be slightly off, but error
  * won't aggregate over time.
  *
- * @returns overall number of new items.
+ * Returns: overall number of new items.
  */
 guint feedlist_get_new_item_count (void);
 
 /**
+ * feedlist_reset_new_item_count:
+ *
  * Reset the global feed list new item counter.
  *
- * @todo: use signal instead
+ * TODO: use signal instead
  */
 void feedlist_reset_new_item_count (void);
 
 /**
+ * feedlist_node_was_updated: (skip)
+ * @node:		the updated node
+ *
  * To be called when a feed is updated and has
  * new or dropped items forcing a node unread count
  * update for all affected nodes in the feed list.
  *
- * @param node		the updated node
  */
 void feedlist_node_was_updated (nodePtr node);
 
 /**
+ * feedlist_get_root: (skip)
+ *
  * Helper function to query the feed list root node.
  *
- * @returns the feed list root node
+ * Returns: (transfer none): the feed list root node
  */
 nodePtr feedlist_get_root (void);
 
@@ -117,37 +131,43 @@ typedef enum {
 } feedListFindType;
 
 /**
+ * feedlist_find_node: (skip)
+ * @parent: (nullable): 	parent node to traverse from (or NULL)
+ * @type:		        NODE_BY_(URL|FOLDER_TITLE|ID)
+ * @str:		        string to compare to
+ *
  * Search trough list of subscriptions for a node matching exactly 
  * to an criteria defined by the find type and comparison string.
  * Searches recursively from a given parent node or the root node.
  * Always returns just the first occurence in traversal order.
  *
- * @param parent	parent node to traverse from (or NULL)
- * @param type		NODE_BY_(URL|FOLDER_TITLE|ID)
- * @param str		string to compare to
- *
- * @returns a nodePtr or NULL
+ * Returns: (nullable) (transfer none): a nodePtr or NULL
  */
 nodePtr feedlist_find_node (nodePtr parent, feedListFindType type, const gchar *str);
 
 /**
- * Adds a new subscription to the feed list.
+ * feedlist_add_subscription: (skip)
+ * @source:	        the subscriptions source URL
+ * @filter: (nullable):	NULL or the filter for the subscription
+ * @options: (nullable): NULL or the update options
+ * @flags:		download request flags
  *
- * @param source	the subscriptions source URL
- * @param filter	NULL or the filter for the subscription
- * @param options	NULL or the update options
- * @param flags		download request flags
+ * Adds a new subscription to the feed list.
  */
 void feedlist_add_subscription (const gchar *source, const gchar *filter, updateOptionsPtr options, gint flags);
 
 /**
- * Adds a folder to the feed list without any user interaction.
+ * feedlist_add_folder:
+ * @title:		the title of the new folder.
  *
- * @param title		the title of the new folder.
+ * Adds a folder to the feed list without any user interaction.
  */
 void feedlist_add_folder (const gchar *title);
 
 /**
+ * feedlist_node_added: (skip)
+ * @node:		the new node
+ *
  * Notifies the feed list controller that a new node
  * was added to the feed list. This method will insert
  * the new node into the feed list view and select 
@@ -158,11 +178,13 @@ void feedlist_add_folder (const gchar *title);
  * Before calling this method the node must be given
  * a parent node using node_set_parent().
  *
- * @param node		the new node
  */
 void feedlist_node_added (nodePtr node);
 
 /**
+ * feedlist_node_imported: (skip)
+ * @node:		the new node
+ *
  * Notifies the feed list controller that a new node
  * was added to the feed list. Similar to feedlist_node_added()
  * the new node will be added to the feed list but the
@@ -173,93 +195,107 @@ void feedlist_node_added (nodePtr node);
  * Before calling this method the node must be given
  * a parent node using node_set_parent().
  *
- * @param node		the new node
  */
 void feedlist_node_imported (nodePtr node);
 
 /**
- * Removes the given node from the feed list.
+ * feedlist_remove_node: (skip)
+ * @node:		the node to remove
  *
- * @param node		the node to remove
+ * Removes the given node from the feed list.
  */
 void feedlist_remove_node (nodePtr node);
 
 /**
+ * feedlist_node_removed: (skip)
+ * @node:		the removed node
+ *
  * Notifies the feed list controller that an existing
  * node was removed from it's source (feed list subtree)
  * and is to be destroyed and to be removed from the 
  * feed list view.
  *
- * @param node		the removed node
  */
 void feedlist_node_removed (nodePtr node);
 
 /**
+ * feedlist_schedule_save: (skip)
+ *
  * Schedules a save requests for the feed list within the next 5s.
  * Triggers state saving for all feed list sources.
  */
 void feedlist_schedule_save (void);
 
 /**
+ * feedlist_reset_update_counters: (skip)
+ * @node: (nullable):	the node (or NULL for whole feed list)
+ *
  * Resets the update counter of all childs of the given node
  *
- * @param node		the node (or NULL for whole feed list)
  */
 void feedlist_reset_update_counters (nodePtr node);
 
 gboolean feedlist_is_writable (void);
 
 /**
+ * feedlist_mark_all_read: (skip)
+ * @node:		the node to start with
+ *
  * Triggers a recursive mark-all-read on the given node
  * and updates the feed list afterwards.
  *
- * @param node		the node to start with
  */
 void feedlist_mark_all_read (nodePtr node);
 
 /* feed list iterating interface */
 
 /**
+ * feedlist_foreach: (skip)
+ * @func:		the function to process all found elements
+ *
  * Helper function to recursivly call node methods for all
  * nodes in the feed list. This method is just a wrapper for
  * node_foreach_child().
- *
- * @param func		the function to process all found elements
  */
 #define feedlist_foreach(func) node_foreach_child(feedlist_get_root(), func)
 
 /**
+ * feedlist_foreach_data: (skip)
+ * @func:		the function to process all found elements
+ * @user_data:  	specifies the second argument that func should be passed
+ *
  * Helper function to recursivly call node methods for all
  * nodes in the feed list. This method is just a wrapper for
  * node_foreach_child_data().
  *
- * @param func		the function to process all found elements
- * @param user_data	specifies the second argument that func should be passed
  */
 #define feedlist_foreach_data(func, user_data) node_foreach_child_data(feedlist_get_root(), func, user_data)
 
 /* UI callbacks */
 
 /**
- * Callback for feed list selection change .
+ * feedlist_selection_changed: (skip)
+ * @node:	the new selected node
  *
- * @param node		the new selected node
+ * Callback for feed list selection change .
  */
 void feedlist_selection_changed (nodePtr node);
 
 /** 
- * Tries to find the first node with an unread item in the given folder.
+ * feedlist_find_unread_feed: (skip)
+ * @folder:	the folder to search
  *
- * @param folder	the folder to search
+ * Tries to find the first node with an unread item in the given folder.
  * 
- * @return a found node or NULL
+ * Returns: (nullable) (transfer none): a found node or NULL
  */
 nodePtr	feedlist_find_unread_feed (nodePtr folder);
 
 /**
- * To be called when node subscription update gained new items.
+ * feedlist_new_items: (skip)
+ * @newCount:	number of new and unread items
  *
- * @param newCount	number of new and unread items
+ * To be called when node subscription update gained new items.
  */
 void feedlist_new_items (guint newCount);
 

--- a/src/fl_sources/node_source.c
+++ b/src/fl_sources/node_source.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file node_source.c  generic node source provider implementation
  * 
  * Copyright (C) 2005-2016 Lars Windolf <lars.windolf@gmx.de>
@@ -261,7 +261,7 @@ node_source_set_state (nodePtr node, gint newState)
 {
 	debug3 (DEBUG_UPDATE, "node source '%s' now in state %d (was %d)", node->id, newState, node->source->loginState);
 
-	/** State transition actions below... */
+	/* State transition actions below... */
 	if (newState == NODE_SOURCE_STATE_ACTIVE)
 		node->source->authFailures = 0;
 

--- a/src/fl_sources/node_source.h
+++ b/src/fl_sources/node_source.h
@@ -1,12 +1,12 @@
-/**
+/*
  * @file node_source.h  generic node source interface
- * 
+ *
  * Copyright (C) 2005-2014 Lars Windolf <lars.windolf@gmx.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version. 
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -29,14 +29,14 @@
 #include "fl_sources/google_reader_api.h"
 
 /* Liferea allows to have different sources in the feed list. These
-   sources are called "node sources" henceforth. Node sources can 
+   sources are called "node sources" henceforth. Node sources can
    (but do not need to) be single instance only. Node sources do
    provide a subtree of the feed list that can be read-only
    or not. A node source might allow or not allow to add sub folders
-   and reorder (DnD) folder contents. A node source might allow 
+   and reorder (DnD) folder contents. A node source might allow
    hierarchic grouping of its subtree or not. These properties
    are determined by the node source type capability flags.
-   
+
    The node source concept itself is a node type. The implementation
    of this node type can be found in node_source.c.
 
@@ -45,78 +45,78 @@
    all other node source instances at their insertion nodes in
    the feed list.
 
-   Each source type has to be able to serve user requests and is 
+   Each source type has to be able to serve user requests and is
    responsible for keeping its feed list node's states up-to-date.
-   A source type implementation can omit all callbacks marked as 
+   A source type implementation can omit all callbacks marked as
    optional. */
 
 typedef enum {
-	NODE_SOURCE_CAPABILITY_IS_ROOT			= (1<<0),	/**< flag only for default feed list source */
-	NODE_SOURCE_CAPABILITY_DYNAMIC_CREATION		= (1<<1),	/**< feed list source is user created */
-	NODE_SOURCE_CAPABILITY_WRITABLE_FEEDLIST	= (1<<2),	/**< the feed list tree of the source can be changed */
-	NODE_SOURCE_CAPABILITY_ADD_FEED			= (1<<3),	/**< feeds can be added to the source */
-	NODE_SOURCE_CAPABILITY_ADD_FOLDER		= (1<<4),	/**< folders can be added to the source */
-	NODE_SOURCE_CAPABILITY_HIERARCHIC_FEEDLIST	= (1<<5),	/**< the feed list tree of the source can have hierarchic folders */
-	NODE_SOURCE_CAPABILITY_ITEM_STATE_SYNC		= (1<<6),	/**< the item state can and should be sync'ed with remote */
-	NODE_SOURCE_CAPABILITY_CONVERT_TO_LOCAL		= (1<<7),	/**< node sources of this type can be converted to internal subscription lists */
-	NODE_SOURCE_CAPABILITY_GOOGLE_READER_API	= (1<<8),	/**< node sources of this type are Google Reader clones */
-	NODE_SOURCE_CAPABILITY_CAN_LOGIN		= (1<<9)	/**< node source needs login (means loginState member is to be used) */
+	NODE_SOURCE_CAPABILITY_IS_ROOT			= (1<<0),	/*<< flag only for default feed list source */
+	NODE_SOURCE_CAPABILITY_DYNAMIC_CREATION		= (1<<1),	/*<< feed list source is user created */
+	NODE_SOURCE_CAPABILITY_WRITABLE_FEEDLIST	= (1<<2),	/*<< the feed list tree of the source can be changed */
+	NODE_SOURCE_CAPABILITY_ADD_FEED			= (1<<3),	/*<< feeds can be added to the source */
+	NODE_SOURCE_CAPABILITY_ADD_FOLDER		= (1<<4),	/*<< folders can be added to the source */
+	NODE_SOURCE_CAPABILITY_HIERARCHIC_FEEDLIST	= (1<<5),	/*<< the feed list tree of the source can have hierarchic folders */
+	NODE_SOURCE_CAPABILITY_ITEM_STATE_SYNC		= (1<<6),	/*<< the item state can and should be sync'ed with remote */
+	NODE_SOURCE_CAPABILITY_CONVERT_TO_LOCAL		= (1<<7),	/*<< node sources of this type can be converted to internal subscription lists */
+	NODE_SOURCE_CAPABILITY_GOOGLE_READER_API	= (1<<8),	/*<< node sources of this type are Google Reader clones */
+	NODE_SOURCE_CAPABILITY_CAN_LOGIN		= (1<<9)	/*<< node source needs login (means loginState member is to be used) */
 } nodeSourceCapability;
 
-/** Node source state model */
-typedef enum { 
-	NODE_SOURCE_STATE_NONE = 0,		/**< no authentication tried so far */
-	NODE_SOURCE_STATE_IN_PROGRESS,		/**< authentication in progress */
-	NODE_SOURCE_STATE_ACTIVE,		/**< authentication succeeded */
-	NODE_SOURCE_STATE_NO_AUTH,		/**< authentication has failed */
-	NODE_SOURCE_STATE_MIGRATE,		/**< source will be migrated, do not do anything anymore! */
+/* Node source state model */
+typedef enum {
+	NODE_SOURCE_STATE_NONE = 0,		/*<< no authentication tried so far */
+	NODE_SOURCE_STATE_IN_PROGRESS,		/*<< authentication in progress */
+	NODE_SOURCE_STATE_ACTIVE,		/*<< authentication succeeded */
+	NODE_SOURCE_STATE_NO_AUTH,		/*<< authentication has failed */
+	NODE_SOURCE_STATE_MIGRATE,		/*<< source will be migrated, do not do anything anymore! */
 } nodeSourceState;
 
-/** Node source subscription update flags */
-typedef enum { 
-	/**
+/* Node source subscription update flags */
+typedef enum {
+	/*
 	 * Update only the subscription list, and not each node underneath it.
 	 * Note: Uses higher 16 bits to avoid conflict.
 	 */
 	NODE_SOURCE_UPDATE_ONLY_LIST = (1<<16),
-	/**
-	 * Only login, do not do any updates. 
+	/*
+	 * Only login, do not do any updates.
 	 */
 	NODE_SOURCE_UPDATE_ONLY_LOGIN = (1<<17)
 } nodeSourceUpdate;
 
-/**
+/*
  * Number of auth failures after which we stop bothering the user while
  * auto-updating until he manually updates again.
  */
 #define NODE_SOURCE_MAX_AUTH_FAILURES		3
 
-/** feed list node source type */
+/* feed list node source type */
 typedef struct nodeSourceType {
-	const gchar	*id;		/**< a unique feed list source type identifier */
-	const gchar	*name;		/**< a descriptive source name (for preferences and menus) */
-	gulong		capabilities;	/**< bitmask of feed list source capabilities */
-	googleReaderApi	api;		/**< OPTIONAL endpoint definitions for Google Reader like JSON API */
+	const gchar	*id;		/*<< a unique feed list source type identifier */
+	const gchar	*name;		/*<< a descriptive source name (for preferences and menus) */
+	gulong		capabilities;	/*<< bitmask of feed list source capabilities */
+	googleReaderApi	api;		/*<< OPTIONAL endpoint definitions for Google Reader like JSON API */
 
-	/** The subscription type for all child nodes that are subscriptions */
+	/* The subscription type for all child nodes that are subscriptions */
 	subscriptionTypePtr	feedSubscriptionType;
 
-	/** The subscription type for the source itself (can be NULL) */
+	/* The subscription type for the source itself (can be NULL) */
 	subscriptionTypePtr	sourceSubscriptionType;
 
 	/* source type loading and unloading methods */
 	void		(*source_type_init)(void);
 	void 		(*source_type_deinit)(void);
 
-	/**
+	/*
 	 * This OPTIONAL callback is used to create an instance
-	 * of the implemented source type. It is to be called by 
-	 * the parent source node_request_add_*() implementation. 
+	 * of the implemented source type. It is to be called by
+	 * the parent source node_request_add_*() implementation.
 	 * Mandatory for all sources except the root source.
 	 */
 	void 		(*source_new)(void);
 
-	/**
+	/*
 	 * This OPTIONAL callback is used to delete an instance
 	 * of the implemented source type. It is to be called
 	 * by the parent source node_remove() implementation.
@@ -124,58 +124,58 @@ typedef struct nodeSourceType {
 	 */
 	void 		(*source_delete)(nodePtr node);
 
-	/**
+	/*
 	 * This MANDATORY method is called when the source is to
 	 * create the feed list subtree attached to the source root
 	 * node.
 	 */
 	void 		(*source_import)(nodePtr node);
 
-	/**
+	/*
 	 * This MANDATORY method is called when the source is to
 	 * save it's feed list subtree (if necessary at all). This
 	 * is not a request to save the data of the attached nodes!
 	 */
 	void 		(*source_export)(nodePtr node);
-	
-	/**
+
+	/*
 	 * This MANDATORY method is called to get an OPML representation
 	 * of the feedlist of the given node source. Returns a newly
 	 * allocated filename string that is to be freed by the
 	 * caller.
 	 */
 	gchar *		(*source_get_feedlist)(nodePtr node);
-	
-	/**
+
+	/*
 	 * This MANDATARY method is called to request the source to update
 	 * its subscriptions list and the child subscriptions according
 	 * the its update interval.
 	 */
 	void		(*source_auto_update)(nodePtr node);
-	
-	/**
+
+	/*
 	 * Frees all data of the given node source instance. To be called
 	 * during node_free() for a source node.
 	 */
 	void		(*free) (nodePtr node);
 
-	/**
-	 * Changes the flag state of an item.  This is to allow node source type 
+	/*
+	 * Changes the flag state of an item.  This is to allow node source type
 	 * implementations to synchronize remote item states.
 	 *
 	 * This is an OPTIONAL method.
 	 */
 	void		(*item_set_flag) (nodePtr node, itemPtr item, gboolean newState);
 
-	/**
-	 * Mark an item as read. This is to allow node source type 
+	/*
+	 * Mark an item as read. This is to allow node source type
 	 * implementations to synchronize remote item states.
 	 *
 	 * This is an OPTIONAL method.
 	 */
 	void            (*item_mark_read) (nodePtr node, itemPtr item, gboolean newState);
-	
-	/**
+
+	/*
 	 * Add a new folder to the feed list provided by node
 	 * source. OPTIONAL, but must be implemented when
 	 * NODE_SOURCE_CAPABILITY_WRITABLE_FEEDLIST and
@@ -183,30 +183,30 @@ typedef struct nodeSourceType {
 	 */
 	nodePtr		(*add_folder) (nodePtr node, const gchar *title);
 
-	/**
+	/*
 	 * Add a new subscription to the feed list provided
 	 * by the node source. OPTIONAL method, that must be implemented
 	 * when NODE_SOURCE_CAPABILITY_WRITABLE_FEEDLIST is set.
 	 *
-	 * The implementation could propagate the added subscription 
+	 * The implementation could propagate the added subscription
 	 * to a remote feed list service.
 	 *
-	 * The implementation MUST create and return a new child node 
+	 * The implementation MUST create and return a new child node
 	 * setup with the given subscription which might be changed as necessary.
 	 *
 	 * The returned node will be automatically added to the feed list UI.
 	 * Initial update and state saving will be triggered automatically.
 	 */
 	nodePtr		(*add_subscription) (nodePtr node, struct subscription *subscription);
-	 
-	/**
-	 * Removes an existing node (subscription or folder) from the feed list 
+
+	/*
+	 * Removes an existing node (subscription or folder) from the feed list
 	 * provided by the node source. OPTIONAL method that must be
 	 * implemented when NODE_SOURCE_CAPABILITY_WRITABLE_FEEDLIST is set.
 	 */
 	void		(*remove_node) (nodePtr node, nodePtr child);
 
-	/**
+	/*
 	 * Converts all subscriptions to default source subscriptions.
 	 *
 	 * This is an OPTIONAL method.
@@ -215,172 +215,187 @@ typedef struct nodeSourceType {
 
 } *nodeSourceTypePtr;
 
-/** feed list source instance */
+/* feed list source instance */
 typedef struct nodeSource {
-	nodeSourceTypePtr	type;		/**< node source type of this source instance */
-	nodePtr			root;		/**< insertion node of this node source instance */
-	GQueue			*actionQueue;	/**< queue for async actions */
-	gint			loginState;	/**< The current login state */
+	nodeSourceTypePtr	type;		/*<< node source type of this source instance */
+	nodePtr			root;		/*<< insertion node of this node source instance */
+	GQueue			*actionQueue;	/*<< queue for async actions */
+	gint			loginState;	/*<< The current login state */
 
-	gchar			*authToken;	/**< The authorization token */
-	gint			authFailures;	/**< Number of authentication failures */
+	gchar			*authToken;	/*<< The authorization token */
+	gint			authFailures;	/*<< Number of authentication failures */
 } *nodeSourcePtr;
 
-/** Use this to cast the node source type from a node structure. */
+/* Use this to cast the node source type from a node structure. */
 #define NODE_SOURCE_TYPE(node) ((nodeSourcePtr)(node->source))->type
 
 #define NODE_SOURCE_TYPE_DUMMY_ID "fl_dummy"
 
 /**
+ * node_source_root_from_node: (skip)
+ * @node:	any child node
+ *
  * Get the root node of a feed list source for any given child node.
  *
- * @param node	any child node
- *
- * @returns node source root node
+ * Returns: node source root node
  */
 nodePtr node_source_root_from_node (nodePtr node);
 
-/** 
+/**
+ * node_source_setup_root: (skip)
+ *
  * Scans the source type list for the root source provider.
  * If found creates a new root source and starts it's import.
  *
- * @returns a newly created root node
+ * Returns: a newly created root node
  */
 nodePtr node_source_setup_root (void);
 
 /**
- * Creates a new source and assigns it to the given new node. 
- * To be used to prepare a source node before adding it to the 
+ * node_source_new: (skip)
+ * @node:			a newly created node
+ * @nodeSourceType:     	the node source type
+ * @url:			subscription URL
+ *
+ * Creates a new source and assigns it to the given new node.
+ * To be used to prepare a source node before adding it to the
  * feed list. This method takes care of setting the proper source
  * subscription type and setting up the subscription if url != NULL.
  * The caller needs set additional auth info for the subscription.
- *
- * @param node			a newly created node
- * @param nodeSourceType	the node source type
- * @param url			subscription URL
  */
 void node_source_new (nodePtr node, nodeSourceTypePtr nodeSourceType, const gchar *url);
 
 /**
- * node_source_set_state
- *
- * Change state of the node source by node
- *
+ * node_source_set_state: (skip)
  * @node:		the node source node
  * @newState:		the new state
+ *
+ * Change state of the node source by node
  */
 void node_source_set_state (nodePtr node, gint newState);
 
 /**
+ * node_source_set_auth_token: (skip)
+ * @node:			a node
+ * @token:			a string
+ *
  * Store any type of authentication token (e.g. a cookie or session id)
  *
  * FIXME: maybe drop this in favour of node metadata
- *
- * @param node			a node
- * @param token			a string
  */
 void node_source_set_auth_token (nodePtr node, gchar *token);
 
 /**
+ * node_source_update: (skip)
+ * @node:			the source node
+ *
  * Force the source to update its subscription list and
  * the child subscriptions themselves.
- *
- * @param node			the source node
  */
 void node_source_update (nodePtr node);
 
 /**
+ * node_source_auto_update: (skip)
+ * @node:			the source node
+ *
  * Request the source to update its subscription list and
  * the child subscriptions if necessary according to the
  * update interval of the source.
- *
- * @param node			the source node
  */
 void node_source_auto_update (nodePtr node);
 
 /**
+ * node_source_add_subscription: (skip)
+ * @node:		the source node
+ * @subscription:	the new subscription
+ *
  * Called when a new subscription has been added to the node source.
  *
- * @param node		the source node
- * @param subscription	the new subscription
- *
- * @returns a new node intialized with the new subscription
+ * Returns: a new node intialized with the new subscription
  */
 nodePtr node_source_add_subscription (nodePtr node, struct subscription *subscription);
 
 /**
- * Called when an existing subscription is to be removed from a node source.
+ * node_source_remove_node: (skip)
+ * @node:		the source node
+ * @child:		the child node to remove
  *
- * @param node		the source node
- * @param child		the child node to remove
+ * Called when an existing subscription is to be removed from a node source.
  */
 void node_source_remove_node (nodePtr node, nodePtr child);
 
 /**
+ * node_source_add_folder: (skip)
+ * @node:		the source node
+ * @title:      	the folder title
+ *
  * Called when a new folder is to be added to a node source feed list.
  *
- * @param node		the source node
- * @param title		the folder title
- *
- * @returns a new node representing the new folder
+ * Returns: a new node representing the new folder
  */
 nodePtr node_source_add_folder (nodePtr node, const gchar *title);
 
 /**
- * Called to update a nodes folder. If current folder != given folder 
- * the node will be reparented.
+ * node_source_update_folder: (skip)
+ * @node:		any node
+ * @folder:     	the target folder
  *
- * @param node		any node
- * @param folder	the target folder
+ * Called to update a nodes folder. If current folder != given folder
+ * the node will be reparented.
  */
 void node_source_update_folder (nodePtr node, nodePtr folder);
 
-/* 
- * Find a folder by the name under parent or create it. 
- * 
- * If a node source doesn't provide ids the category display name should be 
- * used as id. The worst thing happening then is to evenly named categories 
- * being merged into one (which the user can easily workaround by renaming 
- * on the remote side).
- * 
- * @param parent	Parent folder (or source root node)
- * @param id		Folder/category id (or NULL)
- * @param name		Folder display name
+/**
+ * node_source_find_or_create_folder: (skip)
+ * @parent:     	Parent folder (or source root node)
+ * @id: 		Folder/category id (or NULL)
+ * @label:		Folder display name
  *
- * @returns a valid nodePtr
+ * Find a folder by the name under parent or create it.
+ *
+ * If a node source doesn't provide ids the category display name should be
+ * used as id. The worst thing happening then is to evenly named categories
+ * being merged into one (which the user can easily workaround by renaming
+ * on the remote side).
+ *
+ * Returns: a valid nodePtr
  */
 nodePtr node_source_find_or_create_folder (nodePtr parent, const gchar *id, const gchar *label);
 
 /**
- * Called when the read state of an item changes.
+ * node_source_item_mark_read: (skip)
+ * @node:		the source node
+ * @item:		the affected item
+ * @newState:   	the new item read state
  *
- * @param node		the source node 
- * @param item		the affected item
- * @param newState	the new item read state
+ * Called when the read state of an item changes.
  */
 void node_source_item_mark_read (nodePtr node, itemPtr item, gboolean newState);
 
 /**
- * Called when the flag state of an item changes.
+ * node_source_set_item_flag: (skip)
+ * @node:		the source node
+ * @item:		the affected item
+ * @newState:   	the new item flag state
  *
- * @param node		the source node 
- * @param item		the affected item
- * @param newState	the new item flag state
+ * Called when the flag state of an item changes.
  */
 void node_source_item_set_flag (nodePtr node, itemPtr item, gboolean newState);
 
 /**
- * Converts all subscriptions to default source subscriptions.
+ * node_source_convert_to_local: (skip)
+ * @node:		the source node
  *
- * @param node		the source node
+ * Converts all subscriptions to default source subscriptions.
  */
 void node_source_convert_to_local (nodePtr node);
 
 /**
+ * node_source_type_register: (skip)
+ * @type:		the type to register
+ *
  * Registers a new node source type. Needs to be called before feed list import!
  * To be used only via NodeSourceTypeActivatable
- *
- * @param type		the type to register
  */
 gboolean node_source_type_register (nodeSourceTypePtr type);
 
@@ -389,8 +404,10 @@ gboolean node_source_type_register (nodeSourceTypePtr type);
 
 #define IS_NODE_SOURCE(node) (node->type == node_source_get_node_type ())
 
-/** 
- * Returns the node source node type implementation.
+/**
+ * node_source_get_node_type: (skip)
+ *
+ * Returns: the node source node type implementation.
  */
 nodeTypePtr node_source_get_node_type (void);
 

--- a/src/item.h
+++ b/src/item.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file item.h common item handling
  * 
  * Copyright (C) 2003-2012 Lars Windolf <lars.windolf@gmx.de>
@@ -34,7 +34,7 @@
 /* item interface						*/
 /* ------------------------------------------------------------ */
 
-/**
+/*
  * An item stores a particular entry in a feed or a search.
  *  Each item belongs to an item set. An itemset is a collection
  *  of items. There are different item set types (e.g. feed,
@@ -42,124 +42,139 @@
  *  The item set node and the item source node is different
  *  for folders and vfolders. */
 typedef struct item {
-	gulong		id;			/**< internally unique item id */
+	gulong		id;			/*<< internally unique item id */
 
 	/* those fields should not be accessed directly. Accessors are provided. */
-	gboolean 	readStatus;		/**< TRUE if the item has been read */
-	gboolean	popupStatus;		/**< TRUE if the item was downloaded and is yet to be displayed by the popup notification feature */
-	gboolean	updateStatus;		/**< TRUE if the item content was updated */
-	gboolean 	flagStatus;		/**< TRUE if the item has been flagged */
-	gboolean	hasEnclosure;		/**< TRUE if this item has at least one enclosure */
-	gchar		*title;			/**< Title */
-	gchar		*source;		/**< URL to the post online */
-	gchar		*sourceId;		/**< "Unique" syndication item identifier, for example <guid> in RSS */
-	gboolean	validGuid;		/**< TRUE if id of this item is a GUID and can be used for duplicate detection */
-	gchar		*description;		/**< XHTML string containing the item's description */
+	gboolean 	readStatus;		/*<< TRUE if the item has been read */
+	gboolean	popupStatus;		/*<< TRUE if the item was downloaded and is yet to be displayed by the popup notification feature */
+	gboolean	updateStatus;		/*<< TRUE if the item content was updated */
+	gboolean 	flagStatus;		/*<< TRUE if the item has been flagged */
+	gboolean	hasEnclosure;		/*<< TRUE if this item has at least one enclosure */
+	gchar		*title;			/*<< Title */
+	gchar		*source;		/*<< URL to the post online */
+	gchar		*sourceId;		/*<< "Unique" syndication item identifier, for example <guid> in RSS */
+	gboolean	validGuid;		/*<< TRUE if id of this item is a GUID and can be used for duplicate detection */
+	gchar		*description;		/*<< XHTML string containing the item's description */
 	
-	GSList		*metadata;		/**< Metadata of this item */
-	GHashTable	*tmpdata;		/**< Temporary data hash used during stateful parsing */
-	time_t		time;			/**< Last modified date of the headline */
+	GSList		*metadata;		/*<< Metadata of this item */
+	GHashTable	*tmpdata;		/*<< Temporary data hash used during stateful parsing */
+	time_t		time;			/*<< Last modified date of the headline */
 
-	gchar		*commentFeedId;		/**< Id of the comment feed of this item (or NULL if there is no comment feed) */
+	gchar		*commentFeedId;		/*<< Id of the comment feed of this item (or NULL if there is no comment feed) */
 	
 	/* comment item properties */
-	gulong		parentItemId;		/**< Id of the parent item the item belongs to(or 0 if no comment item) */
-	gboolean	isComment;		/**< TRUE if item is from a comment feed */
+	gulong		parentItemId;		/*<< Id of the parent item the item belongs to(or 0 if no comment item) */
+	gboolean	isComment;		/*<< TRUE if item is from a comment feed */
 
 	/* item source properties */
-	gchar		*nodeId;		/**< Node id the containing node. Might be a comment feed id. */
-	gchar		*parentNodeId;		/**< Real parent node id. Always a feed list node id. */
-	gulong 		sourceNr;		/**< Either equal to nr or the number of the item this one is a copy of */
+	gchar		*nodeId;		/*<< Node id the containing node. Might be a comment feed id. */
+	gchar		*parentNodeId;		/*<< Real parent node id. Always a feed list node id. */
+	gulong 		sourceNr;		/*<< Either equal to nr or the number of the item this one is a copy of */
 
 	/* remote states used during sync of remote accounts */
-	gboolean	remoteReadStatus;	/**< TRUE if the remote copy of the item has been read */
-	gboolean	remoteFlagStatus;	/**< TRUE if the remote copy of the item has been flagged */
+	gboolean	remoteReadStatus;	/*<< TRUE if the remote copy of the item has been read */
+	gboolean	remoteFlagStatus;	/*<< TRUE if the remote copy of the item has been flagged */
 } *itemPtr;
 
 /**
+ * item_new: (skip)
  * Allocates a new item structure.
  *
- * @returns the new structure
+ * Returns: (transfer full): the new structure
  */
 itemPtr 	item_new(void);
 
 /**
+ * item_load: (skip)
+ * @id:	item id to load
+ *
  * Returns the item structure for the given item id or
  * NULL if no such item does exist. The caller has to free
  * the item with item_unload() once it is not used anymore.
  *
- * @param id	item id to load
- *
- * @returns item structure
+ * Returns: (transfer full) (nullable): item structure
  */
 itemPtr		item_load(gulong id);
 
 /**
+ * item_copy: (skip)
+ * @item: the item to copy
+ *
  * Method to create a copy of an item. The copy will be
  * linked to the original item to allow state update
  * propagation (to be used with vfolders).
+ *
+ * Returns: (transfer full): copy of the item.
  */
 itemPtr		item_copy(itemPtr item);
 
 /**
+ * item_get_base_url: (skip)
+ * @item:	the item
+ *
  * Returns the base URL for the given item.
  *
- * @param item	the item
- *
- * @returns base URL
+ * Returns: base URL
  */
 const gchar * item_get_base_url(itemPtr item);
 
 /**
+ * item_unload: (skip)
+ * @item:	the item to unload
+ *
  * Free the memory used by an itempointer. The item needs to be
  * removed from the itemlist before calling this function.
  *
- * @param item	the item to unload
  */
 void	item_unload(itemPtr item);
 
 /* methods to access properties */
-/** Returns the id of item. */
+/* Returns the id of item. */
 const gchar *	item_get_id(itemPtr item);
-/** Returns the title of item. */
+/* Returns the title of item. */
 const gchar *	item_get_title(itemPtr item);
-/** Returns the description of item. */
+/* Returns the description of item. */
 const gchar *	item_get_description(itemPtr item);
-/** Returns the source of item. */
+/* Returns the source of item. */
 const gchar *	item_get_source(itemPtr item);
 
 /**
+ * item_make_link: (skip)
+ * @item:	the item
+ *
  * Returns the resolved link for the item.
  *
- * @param item	the item
- *
- * @returns newly allocated URI to be free'd using g_free()
+ * Returns: (transfer full): newly allocated URI to be free'd using g_free()
  */
 gchar *	item_make_link(itemPtr item);
 
-/** Sets the item title */
+/* Sets the item title */
 void		item_set_title(itemPtr item, const gchar * title);
 
 /**
+ * item_set_description: (skip)
+ * @item:		the item
+ * @description:	the content
+ *
  * Sets the item description. If called more than once it
  * will merge the new description against the old one deciding
  * on the best to keep.
  *
- * @param item		the item
- * @param description	the content
  */
 void item_set_description (itemPtr item, const gchar *description);
 
-/** Sets the item source */
+/* Sets the item source */
 void		item_set_source(itemPtr item, const gchar * source);
-/** Sets the item id */
+/* Sets the item id */
 void		item_set_id(itemPtr item, const gchar * id);
 
 /**
+ * item_to_xml: (skip)
+ * @item:		the item to save to cache
+ * @parentNode:	the xmlNodePtr to add to
+ *
  * Adds an XML node to the given feed item list node. 
  *
- * @param item		the item to save to cache
- * @param parentNode	the xmlNodePtr to add to
  */
 void item_to_xml (itemPtr item, gpointer parentNode);
 

--- a/src/itemlist.c
+++ b/src/itemlist.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file itemlist.c  item list handling
  *
  * Copyright (C) 2004-2012 Lars Windolf <lars.windolf@gmx.de>
@@ -61,17 +61,17 @@
 
 struct ItemListPrivate
 {
-	GHashTable	*guids;			/**< list of GUID to avoid having duplicates in currently loaded list */
-	itemSetPtr	filter;			/**< currently active filter rules */
-	nodePtr		currentNode;		/**< the node whose own or its child items are currently displayed */
-	gulong		selectedId;		/**< the currently selected (and displayed) item id */
+	GHashTable	*guids;			/*<< list of GUID to avoid having duplicates in currently loaded list */
+	itemSetPtr	filter;			/*<< currently active filter rules */
+	nodePtr		currentNode;		/*<< the node whose own or its child items are currently displayed */
+	gulong		selectedId;		/*<< the currently selected (and displayed) item id */
 	
-	nodeViewType	viewMode;		/**< current viewing mode */
-	guint 		loading;		/**< if >0 prevents selection effects when loading the item list */
-	itemPtr		invalidSelection;	/**< if set then the next selection might need to do an unselect first */
+	nodeViewType	viewMode;		/*<< current viewing mode */
+	guint 		loading;		/*<< if >0 prevents selection effects when loading the item list */
+	itemPtr		invalidSelection;	/*<< if set then the next selection might need to do an unselect first */
 
-	gboolean 	deferredRemove;		/**< TRUE if selected item needs to be removed from cache on unselecting */
-	gboolean 	deferredFilter;		/**< TRUE if selected item needs to be filtered on unselecting */
+	gboolean 	deferredRemove;		/*<< TRUE if selected item needs to be removed from cache on unselecting */
+	gboolean 	deferredFilter;		/*<< TRUE if selected item needs to be filtered on unselecting */
 };
 
 static GObjectClass *parent_class = NULL;

--- a/src/itemlist.h
+++ b/src/itemlist.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file itemlist.h  itemlist handling
  *
  * Copyright (C) 2004-2011 Lars Windolf <lars.windolf@gmx.de>
@@ -59,25 +59,31 @@ GType itemlist_get_type (void);
  *
  * Set up the item list.
  *
- * Returns: the item list instance
+ * Returns: (transfer full): the item list instance
  */
 ItemList * itemlist_create (void);
 
 /**
+ * itemlist_get_displayed_node: (skip)
+ *
  * Returns the currently displayed node.
  *
- * Returns: displayed node (or NULL)
+ * Returns: (transfer none) (nullable): displayed node (or NULL)
  */
 struct node * itemlist_get_displayed_node (void);
 
 /**
+ * itemlist_get_selected: (skip)
+ *
  * Returns the currently selected and displayed item.
  *
- * Returns: displayed item (or NULL) to be free'd using item_unload()
+ * Returns: (transfer full) (nullable): displayed item (or NULL) to be free'd using item_unload()
  */
 itemPtr itemlist_get_selected (void);
 
 /**
+ * itemlist_get_selected_id:
+ *
  * Returns the id of the currently selected item.
  *
  * Returns: displayed item id (or 0)
@@ -85,39 +91,46 @@ itemPtr itemlist_get_selected (void);
 gulong itemlist_get_selected_id (void);
 
 /**
+ * itemlist_merge_itemset: (skip)
+ * @itemSet:	the item set to be merged
+ *
  * To be called whenever a feed was updated. If it is a somehow
  * displayed feed it is loaded this method decides if the
  * and how the item list GUI needs to be updated.
  *
- * @itemSet:	the item set to be merged
  */
 void itemlist_merge_itemset (itemSetPtr itemSet);
 
 /** 
- * Loads the passed nodes items into the item list.
- *
+ * itemlist_load: (skip)
  * @node: 	the node
+ *
+ * Loads the passed nodes items into the item list.
  */
 void itemlist_load (struct node *node);
 
 /**
+ * itemlist_unload: (skip)
+ * @markRead:	if TRUE all items are marked as read
+ *
  * Clears the item list. Unsets the currently
  * displayed item set. Optionally marks every item read.
- *
- * @markRead:	if TRUE all items are marked as read
  */
 void itemlist_unload (gboolean markRead);
 
 /**
+ * itemlist_set_view_mode:
+ * @newMode:	0 = normal, 1 = wide, 2 = combined view
+ *
  * Changes the viewing mode property of the item list.
  * Do not use this method to change the viewing mode
  * of a displayed node!
- *
- * @newMode:	(0 = normal, 1 = wide, 2 = combined view)
  */
 void itemlist_set_view_mode (guint newMode);
 
 /**
+ * itemlist_get_view_mode:
+ *
  * Returns the viewing mode property of the currently displayed item set.
  *
  * Returns: viewing mode (0 = normal, 1 = wide, 2 = combined view)
@@ -125,20 +138,25 @@ void itemlist_set_view_mode (guint newMode);
 guint itemlist_get_view_mode (void);
 
 /**
- * Menu callback that toggles the different viewing modes
- *
+ * on_view_activate: (skip)
  * @action:	the action that emitted the signal
  * @current:	the member of action which was activated
  * @user_data:	unused
+ *
+ * Menu callback that toggles the different viewing modes
  */
 void on_view_activate (GtkRadioAction *action, GtkRadioAction *current, gpointer user_data);
 
 /**
+ * on_prev_read_item_activate: (skip)
+ *
  * Menu callback to select the previously read item from the item history
  */
 void on_prev_read_item_activate (GtkMenuItem *menuitem, gpointer user_data);
 
 /**
+ * on_next_read_item_activate: (skip)
+ *
  * Menu callback to select the next read item from the item history
  */
 void on_next_read_item_activate (GtkMenuItem *menuitem, gpointer user_data);
@@ -150,69 +168,75 @@ void itemlist_update_item (itemPtr item);
 
 
 /**
+ * itemlist_remove_item: (skip)
+ * @item:	the item
+ *
  * To be called whenever the user wants to remove
  * a single item. If necessary the item will be unselected.
  * The item will be removed immediately.
- *
- * @item:	the item
  */
 void itemlist_remove_item (itemPtr item);
 
 /**
  * itemlist_remove_items: (skip)
+ * @itemSet:	the item set from which items are to be removed
+ * @items:	the items to be removed
  *
  * To be called whenever some of the items of an item set
  * are to be removed. In difference to itemlist_remove_item()
  * this function will remove all items first and update the
  * GUI once.
- *
- * @itemSet:	the item set from which items are to be removed
- * @items:	the items to be removed
  */
 void itemlist_remove_items (itemSetPtr itemSet, GList *items);
 
 /**
+ * itemlist_remove_all_items: (skip)
+ * @node:	the node whose item list is to be removed
+ *
  * To be called whenever the user wants to remove 
  * all items of a node. Item list selection will be
  * resetted. All items are removed immediately.
- *
- * @node:	the node whose item list is to be removed
  */
 void itemlist_remove_all_items (struct node *node);
 
 /**
- * Called from GUI when item list selection changes.
- *
+ * itemlist_selection_changed: (skip)
  * @item:	new selected item 
+ *
+ * Called from GUI when item list selection changes.
  */
 void itemlist_selection_changed (itemPtr item);
 
 /**
+ * itemlist_select_next_unread:
+ *
  * Tries to select the next unread item that is currently in the
  * item list. Or does nothing if there are no unread items left.
  */
 void itemlist_select_next_unread (void);
 
 /**
- * Toggle the flag of the given item.
- *
+ * itemlist_toggle_flag: (skip)
  * @item:		the item
+ *
+ * Toggle the flag of the given item.
  */
 void itemlist_toggle_flag (itemPtr item);
 
 /**
- * Toggle the read status of the given item.
- *
+ * itemlist_toggle_read_status: (skip)
  * @item:		the item
+ *
+ * Toggle the read status of the given item.
  */
 void itemlist_toggle_read_status (itemPtr item);
 
 /**
  * itemlist_add_search_result: (skip)
+ * @loader:	the search result item loader
  *
  * Register a search result item loader.
  *
- * @loader:	the search result item loader
  */
 void itemlist_add_search_result (ItemLoader *loader);
 

--- a/src/itemset.c
+++ b/src/itemset.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file itemset.c handling sets of items
  * 
  * Copyright (C) 2005-2015 Lars Windolf <lars.windolf@gmx.de>
@@ -62,17 +62,18 @@ itemset_get_max_item_count (itemSetPtr itemSet)
 }
 
 /**
- * Generic merge logic suitable for feeds
- *
- * @param items		existing items
- * @param newItem	new item to merge
- * @param maxChecks     maximum number of item checks
- * @param allowUpdates	TRUE if item content update is to be
+ * itemset_generic_merge_check: (skip)
+ * @items:		existing items
+ * @newItem:		new item to merge
+ * @maxChecks: 		maximum number of item checks
+ * @allowUpdates:	TRUE if item content update is to be
  *      		allowed for existing items
- * @param allowStateChanges	TRUE if item state shall be
+ * @allowStateChanges:	TRUE if item state shall be
  *				overwritten by source
  *
- * @returns TRUE if merging instead of updating is necessary) 
+ * Generic merge logic suitable for feeds
+ *
+ * Returns: TRUE if merging instead of updating is necessary)
  */
 static gboolean
 itemset_generic_merge_check (GList *items, itemPtr newItem, gint maxChecks, gboolean allowUpdates, gboolean allowStateChanges)

--- a/src/itemset.h
+++ b/src/itemset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file itemset.h  interface to handle sets of items
  * 
  * Copyright (C) 2005-2012 Lars Windolf <lars.windolf@gmx.de>
@@ -25,18 +25,18 @@
 #include "item.h"
 #include "rule.h"
 
-/**
+/*
  * The itemset interface processes item list actions
  * based on the item set type specified by the node
  * the item set belongs to.
  */
 
 typedef struct itemSet {
-	GSList		*rules;		/**< list of rules each item matches */
-	gboolean	anyMatch;	/**< TRUE means only one of the rules must match for item inclusion */
+	GSList		*rules;		/*<< list of rules each item matches */
+	gboolean	anyMatch;	/*<< TRUE means only one of the rules must match for item inclusion */
 	
-	GList		*ids;		/**< the list of item ids */
-	gchar		*nodeId;	/**< the feed list node id this item set belongs to */
+	GList		*ids;		/*<< the list of item ids */
+	gchar		*nodeId;	/*<< the feed list node id this item set belongs to */
 } *itemSetPtr;
 
 /* item set iterating interface */
@@ -44,52 +44,57 @@ typedef struct itemSet {
 typedef void 	(*itemActionFunc)	(itemPtr item);
 
 /**
- * Calls the given callback for each of the items in the item set.
+ * itemset_foreach: (skip)
+ * @itemSet:	the item set
+ * @callback:	the callback
  *
- * @param itemSet	the item set
- * @param callback	the callback
+ * Calls the given callback for each of the items in the item set.
  */
 void itemset_foreach (itemSetPtr itemSet, itemActionFunc callback);
 
 /**
+ * itemset_merge_items: (skip)
+ * @itemSet:		the item set to merge into
+ * @items:		a list of items to merge
+ * @allowUpdates:	TRUE if older items may be replaced
+ * @markAsRead:		TRUE if all new items should be marked as read
+ *
  * Merges the given item set into the item set of
  * the given node. Used for node updating.
  *
- * @param itemSet	the item set to merge into
- * @param items		a list of items to merge
- * @param allowUpdates	TRUE if older items may be replaced
- * @param markAsRead	TRUE if all new items should be marked as read
- *
- * @returns the number of new merged items
+ * Returns: the number of new merged items
  */
 guint itemset_merge_items(itemSetPtr itemSet, GList *items, gboolean allowUpdates, gboolean markAsRead);
 
 /**
+ * itemset_check_item: (skip)
+ * @itemSet:	the itemSet
+ * @item:	the item
+ *
  * Checks if the given item matches the rules of the given item set.
  *
- * @param itemSet	the itemSet
- * @param item		the item
- *
- * @returns TRUE if the item matches the rules of the item set
+ * Returns: TRUE if the item matches the rules of the item set
  */
 gboolean itemset_check_item (itemSetPtr itemSet, itemPtr item);
 
 /**
+ * itemset_add_rule: (skip)
+ * @itemSet:	the item set
+ * @ruleId:	id string for this rule type
+ * @value:	argument string for this rule
+ * @additive:	indicates positive or negative logic
+ *
  * Method that creates and adds a rule to an item set. To be used
  * on loading time, when creating searches or when editing
  * search folder properties.
- *
- * @param itemSet	the item set
- * @param ruleId	id string for this rule type
- * @param value		argument string for this rule
- * @param additive	indicates positive or negative logic
  */
 void itemset_add_rule (itemSetPtr itemSet, const gchar *ruleId, const gchar *value, gboolean additive);
 
 /**
- * Frees the given item set and all items it contains.
+ * itemset_free: (skip)
+ * @itemSet:	the item set to free
  *
- * @param itemSet	the item set to free
+ * Frees the given item set and all items it contains.
  */
 void itemset_free(itemSetPtr itemSet);
 

--- a/src/node.c
+++ b/src/node.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file node.c  hierarchic feed list node handling
  * 
  * Copyright (C) 2003-2016 Lars Windolf <lars.windolf@gmx.de>
@@ -39,7 +39,7 @@
 #include "ui/liferea_shell.h"
 #include "ui/feed_list_node.h"
 
-static GHashTable *nodes = NULL;	/**< node id -> node lookup table */
+static GHashTable *nodes = NULL;	/*<< node id -> node lookup table */
 
 #define NODE_ID_LEN	7
 
@@ -422,7 +422,7 @@ node_load_icon (nodePtr node)
 		node->iconFile = g_build_filename (PACKAGE_DATA_DIR, PACKAGE, "pixmaps", "default.png", NULL);
 }
 
-/** determines the nodes favicon or default icon */
+/* determines the nodes favicon or default icon */
 gpointer
 node_get_icon (nodePtr node)
 {

--- a/src/node.h
+++ b/src/node.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file node.h  hierarchic feed list node interface
  * 
  * Copyright (C) 2003-2015 Lars Windolf <lars.windolf@gmx.de>
@@ -38,359 +38,397 @@
    complexity for the GUI, scripting and updating functionality.
  */
 
-/** generic feed list node structure */
+/* generic feed list node structure */
 typedef struct node {
-	gpointer		data;		/**< node type specific data structure */
-	struct subscription	*subscription;	/**< subscription attached to this node (or NULL) */
-	struct nodeType		*type;		/**< node type implementation */	
-	struct nodeSource	*source;	/**< the feed list source handling this node */
-	gchar			*iconFile;	/**< the path of the favicon file */
+	gpointer		data;		/*<< node type specific data structure */
+	struct subscription	*subscription;	/*<< subscription attached to this node (or NULL) */
+	struct nodeType		*type;		/*<< node type implementation */
+	struct nodeSource	*source;	/*<< the feed list source handling this node */
+	gchar			*iconFile;	/*<< the path of the favicon file */
 
 	/* feed list state properties of this node */
-	struct node		*parent;	/**< the parent node (or NULL if at root level) */
-	GSList			*children;	/**< ordered list of node children */
-	gchar			*id;		/**< unique node identifier string */
+	struct node		*parent;	/*<< the parent node (or NULL if at root level) */
+	GSList			*children;	/*<< ordered list of node children */
+	gchar			*id;		/*<< unique node identifier string */
 
-	guint			itemCount;	/**< number of items */
-	guint			unreadCount;	/**< number of unread items */
-	guint			popupCount;	/**< number of items to be notified */
-	guint			newCount;	/**< number of recently downloaded items */
+	guint			itemCount;	/*<< number of items */
+	guint			unreadCount;	/*<< number of unread items */
+	guint			popupCount;	/*<< number of items to be notified */
+	guint			newCount;	/*<< number of recently downloaded items */
 
-	gchar			*title;		/**< the label of the node in the feed list */
-	gpointer		icon;		/**< 16x16 favicon GdkPixBuf (or NULL) */
-	gpointer		largeIcon;	/**< 32x32 favicon GdkPixBuf (or NULL) */
-	gboolean		available;	/**< availability of this node (usually the last downloading state) */
-	gboolean		expanded;	/**< expansion state (for nodes with childs) */
+	gchar			*title;		/*<< the label of the node in the feed list */
+	gpointer		icon;		/*<< 16x16 favicon GdkPixBuf (or NULL) */
+	gpointer		largeIcon;	/*<< 32x32 favicon GdkPixBuf (or NULL) */
+	gboolean		available;	/*<< availability of this node (usually the last downloading state) */
+	gboolean		expanded;	/*<< expansion state (for nodes with childs) */
 
 	/* item list state properties of this node */
-	nodeViewType		viewMode;	/**< Viewing mode for this node (one of NODE_VIEW_MODE_*) */
-	nodeViewSortType	sortColumn;	/**< Node specific item view sort attribute. */
-	gboolean		sortReversed;	/**< Sort in the reverse order? */
+	nodeViewType		viewMode;	/*<< Viewing mode for this node (one of NODE_VIEW_MODE_*) */
+	nodeViewSortType	sortColumn;	/*<< Node specific item view sort attribute. */
+	gboolean		sortReversed;	/*<< Sort in the reverse order? */
 	
 	/* rendering behaviour of this node */
-	gboolean	loadItemLink;	/**< if TRUE do automatically load the item link into the HTML pane */
+	gboolean	loadItemLink;	/*<< if TRUE do automatically load the item link into the HTML pane */
 	
 	/* current state of this node */	
-	gboolean	needsUpdate;	/**< if TRUE: the item list has changed and the nodes feed list representation needs to be updated */
-	gboolean	needsRecount;	/**< if TRUE: the number of unread/total items is currently unknown and needs recounting */
+	gboolean	needsUpdate;	/*<< if TRUE: the item list has changed and the nodes feed list representation needs to be updated */
+	gboolean	needsRecount;	/*<< if TRUE: the number of unread/total items is currently unknown and needs recounting */
 
 } *nodePtr;
 
 /**
+ * node_new: (skip)
  * Creates a new node structure.
  *
- * @returns the new node
+ * Returns: (transfer full): the new node
  */
 nodePtr node_new (struct nodeType *type);
 
 /**
+ * node_is_used_id: (skip)
+ * @id:	the node id to check
+ *
  * Can be used to check whether an id is used or not.
  *
- * @param id	the node id to check
- *
- * @returns the node with the given id (or NULL)
+ * Returns: (transfer none) (nullable): the node with the given id (or NULL)
  */
 nodePtr node_is_used_id (const gchar *id);
 
 /**
+ * node_from_id: (skip)
+ * @id:	the node id to look up
+ *
  * Node lookup by node id. Will report an error if the queried
  * id does not exist.
  *
- * @param id	the node id to look up
- *
- * @returns the node with the given id (or NULL)
+ * Returns: (transfer none) (nullable): the node with the given id (or NULL)
  */
 nodePtr node_from_id (const gchar *id);
 
 /**
+ * node_set_parent: (skip)
+ * @node:		the node
+ * @parent: (nullable):	the parent node (optional can be NULL)
+ * @position:   	insert position (optional can be 0)
+ *
  * Sets a nodes parent. If no parent node is given the 
  * parent node of the currently selected feed or the 
  * selected folder will be used.
  *
  * To be used before calling feedlist_node_added()
- *
- * @param node		the node
- * @param parent	the parent node (optional can be NULL)
- * @param position	insert position (optional can be 0)
  */
 void node_set_parent (nodePtr node, nodePtr parent, gint position);
 
 /**
+ * node_reparent: (skip)
+ * @node:		the node
+ * @new_parent: 	nodes new parent
+ *
  * Set a node's new parent and update UI. If a node already has a parent, 
  * it will be removed from its parent children list. 
- * 
- * @param node			the node
- * @param new_parent	nodes new parent
  */ 
 void node_reparent (nodePtr node, nodePtr new_parent);
 
 /**
- * Removes all data associated with the given node.
+ * node_remove: (skip)
+ * @node:		the node
  *
- * @param node		the node
+ * Removes all data associated with the given node.
  */
 void node_remove (nodePtr node);
 
 /**
- * Attaches a data structure to the given node.
+ * node_set_data: (skip)
+ * @node: 	the node to attach to
+ * @data:	the structure
  *
- * @param node 	the node to attach to
- * @param data	the structure
+ * Attaches a data structure to the given node.
  */
 void node_set_data(nodePtr node, gpointer data);
 
 /**
- * Attaches the subscription to the given node.
+ * node_set_subscription: (skip)
+ * @node:		the node
+ * @subscription:	the subscription
  *
- * @param node		the node
- * @param subscription	the subscription
+ * Attaches the subscription to the given node.
  */
 void node_set_subscription (nodePtr node, struct subscription *subscription);
 
 /**
+ * node_update_subscription: (skip)
+ * @node:		the node
+ * @user_data:  	update flags
+ *
  * Helper function to be used with node_foreach_child()
  * to mass-update subscriptions.
- *
- * @param node		the node
- * @param user_data	update flags
  */
 void node_update_subscription (nodePtr node, gpointer user_data);
 
 /**
+ * node_auto_update_subscription: (skip)
+ * @node:		the node
+ *
  * Helper function to be used with node_foreach_child()
  * to mass-auto-update subscriptions.
- *
- * @param node		the node
  */
 void node_auto_update_subscription (nodePtr node);
 
 /**
+ * node_reset_update_counter: (skip)
+ * @node:		the node
+ * @now:		the current timestamp
+ *
  * Helper function to be used with node_foreach_child()
  * to mass-auto-update subscriptions.
- *
- * @param node		the node
- * @param now		the current timestamp
  */
 void node_reset_update_counter (nodePtr node, GTimeVal *now);
 
 /**
+ * node_is_ancestor: (skip)
+ * @node1:		the possible ancestor
+ * @node2:		the possible child
+ *
  * Determines whether node1 is an ancestor of node2
  *
- * @param node1		the possible ancestor
- * @param node2		the possible child
- * @returns TRUE if node1 is ancestor of node2
+ * Returns: TRUE if node1 is ancestor of node2
  */
 gboolean node_is_ancestor(nodePtr node1, nodePtr node2);
 
 /** 
+ * node_get_title: (skip)
+ * @node:	the node
+ *
  * Query the node's title for the feed list.
  *
- * @param node	the node
- *
- * @returns the title
+ * Returns: the title
  */
 const gchar * node_get_title(nodePtr node);
 
 /**
- * Sets the node's title for the feed list.
+ * node_set_title: (skip)
+ * @node:	the node
+ * @title:	the title
  *
- * @param node	the node
- * @param title	the title
+ * Sets the node's title for the feed list.
  */
 void node_set_title(nodePtr node, const gchar *title);
 
 /**
+ * node_update_counters: (skip)
+ * @node:	the node
+ *
  * Update the number of items and unread items of a node from
  * the DB. This method ensures propagation to parent folders.
- *
- * @param node	the node
  */
 void node_update_counters(nodePtr node);
 
 /**
- * Recursively marks all items of the given node as read.
+ * node_mark_all_read: (skip)
+ * @node:	the node to process
  *
- * @param node	the node to process
+ * Recursively marks all items of the given node as read.
  */
 void node_mark_all_read(nodePtr node);
 
 /**
- * Assigns a new pixmaps as the favicon representing this node.
+ * node_set_icon: (skip)
+ * @node:		the node
+ * @icon: (nullable):	a pixmap or NULL
  *
- * @param node		the node
- * @param icon		a pixmap or NULL
+ * Assigns a new pixmaps as the favicon representing this node.
  */
 void node_set_icon(nodePtr node, gpointer icon);
 
 /**
+ * node_get_icon: (skip)
+ *
  * Returns an appropriate icon for the given node. If the node
  * is unavailable the "unavailable" icon will be returned. If
  * the node is available an existing favicon or the node type
  * specific default icon will be returned.
  *
- * @returns a pixmap or NULL
+ * Returns: (nullable): a pixmap or NULL
  */
 gpointer node_get_icon (nodePtr node);
 
 /**
+ * node_get_large_icon: (skip)
+ *
  * Returns a large icon for the node. Does not return any default
  * icons like node_get_icon() does.
  *
- * @returns a pixmap or NULL
+ * Returns: (nullable): a pixmap or NULL
  */
 gpointer node_get_large_icon (nodePtr node);
 
 /**
+ * node_get_favicon_file: (skip)
+ * @node:		the node
+ *
  * Returns the name of the favicon cache file for the given node.
  * If there is no favicon a default icon file name will be returned.
  *
- * @param node		the node
- *
- * @return a file name
+ * Returns: a file name
  */
 const gchar * node_get_favicon_file(nodePtr node);
 
 /**
+ * node_new_id:
+ *
  * Returns a new unused unique node id.
  *
- * @returns new id (to be free'd using g_free)
+ * Returns: (transfer full): new id (to be free'd using g_free)
  */
 gchar * node_new_id (void);
 
 /**
+ * node_get_id: (skip)
+ * @node:	the node
+ *
  * Query the unique id string of the node.
  *
- * @param node	the node
- *
- * @returns id string
+ * Returns: id string
  */
 const gchar *node_get_id (nodePtr node);
 
 /** 
- * Set the unique id string of the node.
+ * node_set_id: (skip)
+ * @node:	the node
+ * @id: 	the id string
  *
- * @param node	the node
- * @param id 	the id string
+ * Set the unique id string of the node.
  */
 void node_set_id(nodePtr node, const gchar *id);
 
 /** 
- * Frees a given node structure.
+ * node_free: (skip)
+ * @node: the node to free
  *
- * @param the node to free
+ * Frees a given node structure.
  */
 void node_free(nodePtr node);
 
 /**
+ * node_default_render: (skip)
+ * @node:		the node to render
+ *
  * Helper function for generic node rendering. Performs
  * a generic node serialization to XML and passes the
  * generated XML source document to the XSLT stylesheet
  * with the same name as the node type id.
  *
- * @param node		the node to render
- *
- * @returns XHTML string
+ * Returns: XHTML string
  */
 gchar * node_default_render(nodePtr node);
 
 /**
- * Saves the given node to cache.
+ * node_save: (skip)
+ * @node:	the node
  *
- * @param node	the node
+ * Saves the given node to cache.
  */
 void node_save(nodePtr node);
 
 /**
+ * node_get_itemset: (skip)
+ * @node:	the node
+ *
  * Loads all items of the given node into memory.
  * The caller needs to free the item set using itemset_free()
  *
- * @param node	the node
- *
- * @returns the item set
+ * Returns: the item set
  */
 itemSetPtr node_get_itemset(nodePtr node);
 
 /**
+ * node_render: (skip)
+ * @node:	the node
+ *
  * Node content rendering
  *
- * @param node	the node
- *
- * @returns string with node rendered in HTML
+ * Returns: string with node rendered in HTML
  */
 gchar * node_render(nodePtr node);
 
 /**
- * Called when updating favicons is requested.
+ * node_update_favicon: (skip)
+ * @node:		the node
  *
- * @param node		the node
+ * Called when updating favicons is requested.
  */
 void node_update_favicon (nodePtr node);
 
 /**
- * node_load_icon:
+ * node_load_icon: (skip)
+ * @node:	the node
  *
  * Load node icon in memory. Should be called only once on startup
  * and when the node icon has changed.
- *
- * @node:	the node
  */
 void node_load_icon (nodePtr node);
 
 /**
+ * node_set_sort_column: (skip)
+ * @node:		the node
+ * @sortColumn: 	sort column id
+ * @reversed:   	TRUE if order should be reversed
+ *
  * Change/Set the sort column of a given node.
  *
- * @param node		the node
- * @param sortColumn	sort column id
- * @param reversed	TRUE if order should be reversed
- *
- * @returns TRUE if the passed settings were different from the previous ones
+ * Returns: TRUE if the passed settings were different from the previous ones
  */
 gboolean node_set_sort_column (nodePtr node, nodeViewSortType sortColumn, gboolean reversed);
 
 /**
- * Change/Set the viewing mode of a given node.
+ * node_set_view_mode: (skip)
+ * @node:		the node
+ * @newMode:    	viewing mode (NODE_VIEW_MODE_*)
  *
- * @param node		the node
- * @param newMode	viewing mode (NODE_VIEW_MODE_*)
+ * Change/Set the viewing mode of a given node.
  */
 void node_set_view_mode(nodePtr node, nodeViewType newMode);
 
 /**
+ * node_get_view_mode: (skip)
+ * @node: 	the node
+ *
  * Query the effective viewing mode setting of a given mode.
  * When node viewing mode is set to default it will return the
  * configured default.
  *
- * @param node 	the node
- *
- * @returns viewing mode (NODE_VIEW_MODE_*)
+ * Returns: viewing mode (NODE_VIEW_MODE_*)
  */
 nodeViewType node_get_view_mode(nodePtr node);
 
 /**
+ * node_get_base_url: (skip)
+ * @node:	the node
+ *
  * Returns the base URL for the given node.
  * If it is a mixed item set NULL will be returned.
  *
- * @param node	the node
- *
- * @returns base URL
+ * Returns: base URL
  */
 const gchar * node_get_base_url(nodePtr node);
 
 /**
+ * node_can_add_child_feed: (skip)
+ * @node:	the node
+ *
  * Query whether a feed be added to the given node.
  *
- * @param node	the node
- *
- * @returns TRUE if a feed can be added
+ * Returns: TRUE if a feed can be added
  */
 gboolean node_can_add_child_feed (nodePtr node);
 
 /**
+ * node_can_add_child_folder: (skip)
+ * @node:	the node
+ *
  * Query whether a folder be added to the given node.
  *
- * @param node	the node
- *
- * @returns TRUE if a folder can be added
+ * Returns: TRUE if a folder can be added
  */
 gboolean node_can_add_child_folder (nodePtr node);
 
@@ -399,30 +437,32 @@ gboolean node_can_add_child_folder (nodePtr node);
 typedef void 	(*nodeActionFunc)	(nodePtr node);
 typedef void 	(*nodeActionDataFunc)	(nodePtr node, gpointer user_data);
 
-/**
+/*
  * Do not call this method directly! Do use
  * node_foreach_child() or node_foreach_child_data()!
  */
 void node_foreach_child_full(nodePtr ptr, gpointer func, gint params, gpointer user_data);
 
 /**
+ * node_foreach_child: (skip)
+ * @node:	node pointer whose children should be processed
+ * @func:	the function to process all found elements
+ *
  * Helper function to call node methods for all
  * children of a given node. The given function may
  * modify the children list.
- *
- * @param node	node pointer whose children should be processed
- * @param func	the function to process all found elements
  */
 #define node_foreach_child(node, func) node_foreach_child_full(node,func,0,NULL)
 
 /**
+ * node_foreach_child_data: (skip)
+ * @node:	node pointer whose children should be processed
+ * @func:	the function to process all found elements
+ * @user_data:  specifies the second argument that func should be passed
+ *
  * Helper function to call node methods for all
  * children of a given node. The given function may 
  * modify the children list.
- *
- * @param node	node pointer whose children should be processed
- * @param func	the function to process all found elements
- * @param user_data specifies the second argument that func should be passed
  */
 #define node_foreach_child_data(node, func, user_data) node_foreach_child_full(node,func,1,user_data)
 

--- a/src/node_view.h
+++ b/src/node_view.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file node_view.h  node view modes
  * 
  * Copyright (C) 2009-2012 Lars Windolf <lars.windolf@gmx.de>

--- a/src/social.c
+++ b/src/social.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file social.c  social networking integration
  * 
  * Copyright (C) 2006-2013 Lars Windolf <lars.windolf@gmx.de>
@@ -24,10 +24,10 @@
 #include "debug.h"
 #include "ui/browser_tabs.h"
 
-/** list of registered bookmarking sites */
+/* list of registered bookmarking sites */
 GSList *bookmarkSites = NULL;
 
-/** the currently configured bookmarking site */
+/* the currently configured bookmarking site */
 static socialSitePtr bookmarkSite = NULL;
 
 void

--- a/src/social.h
+++ b/src/social.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file social.h  social networking integration
  * 
  * Copyright (C) 2006-2010 Lars Windolf <lars.windolf@gmx.de>
@@ -26,58 +26,68 @@
 #include "item.h"
 
 typedef struct socialSite {
-	gchar		*name;		/**< Descriptive name for HTML rendering and preferences */
-	gchar		*url;		/**< URL format string with %s for title and URL insertion */
-	gboolean	title;		/**< TRUE if title submission supported */
-	gboolean	titleFirst;	/**< TRUE if title %s comes first */
+	gchar		*name;		/*<< Descriptive name for HTML rendering and preferences */
+	gchar		*url;		/*<< URL format string with %s for title and URL insertion */
+	gboolean	title;		/*<< TRUE if title submission supported */
+	gboolean	titleFirst;	/*<< TRUE if title %s comes first */
 } *socialSitePtr;
 
 /**
+ * social_init: (skip)
+ *
  * Initialize social bookmarking support.
  */
 void social_init (void);
 
 /**
+ * social_free: (skip)
+ *
  * Frees social bookmarking structures
  */
 void social_free (void);
 
 /**
- * Change the site used for bookmarking.
+ * social_set_bookmark_site:
+ * @name:		name of the site
  *
- * @param name		name of the site
+ * Change the site used for bookmarking.
  */
 void social_set_bookmark_site (const gchar *name);
 
 /**
- * Add a new site to the social bookmarking site list.
+ * social_register_bookmark_site:
+ * @name:		descriptive name
+ * @url:		valid HTTP GET URL with one or two %s format codes
+ * @title:		TRUE if site accepts titles (URL must have two %s format codes!)
+ * @titleFirst: 	TRUE if title is first format code (title must be TRUE)
  *
- * @param name		descriptive name
- * @param url		valid HTTP GET URL with one or two %s format codes
- * @param title		TRUE if site accepts titles (URL must have two %s format codes!)
- * @param titleFirst	TRUE if title is first format code (title must be TRUE)
+ * Add a new site to the social bookmarking site list.
  */
 void social_register_bookmark_site (const gchar *name, const gchar *url, gboolean title, gboolean titleFirst);
 
 /**
+ * social_get_bookmark_url:
+ * @link:		the link to encode (mandatory)
+ * @title:		the title to encode (mandatory)
+ *
  * Returns a social bookmarking link for the configured site
  *
- * @param link		the link to encode (mandatory)
- * @param title		the title to encode (mandatory)
- *
- * @returns new URL string
+ * Returns: new URL string
  */
 gchar * social_get_bookmark_url (const gchar *link, const gchar *title);
 
 /**
- * Add a social bookmark for the link of the given item
+ * social_add_bookmark: (skip)
+ * @item:		the item
  *
- * @param item		the item
+ * Add a social bookmark for the link of the given item
  */
 void social_add_bookmark (const itemPtr item);
 
 /**
- * Returns the name of the currently configured social bookmarking site.
+ * social_get_bookmark_site:
+ *
+ * Returns: the name of the currently configured social bookmarking site.
  */
 const gchar * social_get_bookmark_site (void);
 

--- a/src/subscription_type.h
+++ b/src/subscription_type.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file subscription_type.h  subscription type interface
  * 
  * Copyright (C) 2008 Lars Windolf <lars.windolf@gmx.de>
@@ -24,18 +24,18 @@
 
 #include "subscription.h"
 
-/**
+/*
  * Liferea supports different types of subscriptions that differ
  * in their updating behaviour and update state.
  */
 
-/** subscription type interface */
+/* subscription type interface */
 typedef struct subscriptionType {
 
 	/* Note: the default implementation of this interface is
 	   provided by feed.c */
 
-	/**
+	/*
 	 * Preparation callback for a update type. Allows a specific
 	 * subscription type implementation to make changes to the
 	 * already created update request (e.g. URI adaptions or
@@ -52,7 +52,7 @@ typedef struct subscriptionType {
 	 */
 	gboolean (*prepare_update_request)(subscriptionPtr subscription, struct updateRequest * request);
 	
-	/**
+	/*
 	 * Subscription type specific update result processing callback.
 	 *
 	 * @param subscription	the subscription that was updated

--- a/src/ui/browser_tabs.c
+++ b/src/ui/browser_tabs.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file browser_tabs.c  internal browsing using multiple tabs
  *
  * Copyright (C) 2004-2012 Lars Windolf <lars.windolf@gmx.de>
@@ -115,9 +115,9 @@ enum {
 struct BrowserTabsPrivate {
 	GtkNotebook	*notebook;
 
-	GtkWidget	*headlines;	/**< widget of the headlines tab */
+	GtkWidget	*headlines;	/*<< widget of the headlines tab */
 	
-	GSList		*list;		/**< tabInfo structures for all tabs */
+	GSList		*list;		/*<< tabInfo structures for all tabs */
 };
 
 static GObjectClass *parent_class = NULL;
@@ -125,7 +125,7 @@ static BrowserTabs *tabs = NULL;
 
 G_DEFINE_TYPE (BrowserTabs, browser_tabs, G_TYPE_OBJECT);
 
-/** Removes tab info structure */
+/* Removes tab info structure */
 static void
 browser_tabs_remove_tab (tabInfo *tab)
 {
@@ -283,7 +283,7 @@ on_htmlview_close_tab (gpointer object, gpointer user_data)
 	browser_tabs_close_tab((tabInfo *)user_data);
 }
 
-/** Close tab and removes tab info structure */
+/* Close tab and removes tab info structure */
 static void
 browser_tabs_close_tab (tabInfo *tab)
 {	

--- a/src/ui/browser_tabs.h
+++ b/src/ui/browser_tabs.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file browser_tabs.h  internal browsing using multiple tabs
  *
  * Copyright (C) 2004-2008 Lars Windolf <lars.windolf@gmx.de>
@@ -56,50 +56,58 @@ struct BrowserTabsClass
 GType browser_tabs_get_type (void);
 
 /**
- * Returns the singleton browser tabs instance.
+ * browser_tabs_create: (skip)
+ * @notebook:	GtkNotebook widget to use
  *
- * @param notebook	GtkNotebook widget to use
+ * Returns: the singleton browser tabs instance.
+ *
  */
 BrowserTabs * browser_tabs_create (GtkNotebook *notebook);
 
 /**
+ * browser_tabs_add_new:
+ * @url:	URL to be loaded in new tab (can be NULL to do nothing)
+ * @title:	title of the tab to be created
+ * @activate:   Should the new tab be put in the foreground?
+ *
  * Adds a new tab with the specified URL and title.
  *
- * @param url	URL to be loaded in new tab (can be NULL to do nothing)
- * @param title	title of the tab to be created
- * @param activate Should the new tab be put in the foreground?
- *
- * @returns the newly created HTML view
+ * Returns: the newly created HTML view
  */
 LifereaHtmlView * browser_tabs_add_new (const gchar *url, const gchar *title, gboolean activate);
 
 /**
+ * browser_tabs_show_headlines:
+ *
  * makes the headline tab visible 
  */
 void browser_tabs_show_headlines (void);
 
 /**
+ * browser_tabs_get_active_htmlview:
+ *
  * Used to determine which HTML view (a tab or the headlines view)
  * is currently visible and can be used to display HTML that
  * is to be loaded
  *
- * @returns HTML view widget
+ * Returns: (transfer none) (nullable): HTML view widget
  */
 LifereaHtmlView * browser_tabs_get_active_htmlview (void);
 
 /**
- * Requests the tab to change zoom level.
+ * browser_tabs_do_zoom:
+ * @in:	TRUE if zooming in, FALSE for zooming out
  *
- * @param in	TRUE if zooming in, FALSE for zooming out
+ * Requests the tab to change zoom level.
  */
 void browser_tabs_do_zoom (gboolean in);
 
-/** All widget elements and state of a tab */
+/* All widget elements and state of a tab */
 typedef struct _tabInfo tabInfo;
 struct _tabInfo {
-	GtkWidget	*label;		/**< the tab label */
-	GtkWidget	*widget;	/**< the embedded child widget */
-	LifereaHtmlView	*htmlview;	/**< the tabs HTML view widget */
+	GtkWidget	*label;		/*<< the tab label */
+	GtkWidget	*widget;	/*<< the embedded child widget */
+	LifereaHtmlView	*htmlview;	/*<< the tabs HTML view widget */
 };
 
 G_END_DECLS

--- a/src/ui/icons.c
+++ b/src/ui/icons.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file icons.c  Using icons from theme and package pixmaps
  *
  * Copyright (C) 2010-2014 Lars Windolf <lars.windolf@gmx.de>
@@ -26,7 +26,7 @@
 
 #include "common.h"
 
-static GdkPixbuf *icons[MAX_ICONS];	/**< list of icon assignments */
+static GdkPixbuf *icons[MAX_ICONS];	/*<< list of icon assignments */
 
 static gchar *
 icon_find_pixmap_file (const gchar *filename)

--- a/src/ui/icons.h
+++ b/src/ui/icons.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file icons.h  Using icons from theme and package pixmaps
  *
  * Copyright (C) 2010-2013 Lars Windolf <lars.windolf@gmx.de>
@@ -43,6 +43,8 @@ typedef enum {
 } lifereaIcon;
 
 /**
+ * icons_load: (skip)
+ *
  * Load all icons from theme and Liferea pixmaps.
  *
  * Must be called once before icon_get() may be used!
@@ -52,9 +54,9 @@ void icons_load (void);
 
 /**
  * icon_get:
- * Returns a GdkPixbuf for the requested item.
+ * @icon:	the icon
  *
- * @param icon	the icon
+ * Returns a GdkPixbuf for the requested item.
  *
  * Returns: (transfer none): GdkPixbuf
  */
@@ -62,11 +64,11 @@ const GdkPixbuf * icon_get (lifereaIcon icon);
 
 /**
  * icon_create_from_file:
+ * @file name:	the name of the file
+ *
  * Takes a file name relative to "pixmaps" directory and tries to load the 
  * image into a GdkPixbuf. Can be used to load icons not in lifereaIcon
  * on demand.
- *
- * @param file name	the name of the file
  *
  * Returns: (transfer none): a new pixbuf or NULL
  */

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -1,4 +1,4 @@
-/**
+/*
  * @file item_list_view.c  presenting items in a GtkTreeView
  *  
  * Copyright (C) 2004-2015 Lars Windolf <lars.windolf@gmx.de>
@@ -46,7 +46,7 @@
 #include "ui/popup_menu.h"
 #include "ui/ui_common.h"
 
-/**
+/*
  * Important performance considerations: Early versions had performance problems
  * with the item list loading because of the following two problems:
  *
@@ -58,22 +58,22 @@
  * collections of feeds only by adding items to a new unattached tree store.
  */
 
-/** Enumeration of the columns in the itemstore. */
+/* Enumeration of the columns in the itemstore. */
 enum is_columns {
-	IS_TIME,		/**< Time of item creation */
-	IS_TIME_STR,		/**< Time of item creation as a string*/
-	IS_LABEL,		/**< Displayed name */
-	IS_STATEICON,		/**< Pixbuf reference to the item's state icon */
-	IS_NR,			/**< Item id, to lookup item ptr from parent feed */
-	IS_PARENT,		/**< Parent node pointer */
-	IS_FAVICON,		/**< Pixbuf reference to the item's feed's icon */
-	IS_ENCICON,		/**< Pixbuf reference to the item's enclosure icon */
-	IS_ENCLOSURE,		/**< Flag whether enclosure is attached or not */
-	IS_SOURCE,		/**< Source node pointer */
-	IS_STATE,		/**< Original item state (unread, flagged...) for sorting */
-	ITEMSTORE_WEIGHT,		/**< Flag whether weight is to be bold and "unread" icon is to be shown */
-	ITEMSTORE_ALIGN,        /**< How to align title (RTL support) */
-	ITEMSTORE_LEN		/**< Number of columns in the itemstore */
+	IS_TIME,		/*<< Time of item creation */
+	IS_TIME_STR,		/*<< Time of item creation as a string*/
+	IS_LABEL,		/*<< Displayed name */
+	IS_STATEICON,		/*<< Pixbuf reference to the item's state icon */
+	IS_NR,			/*<< Item id, to lookup item ptr from parent feed */
+	IS_PARENT,		/*<< Parent node pointer */
+	IS_FAVICON,		/*<< Pixbuf reference to the item's feed's icon */
+	IS_ENCICON,		/*<< Pixbuf reference to the item's enclosure icon */
+	IS_ENCLOSURE,		/*<< Flag whether enclosure is attached or not */
+	IS_SOURCE,		/*<< Source node pointer */
+	IS_STATE,		/*<< Original item state (unread, flagged...) for sorting */
+	ITEMSTORE_WEIGHT,		/*<< Flag whether weight is to be bold and "unread" icon is to be shown */
+	ITEMSTORE_ALIGN,        /*<< How to align title (RTL support) */
+	ITEMSTORE_LEN		/*<< Number of columns in the itemstore */
 };
 
 typedef enum {
@@ -124,16 +124,16 @@ launch_item_selected (open_link_target_type open_link_target)
 struct ItemListViewPrivate {
 	GtkTreeView	*treeview;
 	
-	GSList		*item_ids;		/**< list of all currently known item ids */
+	GSList		*item_ids;		/*<< list of all currently known item ids */
 
-	gboolean	batch_mode;		/**< TRUE if we are in batch adding mode */
-	GtkTreeStore	*batch_itemstore;	/**< GtkTreeStore prepared unattached and to be set on update() */
+	gboolean	batch_mode;		/*<< TRUE if we are in batch adding mode */
+	GtkTreeStore	*batch_itemstore;	/*<< GtkTreeStore prepared unattached and to be set on update() */
 
 	GtkTreeViewColumn	*enclosureColumn;
 	GtkTreeViewColumn	*faviconColumn;
 	GtkTreeViewColumn	*stateColumn;
 
-	gboolean	wideView;		/**< TRUE if date has to be rendered into headline column (because date column is invisible) */
+	gboolean	wideView;		/*<< TRUE if date has to be rendered into headline column (because date column is invisible) */
 };
 
 static GObjectClass *parent_class = NULL;
@@ -280,7 +280,7 @@ item_list_view_set_sort_column (ItemListView *ilv, nodeViewSortType sortType, gb
 	                                      sortReversed?GTK_SORT_DESCENDING:GTK_SORT_ASCENDING);
 }
 
-/**
+/*
  * Creates a GtkTreeStore to be filled with ui_itemlist_set_items
  * and to be set with ui_itemlist_set_tree_store().
  */
@@ -355,7 +355,7 @@ itemlist_sort_column_changed_cb (GtkTreeSortable *treesortable, gpointer user_da
 		feedlist_schedule_save ();
 }
 
-/**
+/*
  * Sets a GtkTreeView to the active GtkTreeView.
  */
 static void

--- a/src/ui/item_list_view.h
+++ b/src/ui/item_list_view.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file item_list_view.h  presenting items in a GtkTreeView
  *
  * Copyright (C) 2004-2015 Lars Windolf <lars.windolf@gmx.de>
@@ -62,13 +62,12 @@ struct ItemListViewClass
 GType item_list_view_get_type (void);
 
 /**
- * item_list_view_create:
+ * item_list_view_create: (skip)
+ * @wide:	TRUE if ItemListView should be optimized for wide view(itemview->priv->currentLayoutMode == NODE_VIEW_MODE_WIDE)
  *
  * Create a new ItemListView instance.
  *
- * @wide:	TRUE if ItemListView should be optimized for wide view(itemview->priv->currentLayoutMode == NODE_VIEW_MODE_WIDE)
- *
- * @returns: (transfer none):	the ItemListView instance
+ * Returns: (transfer none):	the ItemListView instance
  */
 ItemListView * item_list_view_create (gboolean wide);
 
@@ -77,132 +76,142 @@ ItemListView * item_list_view_create (gboolean wide);
  *
  * Returns the GtkTreeView used by the ItemListView instance.
  *
- * @returns: (transfer none): a GtkTreeView
+ * Returns: (transfer none): a GtkTreeView
  */
 GtkTreeView * item_list_view_get_widget (ItemListView *ilv);
 
 /**
+ * item_list_view_contains_id:
+ * @ilv:	the ItemListView
+ * @id: 	the item id
+ *
  * Checks whether the given id is in the ItemListView.
  *
- * @param ilv	the ItemListView
- * @param id	the item id
- *
- * @returns TRUE if the item is in the ItemListView
+ * Returns: TRUE if the item is in the ItemListView
  */
 gboolean item_list_view_contains_id (ItemListView *ilv, gulong id);
 
 /**
- * Changes the sorting type (and direction).
+ * item_list_view_set_sort_column:
+ * @ilv:		the ItemListView
+ * @sortType:   	new sort type
+ * @sortReversed:	TRUE for ascending order
  *
- * @param ilv		the ItemListView
- * @param sortType	new sort type
- * @param sortReversed	TRUE for ascending order
+ * Changes the sorting type (and direction).
  */
 void item_list_view_set_sort_column (ItemListView *ilv, nodeViewSortType sortType, gboolean sortReversed);
 
 /**
- * Selects the given item (if it is in the ItemListView).
+ * item_list_view_select: (skip)
+ * @ilv:	the ItemListView
+ * @item:	the item to select
  *
- * @param ilv	the ItemListView
- * @param item	the item to select
+ * Selects the given item (if it is in the ItemListView).
  */
 void item_list_view_select (ItemListView *ilv, itemPtr item);
 
 /**
+ * item_list_view_add_item: (skip)
+ * @ilv:	the ItemListView
+ * @item:	the item to add
+ *
  * Add an item to an ItemListView. This method is expensive and
  * is to be used only for new items that need to be inserted
  * by background updates.
- *
- * @param ilv	the ItemListView
- * @param item	the item to add
  */
 void item_list_view_add_item (ItemListView *ilv, itemPtr item);
 
 /**
+ * item_list_view_remove_item: (skip)
+ * @ilv:	the ItemListView
+ * @item:	the item to remove
+ *
  * Remove an item from an ItemListView. This method is expensive
  * and is to be used only for items removed by background updates
  * (usually cache drops).
- *
- * @param ilv	the ItemListView
- * @param item	the item to remove
  */
 void item_list_view_remove_item (ItemListView *ilv, itemPtr item);
 
 /**
- * Enable the favicon column of the currently displayed itemlist.
+ * item_list_view_enable_favicon:
+ * @ilv:		the ItemListView
+ * @enabled:    	TRUE if column is to be visible
  *
- * @param ilv		the ItemListView
- * @param enabled	TRUE if column is to be visible
+ * Enable the favicon column of the currently displayed itemlist.
  */
 void item_list_view_enable_favicon_column (ItemListView *ilv, gboolean enabled);
 
 /**
- * Remove all items and resets a ItemListView.
+ * item_list_view_clear: (skip)
+ * @ilv:	the ItemListView
  *
- * @param ilv	the ItemListView
+ * Remove all items and resets a ItemListView.
  */
 void item_list_view_clear (ItemListView *ilv);
 
 /**
+ * item_list_view_update: (skip)
+ * @ilv:	        the ItemListView
+ * @hasEnclosures:	TRUE if at least one item has an enclosure
+ *
  * Update the ItemListView with the newly added items. To be called
  * after doing a batch of item_list_view_add_item() calls.
- *
- * @param ilv	the ItemListView
- * @param hasEnclosures	TRUE if at least one item has an enclosure
  */
 void item_list_view_update (ItemListView *ilv, gboolean hasEnclosures);
 
 /* menu callbacks */
 
-/**
+/*
  * Toggles the unread status of the selected item. This is called from
  * a menu.
  */
 void on_toggle_unread_status (GtkMenuItem *menuitem, gpointer user_data);
 
-/**
+/*
  * Toggles the flag of the selected item. This is called from a menu.
  */
 void on_toggle_item_flag (GtkMenuItem *menuitem, gpointer user_data);
 
-/**
+/*
  * Opens the selected item in a browser.
  */
 void on_popup_launch_item_selected (void);
 
-/**
+/*
  * Opens the selected item in a browser.
  */
 void on_popup_launch_item_in_tab_selected (void);
 
-/**
+/*
  * Opens the selected item in a browser.
  */
 void on_popup_launch_item_external_selected (void);
 
-/**
+/*
  * Toggles the read status of right-clicked item.
  */
 void on_popup_toggle_read (void);
 
-/**
+/*
  * Toggles the flag of right-clicked item.
  */
 void on_popup_toggle_flag (void);
 
 /**
- * Removes all items from the selected feed.
+ * on_remove_items_activate: (skip)
+ * @menuitem: The menuitem that was selected.
+ * @user_data: Unused.
  *
- * @param menuitem The menuitem that was selected.
- * @param user_data Unused.
+ * Removes all items from the selected feed.
  */
 void on_remove_items_activate (GtkMenuItem *menuitem, gpointer user_data);
 
 /**
- * Removes the selected item from the selected feed.
+ * on_remove_item_activate: (skip)
+ * @menuitem: The menuitem that was selected.
+ * @user_data: Unused.
  *
- * @param menuitem The menuitem that was selected.
- * @param user_data Unused.
+ * Removes the selected item from the selected feed.
  */  
 void on_remove_item_activate (GtkMenuItem *menuitem, gpointer user_data);
 
@@ -210,43 +219,47 @@ void on_popup_remove_selected (void);
 
 /**
  * item_list_view_find_unread_item: (skip)
+ * @ilv:		the ItemListView
+ * @startId:		0 or the item id to start from
  *
  * Finds and selects the next unread item starting at the given
  * item in a ItemListView according to the current GtkTreeView sorting order.
  *
- * @ilv:		the ItemListView
- * @startId:		0 or the item id to start from
- *
- * Returns: unread item (or NULL)
+ * Returns: (nullable): unread item (or NULL)
  */
 itemPtr item_list_view_find_unread_item (ItemListView *ilv, gulong startId);
 
 /**
+ * on_next_unread_item_activate: (skip)
+ * @menuitem: The menuitem that was selected.
+ * @user_data: Unused.
+ *
  * Searches the displayed feed and then all feeds for an unread
  * item. If one it found, it is displayed.
- *
- * @param menuitem The menuitem that was selected.
- * @param user_data Unused.
  */
 void on_next_unread_item_activate (GtkMenuItem *menuitem, gpointer user_data);
 
 /**
- * Update a single item of a ItemListView
+ * item_list_view_update_item: (skip)
+ * @ilv:	the ItemListView
+ * @item:	the item
  *
- * @param ilv	the ItemListView
- * @param item	the item
+ * Update a single item of a ItemListView
  */
 void item_list_view_update_item (ItemListView *ilv, itemPtr item);
 
 /**
+ * item_list_view_update_all_items: (skip)
+ * @ilv:	the ItemListView
+ *
  * Update all items of the ItemListView. To be used after 
  * initial batch loading.
- *
- * @param ilv	the ItemListView
  */
 void item_list_view_update_all_items (ItemListView *ilv);
 
 /**
+ * on_popup_copy_URL_clipboard: (skip)
+ *
  * Copies the selected items URL to the clipboard.
  */
 void on_popup_copy_URL_clipboard (void);

--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -46,24 +46,24 @@
 #define ITEMVIEW_GET_PRIVATE(object)(G_TYPE_INSTANCE_GET_PRIVATE ((object), ITEMVIEW_TYPE, ItemViewPrivate))
 
 struct ItemViewPrivate {
-	gboolean	htmlOnly;		/**< TRUE if HTML only mode */
-	guint		mode;			/**< current item view mode */
-	nodePtr		node;			/**< the node whose items are displayed */
-	gboolean	browsing;		/**< TRUE if itemview is used as internal browser right now */
-	gboolean	needsHTMLViewUpdate;	/**< flag to be set when HTML rendering is to be 
+	gboolean	htmlOnly;		/*<< TRUE if HTML only mode */
+	guint		mode;			/*<< current item view mode */
+	nodePtr		node;			/*<< the node whose items are displayed */
+	gboolean	browsing;		/*<< TRUE if itemview is used as internal browser right now */
+	gboolean	needsHTMLViewUpdate;	/*<< flag to be set when HTML rendering is to be
 						     updated, used to delay HTML updates */
-	gboolean	hasEnclosures;		/**< TRUE if at least one item of the current itemset has an enclosure */
+	gboolean	hasEnclosures;		/*<< TRUE if at least one item of the current itemset has an enclosure */
 						     
-	nodeViewType	viewMode;		/**< current viewing mode */
-	guint		currentLayoutMode;	/**< layout mode (3 pane, 2 pane, wide view) */
+	nodeViewType	viewMode;		/*<< current viewing mode */
+	guint		currentLayoutMode;	/*<< layout mode (3 pane, 2 pane, wide view) */
 								     
-	GtkWidget	*itemListViewContainer;	/**< scrolled window holding item list tree view */
-	ItemListView	*itemListView;		/**< widget instance used to present items in list mode */
+	GtkWidget	*itemListViewContainer;	/*<< scrolled window holding item list tree view */
+	ItemListView	*itemListView;		/*<< widget instance used to present items in list mode */
 
-	EnclosureListView	*enclosureView;	/**< Enclosure list widget */
-	LifereaHtmlView		*htmlview;	/**< HTML rendering widget instance used to render single items and summaries mode */
+	EnclosureListView	*enclosureView;	/*<< Enclosure list widget */
+	LifereaHtmlView		*htmlview;	/*<< HTML rendering widget instance used to render single items and summaries mode */
 
-	gfloat			zoom;		/**< HTML rendering widget zoom level */
+	gfloat			zoom;		/*<< HTML rendering widget zoom level */
 };
 
 enum {

--- a/src/ui/itemview.h
+++ b/src/ui/itemview.h
@@ -67,67 +67,62 @@ struct ItemViewClass
 GType itemview_get_type (void);
 
 /** 
- * itemview_clear:
+ * itemview_clear: (skip)
  *
  * Removes all currently loaded items from the item view.
  */
 void itemview_clear (void);
     
 /**
- * itemview_set_displayed_node:
+ * itemview_set_displayed_node: (skip)
+ * @node:	the node whose items are to be presented
  *
  * Prepares the view for displaying items of the given node.
- *
- * @param node	the node whose items are to be presented
  */
 void itemview_set_displayed_node (nodePtr node);
 
-/** item view display mode type */
+/* item view display mode type */
 typedef enum {
-	ITEMVIEW_SINGLE_ITEM,	/**< 3 panes, item view shows the selected item only in HTML view */
-	ITEMVIEW_ALL_ITEMS,	/**< 2 panes, item view shows all items combined in HTML view */
-	ITEMVIEW_NODE_INFO	/**< 3 panes, item view shows the selected node description in HTML view*/
+	ITEMVIEW_SINGLE_ITEM,	/*<< 3 panes, item view shows the selected item only in HTML view */
+	ITEMVIEW_ALL_ITEMS,	/*<< 2 panes, item view shows all items combined in HTML view */
+	ITEMVIEW_NODE_INFO	/*<< 3 panes, item view shows the selected node description in HTML view*/
 } itemViewMode;
 
 /**
  * itemview_set_mode:
+ * @mode:		item view mode constant
  *
  * Set/unset the display mode of the item view.
- *
- * @param mode		item view mode constant
  */
 void itemview_set_mode (itemViewMode mode);
 
 /**
- * itemview_add_item:
+ * itemview_add_item: (skip)
+ * @item:		the item to add
  *
  * Adds an item to the view for rendering. The item must belong
  * to the item set that was announced with itemview_set_displayed_node().
- *
- * @param item		the item to add
  *
  * TODO: use item merger signal instead
  */
 void itemview_add_item (itemPtr item);
 
 /**
- * itemview_remove_item:
+ * itemview_remove_item: (skip)
+ * @item:	the item to remove
  *
  * Removes a given item from the view.
- *
- * @param item	the item to remove
  *
  * TODO: use item merger signal instead
  */
 void itemview_remove_item (itemPtr item);
 
 /**
- * itemview_select_item:
+ * itemview_select_item: (skip)
+ * @item: the item to select
  *
  * Selects a given item in the view. The item must be
  * added using itemview_add_item before selecting.
- *
- * @item: the item to select
  */
 void itemview_select_item (itemPtr item);
 
@@ -140,11 +135,10 @@ void itemview_select_item (itemPtr item);
 void itemview_select_enclosure (guint position);
 
 /**
- * itemview_update_item:
+ * itemview_update_item: (skip)
+ * @item:	the item to update
  *
  * Requests updating the rendering of a given item.
- *
- * @item:	the item to update
  */
 void itemview_update_item (itemPtr item);
 
@@ -156,18 +150,17 @@ void itemview_update_item (itemPtr item);
 void itemview_update_all_items (void);
 
 /**
- * itemview_update_node_info:
+ * itemview_update_node_info: (skip)
+ * @node:	the node whose info view is to be updated
  *
  * Requests updating the rendering of the node info view.
- *
- * @node:	the node whose info view is to be updated
  *
  * TODO: register for signal at feed merger instead
  */
 void itemview_update_node_info (struct node *node);
 
 /**
- * itemview_update:
+ * itemview_update: (skip)
  *
  * Refreshes the item view. Needs to be called after each
  * add, remove or update of one or more items.
@@ -178,20 +171,18 @@ void itemview_update (void);
 
 /**
  * itemview_display_info:
+ * @html:	HTML to present
  *
  * Sets an info display in the item view HTML widget.
  * Used for special functionality like search result info.
- *
- * @html:	HTML to present
  */
 void itemview_display_info (const gchar *html);
 
 /**
  * itemview_find_unread_item: (skip)
+ * @startId:	the item id to start at (or NULL for starting at the top)
  *
  * Finds the next unread item.
- *
- * @startId:	the item id to start at (or NULL for starting at the top)
  *
  * Returns: (transfer none): the item found (or NULL)
  */
@@ -207,11 +198,10 @@ void itemview_scroll (void);
 
 /**
  * itemview_move_cursor:
+ * @step:	moving steps
  *
  * Moves the cursor in the item list step times.
  * Negative value means moving backwards.
- * 
- * @step:	moving steps
  */
 void itemview_move_cursor (int step);
 
@@ -224,15 +214,14 @@ void itemview_move_cursor_to_first (void);
 
 /**
  * itemview_set_layout:
+ * @newMode:	new view mode (NODE_VIEW_MODE_*)
  *
  * Switches the layout for the given viewing mode.
- *
- * @newMode:	new view mode (NODE_VIEW_MODE_*)
  */
 void itemview_set_layout (nodeViewType newMode);
 
 /**
- * itemview_create:
+ * itemview_create: (skip)
  * @window:		parent window widget
  *
  * Creates the item view singleton instance.
@@ -243,20 +232,19 @@ ItemView * itemview_create (GtkWidget *window);
 
 /**
  * itemview_launch_URL:
+ * @url:	        the link to load
+ * @internal:	TRUE if internal browsing is to be enforced
  *
  * Launch the given URL in the currently active HTML view.
  *
- * @param url		the link to load
- * @param forceInternal	TRUE if internal browsing is to be enforced
  */
 void itemview_launch_URL (const gchar *url, gboolean internal);
 
 /**
  * itemview_do_zoom:
+ * @in:	TRUE if zooming in, FALSE for zooming out
  *
  * Requests the item view to change zoom level.
- *
- * @param in	TRUE if zooming in, FALSE for zooming out
  */
 void itemview_do_zoom (gboolean in);
 

--- a/src/ui/liferea_htmlview.h
+++ b/src/ui/liferea_htmlview.h
@@ -53,7 +53,7 @@ struct LifereaHtmlViewClass
 GType liferea_htmlview_get_type	(void);
 
 /** 
- * liferea_htmlview_new:
+ * liferea_htmlview_new: (skip)
  * @forceInternalBrowsing:		TRUE to act as fully fledged browser
  *
  * Function to set up a new html view widget for any purpose. 
@@ -72,7 +72,7 @@ LifereaHtmlView * liferea_htmlview_new (gboolean forceInternalBrowsing);
 void liferea_htmlview_set_headline_view (LifereaHtmlView *htmlview);
 
 /**
- * liferea_htmlview_get_widget:
+ * liferea_htmlview_get_widget: (skip)
  * @htmlview:	the HTML view
  *
  * Returns the rendering widget for a HTML view. Only
@@ -83,7 +83,7 @@ void liferea_htmlview_set_headline_view (LifereaHtmlView *htmlview);
 GtkWidget *liferea_htmlview_get_widget (LifereaHtmlView *htmlview);
 
 /** 
- * liferea_htmlview_clear:
+ * liferea_htmlview_clear: (skip)
  * @htmlview:	the HTML view widget to clear
  *
  * Loads a emtpy HTML page. Resets any item view state.
@@ -91,7 +91,7 @@ GtkWidget *liferea_htmlview_get_widget (LifereaHtmlView *htmlview);
 void	liferea_htmlview_clear (LifereaHtmlView *htmlview);
 
 /**
- * liferea_htmlview_write:
+ * liferea_htmlview_write: (skip)
  * @htmlview:	The htmlview widget to be set
  * @string:		HTML source
  * @base:		base url for resolving relative links
@@ -101,7 +101,7 @@ void	liferea_htmlview_clear (LifereaHtmlView *htmlview);
 void	liferea_htmlview_write (LifereaHtmlView *htmlview, const gchar *string, const gchar *base);
 
 /**
- * liferea_html_view_on_url:
+ * liferea_html_view_on_url: (skip)
  * @htmlview:		the htmlview causing the event
  * @url:		new URL (or empty string)
  *
@@ -115,7 +115,7 @@ void liferea_htmlview_title_changed (LifereaHtmlView *htmlview, const gchar *tit
 void liferea_htmlview_location_changed (LifereaHtmlView *htmlview, const gchar *location);
 
 /**
- * liferea_htmlview_handle_URL:
+ * liferea_htmlview_handle_URL: (skip)
  * @htmlview:		the HTML view to use
  * @url:		URL to launch
  *
@@ -138,7 +138,7 @@ void liferea_htmlview_location_changed (LifereaHtmlView *htmlview, const gchar *
 gboolean liferea_htmlview_handle_URL (LifereaHtmlView *htmlview, const gchar *url);
 
 /**
- * liferea_htmlview_launch_URL_internal:
+ * liferea_htmlview_launch_URL_internal: (skip)
  * @htmlview:		the HTML view to use
  * @url:		the URL to load
  *

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -63,31 +63,31 @@ extern gboolean searchFolderRebuild; /* db.c */
 struct LifereaShellPrivate {
 	GtkBuilder	*xml;
 
-	GtkWindow	*window;		/**< Liferea main window */
+	GtkWindow	*window;		/*<< Liferea main window */
 	GtkWidget	*menubar;
 	GtkWidget	*toolbar;
 	GtkTreeView	*feedlistView;
 	
-	GtkStatusbar	*statusbar;		/**< main window status bar */
-	gboolean	statusbarLocked;	/**< flag locking important message on status bar */
-	guint		statusbarLockTimer;	/**< timer id for status bar lock reset timer */
+	GtkStatusbar	*statusbar;		/*<< main window status bar */
+	gboolean	statusbarLocked;	/*<< flag locking important message on status bar */
+	guint		statusbarLockTimer;	/*<< timer id for status bar lock reset timer */
 
 	GtkWidget	*statusbar_feedsinfo;
 	GtkWidget	*statusbar_feedsinfo_evbox;
 	GtkActionGroup	*generalActions;
-	GtkActionGroup	*addActions;		/**< all types of "New" options */
-	GtkActionGroup	*feedActions;		/**< update and mark read */
-	GtkActionGroup	*readWriteActions;	/**< node remove and properties, node itemset items remove */
-	GtkActionGroup	*itemActions;		/**< item state toggline, single item remove */
+	GtkActionGroup	*addActions;		/*<< all types of "New" options */
+	GtkActionGroup	*feedActions;		/*<< update and mark read */
+	GtkActionGroup	*readWriteActions;	/*<< node remove and properties, node itemset items remove */
+	GtkActionGroup	*itemActions;		/*<< item state toggline, single item remove */
 
 	ItemList	*itemlist;	
 	FeedList	*feedlist;
 	ItemView	*itemview;
 	BrowserTabs	*tabs;
 
-	PeasExtensionSet *extensions;		/**< Plugin management */
+	PeasExtensionSet *extensions;		/*<< Plugin management */
 
-	gboolean	fullscreen;		/**< track fullscreen */
+	gboolean	fullscreen;		/*<< track fullscreen */
 };
 
 enum {

--- a/src/ui/liferea_shell.h
+++ b/src/ui/liferea_shell.h
@@ -29,12 +29,12 @@
 
 #include "node.h"
 
-/** possible main window states */
+/* possible main window states */
 enum mainwindowState {
-	MAINWINDOW_SHOWN,	/**< main window is visible */
-	MAINWINDOW_MAXIMIZED,	/**< main window is visible and maximized */
-	MAINWINDOW_ICONIFIED,	/**< main window is iconified */
-	MAINWINDOW_HIDDEN	/**< main window is not visible at all */
+	MAINWINDOW_SHOWN,	/*<< main window is visible */
+	MAINWINDOW_MAXIMIZED,	/*<< main window is visible and maximized */
+	MAINWINDOW_ICONIFIED,	/*<< main window is iconified */
+	MAINWINDOW_HIDDEN	/*<< main window is not visible at all */
 };
 
 G_BEGIN_DECLS
@@ -73,22 +73,21 @@ GType liferea_shell_get_type	(void);
  * Searches the glade XML UI tree for the given widget
  * name and returns the found widget.
  *
- * Returns: (transfer none): the widget found or NULL
+ * Returns: (transfer none) (nullable): the widget found or NULL
  */
 GtkWidget * liferea_shell_lookup (const gchar *name);
 
 /**
- * liferea_shell_create:
+ * liferea_shell_create: (skip)
+ * @app:	                the GtkApplication to attach the main window to
+ * @overrideWindowState:	optional parameter for window state (or NULL)
  *
  * Set up the Liferea main window.
- *
- * @param app	the GtkApplication to attach the main window to
- * @param overrideWindowState	optional parameter for window state (or NULL)
  */
 void liferea_shell_create (GtkApplication *app, const gchar *overrideWindowState);
 
 /**
- * liferea_shell_destroy:
+ * liferea_shell_destroy: (skip)
  *
  * Destroys the global liferea_shell object.
  */
@@ -110,15 +109,14 @@ void liferea_shell_toggle_visibility (void);
 
 /**
  * liferea_shell_set_toolbar_style:
+ * @toolbar_style: text string containing the type of style to use
  *
  * Sets the toolbar to a particular style
- *
- * @param toolbar_style text string containing the type of style to use
  */
 void liferea_shell_set_toolbar_style (const gchar *toolbar_style);
 
 /**
- * liferea_shell_update_toolbar:
+ * liferea_shell_update_toolbar: (skip)
  *
  * According to the preferences this function enables/disables the toolbar.
  *
@@ -127,7 +125,7 @@ void liferea_shell_set_toolbar_style (const gchar *toolbar_style);
 void liferea_shell_update_toolbar (void);
 
 /**
- * liferea_shell_update_history_actions:
+ * liferea_shell_update_history_actions: (skip)
  *
  * Update item history menu actions and toolbar buttons.
  *
@@ -136,47 +134,43 @@ void liferea_shell_update_toolbar (void);
 void liferea_shell_update_history_actions (void);
 
 /**
- * liferea_shell_update_feed_menu:
+ * liferea_shell_update_feed_menu: (skip)
+ * @add:                TRUE if subscribing is to be enabled
+ * @enabled:    	TRUE if feed actions are to be enabled
+ * @readWrite:  	TRUE if feed list modifying actions are enabled
  *
  * Update the sensitivity of options affecting single feeds.
- *
- * @param add           TRUE if subscribing is to be enabled
- * @param enabled	TRUE if feed actions are to be enabled
- * @param readWrite	TRUE if feed list modifying actions are enabled
  *
  * TODO: use signal instead
  */
 void liferea_shell_update_feed_menu (gboolean add, gboolean enabled, gboolean readWrite);
 
 /**
- * liferea_shell_update_item_menu:
+ * liferea_shell_update_item_menu: (skip)
+ * @enabled:	TRUE if item actions are to be enabled
  *
  * Update the sensitivity of options affecting single items.
- *
- * @param enabled	TRUE if item actions are to be enabled
  *
  * TODO: use signal instead
  */
 void liferea_shell_update_item_menu (gboolean enabled);
 
 /**
- * liferea_shell_update_allitems_actions:
+ * liferea_shell_update_allitems_actions: (skip)
+ * @isNotEmpty: 	TRUE if there is a non-empty item set active
+ * @isRead:     	TRUE if there are no unread items in the item set
  *
  * Update the sensitivity of options affecting item sets.
- *
- * @param isNotEmpty	TRUE if there is a non-empty item set active
- * @param isRead	TRUE if there are no unread items in the item set
  *
  * TODO: use signal instead
  */
 void liferea_shell_update_allitems_actions (gboolean isNotEmpty, gboolean isRead);
 
 /**
- * liferea_shell_update_update_menu:
+ * liferea_shell_update_update_menu: (skip)
+ * @enabled:	TRUE if menu options are to be enabled
  *
  * Set the sensitivity of items in the update menu.
- *
- * @param enabled	TRUE if menu options are to be enabled
  *
  * TODO: use signal instead
  */


### PR DESCRIPTION
I removed all the Gtk Doc warnings and added some `(skip)` on functions that aren't useful or usable in plugins (I think GIR can't use C structures that aren't GBoxed types or GObject ?), to see if it would make the errors in #459 go away.

It doesn't make the asserts go away, but the output is more readable if others want to test things ...