### PR TITLE
Item list view : Check if selection really changed in callback

### DIFF
--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -311,12 +311,17 @@ on_itemlist_selection_changed (GtkTreeSelection *selection, gpointer user_data)
 	GtkTreeModel	*model;
 	itemPtr		item = NULL;
 
-	if (gtk_tree_selection_get_selected (selection, &model, &iter))
-		item = item_load (item_list_view_iter_to_id (ITEM_LIST_VIEW (user_data), &iter));
-
-	liferea_shell_update_item_menu (NULL != item);
-	if (item)
-		itemlist_selection_changed (item);
+	if (gtk_tree_selection_get_selected (selection, &model, &iter)) {
+		gulong id = item_list_view_iter_to_id (ITEM_LIST_VIEW (user_data), &iter);
+		if (id != itemlist_get_selected_id ()) {
+			item = item_load (id);
+			liferea_shell_update_item_menu (NULL != item);
+			if (item)
+				itemlist_selection_changed (item);
+		}
+	} else {
+		liferea_shell_update_item_menu (FALSE);
+	}
 }
 
 static void


### PR DESCRIPTION
The GtkTreeSelection "changed" signal can be emitted even when the
selection didn't actually change.
By checking if the selected item really changed before calling
itemlist_selection_changed we avoid entering the loop in #208 : when
viewing a folder, with an item selected, if an update removes some
items the selection "changed" signal is emitted. This caused
itemlist_check_for_deferred_action to be called, removing the actually
selected item and moving the selection, marking many items as read in
the process.
