### PR TITLE
Fixes #464 update monitor

### DIFF
--- a/glade/update_monitor.ui
+++ b/glade/update_monitor.ui
@@ -1,138 +1,33 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="2.18"/>
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.14"/>
   <object class="GtkDialog" id="update_monitor">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Update Monitor</property>
     <property name="default_width">400</property>
     <property name="default_height">300</property>
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox18">
+      <object class="GtkBox" id="dialog-vbox18">
         <property name="visible">True</property>
-        <child>
-          <object class="GtkTable" id="table9">
-            <property name="visible">True</property>
-            <property name="border_width">6</property>
-            <property name="n_rows">2</property>
-            <property name="n_columns">2</property>
-            <property name="column_spacing">6</property>
-            <property name="row_spacing">6</property>
-            <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow9">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
-                <property name="shadow_type">in</property>
-                <child>
-                  <object class="GtkTreeView" id="left">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="headers_visible">False</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow10">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">automatic</property>
-                <property name="vscrollbar_policy">automatic</property>
-                <property name="shadow_type">in</property>
-                <child>
-                  <object class="GtkTreeView" id="right">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="headers_visible">False</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label229">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Pending Requests</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label228">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Downloading Now</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"></property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">2</property>
-          </packing>
-        </child>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area18">
+          <object class="GtkButtonBox" id="dialog-action_area18">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button4">
+                <property name="label" translatable="yes">Cancel All</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <signal name="clicked" handler="on_cancel_all_requests_clicked"/>
-                <child>
-                  <object class="GtkAlignment" id="alignment36">
-                    <property name="visible">True</property>
-                    <property name="xscale">0</property>
-                    <property name="yscale">0</property>
-                    <child>
-                      <object class="GtkHBox" id="hbox92233">
-                        <property name="visible">True</property>
-                        <property name="spacing">2</property>
-                        <child>
-                          <object class="GtkLabel" id="label227">
-                            <property name="visible">True</property>
-                            <property name="label" translatable="yes">Cancel _All</property>
-                            <property name="use_underline">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
+                <signal name="clicked" handler="on_cancel_all_requests_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -148,7 +43,7 @@
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_close_update_monitor_clicked"/>
+                <signal name="clicked" handler="on_close_update_monitor_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -159,8 +54,99 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">6</property>
+            <property name="row_spacing">6</property>
+            <property name="column_spacing">6</property>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolledwindow9">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="left">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="headers_visible">False</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolledwindow10">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="right">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="headers_visible">False</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Pending Requests</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Downloading Now</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -169,5 +155,8 @@
       <action-widget response="0">button4</action-widget>
       <action-widget response="-7">button5</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>

--- a/src/ui/ui_update.c
+++ b/src/ui/ui_update.c
@@ -52,16 +52,20 @@ static void ui_update_remove_request(nodePtr node, GtkTreeStore *store, GHashTab
 
 static void ui_update_merge_request(nodePtr node, GtkTreeStore *store, GHashTable *hash) {
 	GtkTreeIter	*iter;
+        gchar           *title;
 
 	if(NULL != (iter = (GtkTreeIter *)g_hash_table_lookup(hash, (gpointer)node->id)))
 		return;
 
 	iter = g_new0(GtkTreeIter, 1);
 	gtk_tree_store_append(store, iter, NULL);
-	gtk_tree_store_set(store, iter, UM_REQUEST_TITLE, node_get_title(node), 
+        title = g_markup_escape_text (node_get_title (node), -1);
+	gtk_tree_store_set(store, iter, UM_REQUEST_TITLE, title,
 	                                UM_FAVICON, node_get_icon(node),
 	                                -1);
 	g_hash_table_insert(hash, (gpointer)node->id, (gpointer)iter);
+
+        g_free (title);
 }
 
 static void
@@ -144,7 +148,7 @@ void on_menu_show_update_monitor(GtkWidget *widget, gpointer user_data) {
 		
 		/* Set up left store and view */
 		view = GTK_TREE_VIEW(liferea_dialog_lookup(umdialog, "left"));
-		um1store = gtk_tree_store_new(UM_LEN, GDK_TYPE_PIXBUF, G_TYPE_STRING);
+		um1store = gtk_tree_store_new(UM_LEN, G_TYPE_ICON, G_TYPE_STRING);
 		gtk_tree_view_set_model(view, GTK_TREE_MODEL(um1store));
 
 		textRenderer = gtk_cell_renderer_text_new();
@@ -153,13 +157,13 @@ void on_menu_show_update_monitor(GtkWidget *widget, gpointer user_data) {
 	
 		gtk_tree_view_column_pack_start(column, iconRenderer, FALSE);
 		gtk_tree_view_column_pack_start(column, textRenderer, TRUE);
-		gtk_tree_view_column_add_attribute(column, iconRenderer, "pixbuf", UM_FAVICON);
+		gtk_tree_view_column_add_attribute(column, iconRenderer, "gicon", UM_FAVICON);
 		gtk_tree_view_column_add_attribute(column, textRenderer, "markup", UM_REQUEST_TITLE);
 		gtk_tree_view_append_column(view, column);
 		
 		/* Set up right store and view */
 		view = GTK_TREE_VIEW(liferea_dialog_lookup(umdialog, "right"));
-		um2store = gtk_tree_store_new(UM_LEN, GDK_TYPE_PIXBUF, G_TYPE_STRING);
+		um2store = gtk_tree_store_new(UM_LEN, G_TYPE_ICON, G_TYPE_STRING);
 		gtk_tree_view_set_model(view, GTK_TREE_MODEL(um2store));
 
 		textRenderer = gtk_cell_renderer_text_new();
@@ -168,7 +172,7 @@ void on_menu_show_update_monitor(GtkWidget *widget, gpointer user_data) {
 	
 		gtk_tree_view_column_pack_start(column, iconRenderer, FALSE);
 		gtk_tree_view_column_pack_start(column, textRenderer, TRUE);
-		gtk_tree_view_column_add_attribute(column, iconRenderer, "pixbuf", UM_FAVICON);
+		gtk_tree_view_column_add_attribute(column, iconRenderer, "gicon", UM_FAVICON);
 		gtk_tree_view_column_add_attribute(column, textRenderer, "markup", UM_REQUEST_TITLE);
 		gtk_tree_view_append_column(view, column);		
 		


### PR DESCRIPTION
Replaces deprecated elements in the ui file.
Fixes icons due to move to GIcon.
Escapes node title text (which was causing markup error Gtk-Warnings).