### PR TITLE
Set the proxy for WebKit if version supports it

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -115,7 +115,7 @@ network_get_proxy_uri (void)
    last modified string.
  */
 void
-network_process_request (const updateJobPtr const job)
+network_process_request (const updateJobPtr job)
 {
 	SoupMessage	*msg;
 	SoupDate	*date;
@@ -259,14 +259,15 @@ network_set_soup_session_proxy (SoupSession *session, ProxyDetectMode mode, cons
 			soup_uri_set_port (uri, port);
 			soup_uri_set_user (uri, user);
 			soup_uri_set_password (uri, password);
+			soup_uri_set_path (uri, "/");
 
 			if (SOUP_URI_IS_VALID (uri)) {
 				/* Sets proxy-uri, this unsets proxy-resolver. */
 				g_object_set (G_OBJECT (session),
 					SOUP_SESSION_PROXY_URI, uri,
 					NULL);
-				soup_uri_free (uri);
 			}
+			soup_uri_free (uri);
 			break;
 	}
 }

--- a/src/ui/liferea_htmlview.c
+++ b/src/ui/liferea_htmlview.c
@@ -393,7 +393,7 @@ liferea_htmlview_title_changed (LifereaHtmlView *htmlview, const gchar *title)
 void
 liferea_htmlview_location_changed (LifereaHtmlView *htmlview, const gchar *location)
 {
-	if (g_strcmp0 (location, "file:///")) {
+	if (g_strcmp0 (location, "file:///") && g_strcmp0 (location, "file://")) {
 		/* A URI different from the locally generated html base url is being loaded. */
 		htmlview->priv->internal = FALSE;
 	}


### PR DESCRIPTION
Also in net.c : set the path of the SoupUri, to make it a valid SoupUri.
Remove a duplicate const, but I realized, the remaining one isn't
useful either, with the typedef this is a const pointer to a non-const
updateJob.

In liferea_htmlview.c : With the proxy set to an unavailable address,
on some items the location changed to file://, so I changed the
condition to avoid adding file:/// to browser history. It feels hacky
though. There might be a better way to handle it, perhaps a custom uri
scheme instead of file:// for our local content ?