### PR TITLE
Replace deprecated elements in mainwindow.ui

### DIFF
--- a/glade/about.ui
+++ b/glade/about.ui
@@ -1,8 +1,9 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="2.18"/>
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.14"/>
   <object class="GtkAboutDialog" id="about">
+    <property name="can_focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">About</property>
@@ -13,7 +14,6 @@
     <property name="comments" translatable="yes">Liferea is a news aggregator for GTK+</property>
     <property name="website">https://lzone.de/liferea/</property>
     <property name="website_label" translatable="yes">Liferea Homepage</property>
-    <property name="license_type">gpl-2-0</property>
     <property name="authors">
 Developers:
 
@@ -82,28 +82,28 @@ Sargate Kanogan
 Rodrigo Gallardo
 Takeshi AIHANA
 Takeshi Hamasaki
-Vincent Lef&#xE8;vre
+Vincent Lefèvre
 Daniel Nylander
 Mehmet Atif Ergun
-Eren T&#xFC;rkay
+Eren Türkay
 Ihar Hrachyshka
-Ant&#xF3;nio Lima
+António Lima
 Bruno Miguel
 Martin Picek
 Justin Forest
 Oleg Maloglovets
 Sergey Rudchenko
 Leonid Selivanov
-M&#xE1;t&#xE9; &#x150;ry
+Máté Őry
 Gabor Kelemen
-Pavol Kla&#x10D;ansk&#xFD;
+Pavol Klačanský
 Evgenia Petoumenou
 Besnik Bleta
 Christian Dywan
 Robin Stocker
 Paul Seyfert
 Gil Forcada
-I&#xF1;aki Larra&#xF1;aga Murgoitio
+Iñaki Larrañaga Murgoitio
 Mikel Olasagasti Uranga
 Adi Roiban
 Erwin Poeze
@@ -123,27 +123,35 @@ Jorma Karvonen
 Guillaume Bernard
 </property>
     <property name="logo_icon_name">liferea</property>
+    <property name="license_type">gpl-2-0</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox23">
+      <object class="GtkBox" id="dialog-vbox23">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
-        <child>
-          <placeholder/>
-        </child>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area23">
+          <object class="GtkButtonBox" id="dialog-action_area23">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="layout_style">end</property>
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
+        <child>
+          <placeholder/>
+        </child>
       </object>
+    </child>
+    <child>
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/glade/auth.ui
+++ b/glade/auth.ui
@@ -1,124 +1,24 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.14"/>
   <object class="GtkDialog" id="auth">
     <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Authentication</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox14">
+      <object class="GtkBox" id="dialog-vbox14">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
-        <child>
-          <object class="GtkVBox" id="vbox255">
-            <property name="visible">True</property>
-            <property name="border_width">5</property>
-            <property name="spacing">12</property>
-            <child>
-              <object class="GtkLabel" id="prompt">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Enter the username and password for "%s" (%s):</property>
-                <property name="wrap">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkTable" id="table1">
-                <property name="visible">True</property>
-                <property name="n_rows">2</property>
-                <property name="n_columns">2</property>
-                <property name="column_spacing">12</property>
-                <property name="row_spacing">6</property>
-                <child>
-                  <object class="GtkEntry" id="passwordEntry">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="visibility">False</property>
-                    <property name="activates_default">True</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                    <property name="y_options"></property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="usernameEntry">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="activates_default">True</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="right_attach">2</property>
-                    <property name="y_options"></property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label108">
-                    <property name="visible">True</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">_Password:</property>
-                    <property name="use_underline">True</property>
-                    <property name="mnemonic_widget">passwordEntry</property>
-                  </object>
-                  <packing>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"></property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label107">
-                    <property name="visible">True</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">User_name:</property>
-                    <property name="use_underline">True</property>
-                    <property name="mnemonic_widget">usernameEntry</property>
-                  </object>
-                  <packing>
-                    <property name="x_options">GTK_FILL</property>
-                    <property name="y_options"></property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label134">
-                <property name="visible">True</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Note: &lt;i&gt;The username and password will be saved to your Liferea feedlist file without using encryption.&lt;/i&gt;</property>
-                <property name="use_markup">True</property>
-                <property name="wrap">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area14">
+          <object class="GtkButtonBox" id="dialog-action_area14">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancelbutton2">
@@ -154,8 +54,113 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">5</property>
+            <property name="orientation">vertical</property>
+            <property name="row_spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="prompt">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Enter the username and password for "%s" (%s):</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Note: &lt;i&gt;The username and password will be saved to your Liferea feedlist file without using encryption.&lt;/i&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="wrap">True</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="row_spacing">6</property>
+                <property name="column_spacing">12</property>
+                <child>
+                  <object class="GtkLabel" id="label107">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">User_name:</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">usernameEntry</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="usernameEntry">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="activates_default">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label108">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">_Password:</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">passwordEntry</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="passwordEntry">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="visibility">False</property>
+                    <property name="activates_default">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -164,5 +169,8 @@
       <action-widget response="-6">cancelbutton2</action-widget>
       <action-widget response="-5">okbutton1</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>

--- a/glade/mainwindow.ui
+++ b/glade/mainwindow.ui
@@ -1,36 +1,49 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="2.18"/>
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.14"/>
+  <object class="GtkAdjustment" id="adjustment6">
+    <property name="upper">100</property>
+    <property name="value">1</property>
+    <property name="step_increment">1</property>
+  </object>
   <object class="GtkWindow" id="mainwindow">
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Liferea</property>
     <property name="default_width">640</property>
     <property name="default_height">480</property>
     <property name="icon_name">liferea</property>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkGrid" id="vbox1">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="hexpand">True</property>
+        <property name="vexpand">True</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkHPaned" id="leftpane">
+          <object class="GtkPaned" id="leftpane">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
             <property name="position">170</property>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow3">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="hscrollbar_policy">never</property>
-                <property name="vscrollbar_policy">automatic</property>
                 <property name="shadow_type">in</property>
                 <child>
                   <object class="GtkTreeView" id="feedlist">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="has_focus">True</property>
                     <property name="headers_visible">False</property>
                     <property name="reorderable">True</property>
-                    <signal name="button_press_event" handler="on_mainfeedlist_button_press_event"/>
-                    <signal name="popup_menu" handler="on_mainfeedlist_popup_menu"/>
+                    <signal name="button-press-event" handler="on_mainfeedlist_button_press_event" swapped="no"/>
+                    <signal name="popup-menu" handler="on_mainfeedlist_popup_menu" swapped="no"/>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -46,243 +59,278 @@
                 <property name="show_border">False</property>
                 <property name="scrollable">True</property>
                 <child>
-                  <object class="GtkVBox" id="vbox18">
+                  <object class="GtkNotebook" id="itemtabs">
                     <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="show_tabs">False</property>
+                    <property name="show_border">False</property>
                     <child>
-                      <object class="GtkNotebook" id="itemtabs">
+                      <object class="GtkPaned" id="normalViewPane">
                         <property name="visible">True</property>
-                        <property name="show_tabs">False</property>
-                        <property name="show_border">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="orientation">vertical</property>
+                        <property name="position">199</property>
+                        <property name="position_set">True</property>
                         <child>
-                          <object class="GtkVPaned" id="normalViewPane">
+                          <object class="GtkViewport" id="normalViewItems">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="position">199</property>
+                            <property name="can_focus">False</property>
+                            <property name="shadow_type">none</property>
                             <child>
-                              <object class="GtkViewport" id="normalViewItems">
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="resize">False</property>
+                            <property name="shrink">True</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkGrid" id="normalViewVBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkViewport" id="normalViewHtml">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="vexpand">True</property>
                                 <property name="shadow_type">none</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                               </object>
                               <packing>
-                                <property name="resize">False</property>
-                                <property name="shrink">True</property>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
                               </packing>
                             </child>
-                            <child>
-                              <object class="GtkVBox" id="normalViewVBox">
-                                <property name="visible">True</property>
-                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <child>
-                                  <object class="GtkViewport" id="normalViewHtml">
-                                    <property name="visible">True</property>
-                                    <property name="shadow_type">none</property>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="resize">True</property>
-                                <property name="shrink">True</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                        <child type="tab">
-                          <object class="GtkLabel" id="label30">
-                            <property name="visible">True</property>
-                            <property name="label" translatable="yes">normal view</property>
                           </object>
                           <packing>
-                            <property name="tab_fill">False</property>
+                            <property name="resize">True</property>
+                            <property name="shrink">True</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">page 1</property>
+                      </object>
+                      <packing>
+                        <property name="tab_fill">False</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkPaned" id="wideViewPane">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="position">100</property>
+                        <property name="position_set">True</property>
+                        <child>
+                          <object class="GtkViewport" id="wideViewItems">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="shadow_type">none</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="resize">False</property>
+                            <property name="shrink">True</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHPaned" id="wideViewPane">
+                          <object class="GtkGrid" id="wideViewVBox">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="position">100</property>
+                            <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkViewport" id="wideViewItems">
+                              <object class="GtkViewport" id="wideViewHtml">
                                 <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="vexpand">True</property>
                                 <property name="shadow_type">none</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                               </object>
                               <packing>
-                                <property name="resize">False</property>
-                                <property name="shrink">True</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkVBox" id="wideViewVBox">
-                                <property name="visible">True</property>
-                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <child>
-                                  <object class="GtkViewport" id="wideViewHtml">
-                                    <property name="visible">True</property>
-                                    <property name="shadow_type">none</property>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="resize">True</property>
-                                <property name="shrink">True</property>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child type="tab">
-                          <object class="GtkLabel" id="label252">
-                            <property name="visible">True</property>
-                            <property name="label" translatable="yes">wide view</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                            <property name="tab_fill">False</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkVBox" id="vbox2628">
-                            <property name="visible">True</property>
-                            <child>
-                              <object class="GtkToolbar" id="toolbar1">
-                                <child>
-                                  <object class="GtkToolItem" id="toolitem1">
-                                    <property name="visible">True</property>
-                                    <child>
-                                      <object class="GtkButton" id="button9">
-                                        <property name="label">gtk-go-back</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_stock">True</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToolItem" id="toolitem2">
-                                    <property name="visible">True</property>
-                                    <child>
-                                      <object class="GtkButton" id="button10">
-                                        <property name="label">gtk-go-forward</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_stock">True</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToolItem" id="toolitem3">
-                                    <property name="visible">True</property>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spinbutton1">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="adjustment">adjustment6</property>
-                                        <property name="climb_rate">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToolItem" id="toolitem4">
-                                    <property name="visible">True</property>
-                                    <child>
-                                      <object class="GtkLabel" id="label253">
-                                        <property name="visible">True</property>
-                                        <property name="label" translatable="yes">View Headlines</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkViewport" id="combinedViewHtml">
-                                <property name="visible">True</property>
-                                <property name="shadow_type">none</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child type="tab">
-                          <object class="GtkLabel" id="label133">
-                            <property name="visible">True</property>
-                            <property name="label" translatable="yes">combined view</property>
-                          </object>
-                          <packing>
-                            <property name="position">2</property>
-                            <property name="tab_fill">False</property>
+                            <property name="resize">True</property>
+                            <property name="shrink">True</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="position">0</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">page 2</property>
+                      </object>
+                      <packing>
+                        <property name="position">1</property>
+                        <property name="tab_fill">False</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkGrid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkToolbar" id="toolbar1">
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkToolItem" id="toolitem1">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                  <object class="GtkButton" id="button9">
+                                    <property name="label">gtk-go-back</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="use_stock">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="homogeneous">False</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkToolItem" id="toolitem2">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                  <object class="GtkButton" id="button10">
+                                    <property name="label">gtk-go-forward</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="use_stock">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="homogeneous">False</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkToolItem" id="toolitem3">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                  <object class="GtkSpinButton" id="spinbutton1">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="text" translatable="yes">0</property>
+                                    <property name="adjustment">adjustment6</property>
+                                    <property name="climb_rate">1</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="homogeneous">False</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkToolItem" id="toolitem4">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                  <object class="GtkLabel" id="label253">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">View Headlines</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="homogeneous">False</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkViewport" id="combinedViewHtml">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="shadow_type">none</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">page 3</property>
+                      </object>
+                      <packing>
+                        <property name="position">2</property>
+                        <property name="tab_fill">False</property>
                       </packing>
                     </child>
                   </object>
                 </child>
                 <child type="tab">
-                  <object class="GtkLabel" id="label162">
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Headlines</property>
                   </object>
                   <packing>
                     <property name="tab_fill">False</property>
                   </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child type="tab">
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child type="tab">
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -292,33 +340,24 @@
             </child>
           </object>
           <packing>
-            <property name="position">0</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox30">
+          <object class="GtkStatusbar" id="statusbar">
             <property name="visible">True</property>
-            <child>
-              <object class="GtkStatusbar" id="statusbar">
-                <property name="visible">True</property>
-              </object>
-              <packing>
-                <property name="position">1</property>
-              </packing>
-            </child>
+            <property name="can_focus">False</property>
           </object>
           <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
           </packing>
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkAdjustment" id="adjustment6">
-    <property name="value">1</property>
-    <property name="upper">100</property>
-    <property name="step_increment">1</property>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>

--- a/glade/new_folder.ui
+++ b/glade/new_folder.ui
@@ -1,63 +1,26 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="2.18"/>
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.14"/>
   <object class="GtkDialog" id="new_folder">
-    <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">New Folder</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
+    <property name="window_position">center-on-parent</property>
     <property name="type_hint">dialog</property>
-    <signal name="delete_event" handler="gtk_widget_hide" object="new_folder"/>
+    <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox6">
+      <object class="GtkBox" id="dialog-vbox6">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
-        <child>
-          <object class="GtkVBox" id="vbox10">
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkHBox" id="hbox12">
-                <property name="visible">True</property>
-                <property name="border_width">5</property>
-                <property name="spacing">12</property>
-                <child>
-                  <object class="GtkLabel" id="label20">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">_Folder name:</property>
-                    <property name="use_underline">True</property>
-                    <property name="mnemonic_widget">foldertitleentry</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="foldertitleentry">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="activates_default">True</property>
-                  </object>
-                  <packing>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area6">
+          <object class="GtkButtonBox" id="dialog-action_area6">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button3">
@@ -67,7 +30,7 @@
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="new_folder"/>
+                <signal name="clicked" handler="gtk_widget_hide" object="new_folder" swapped="yes"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -84,8 +47,8 @@
                 <property name="has_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_newfolderbtn_clicked"/>
-                <signal name="clicked" handler="gtk_widget_hide" object="new_folder" after="yes"/>
+                <signal name="clicked" handler="gtk_widget_hide" object="new_folder" after="yes" swapped="yes"/>
+                <signal name="clicked" handler="on_newfolderbtn_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -96,8 +59,46 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">5</property>
+            <property name="row_spacing">6</property>
+            <property name="column_spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="label20">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_Folder name:</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="foldertitleentry">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="activates_default">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -106,5 +107,8 @@
       <action-widget response="-6">button3</action-widget>
       <action-widget response="-5">button2</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>

--- a/glade/new_newsbin.ui
+++ b/glade/new_newsbin.ui
@@ -1,58 +1,25 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="2.18"/>
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.14"/>
   <object class="GtkDialog" id="new_newsbin">
-    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
     <property name="title" translatable="yes">Create News Bin</property>
-    <property name="window_position">center</property>
+    <property name="modal">True</property>
+    <property name="window_position">center-on-parent</property>
     <property name="type_hint">dialog</property>
+    <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox22">
+      <object class="GtkBox" id="dialog-vbox22">
         <property name="visible">True</property>
-        <child>
-          <object class="GtkVBox" id="vbox2627">
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkHBox" id="hbox92243">
-                <property name="visible">True</property>
-                <property name="border_width">5</property>
-                <property name="spacing">12</property>
-                <child>
-                  <object class="GtkLabel" id="label250">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">_News Bin Name:</property>
-                    <property name="use_underline">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="newsbinnameentry">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="activates_default">True</property>
-                  </object>
-                  <packing>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="position">2</property>
-          </packing>
-        </child>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area22">
+          <object class="GtkButtonBox" id="dialog-action_area22">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancelbutton6">
@@ -62,7 +29,7 @@
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="new_newsbin"/>
+                <signal name="clicked" handler="gtk_widget_hide" object="new_newsbin" swapped="yes"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -79,8 +46,8 @@
                 <property name="has_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_newnewsbinbtn_clicked" object="new_newsbin"/>
-                <signal name="clicked" handler="gtk_widget_hide" object="new_newsbin" after="yes"/>
+                <signal name="clicked" handler="gtk_widget_hide" object="new_newsbin" after="yes" swapped="yes"/>
+                <signal name="clicked" handler="on_newnewsbinbtn_clicked" object="new_newsbin" swapped="yes"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -91,8 +58,46 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">5</property>
+            <property name="row_spacing">6</property>
+            <property name="column_spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="label250">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_News Bin Name:</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="newsbinnameentry">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="activates_default">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -101,5 +106,8 @@
       <action-widget response="-6">cancelbutton6</action-widget>
       <action-widget response="-5">newnewsbinbtn</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>

--- a/glade/rename_node.ui
+++ b/glade/rename_node.ui
@@ -1,57 +1,26 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="2.18"/>
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.14"/>
   <object class="GtkDialog" id="rename_node">
-    <property name="visible">True</property>
+    <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Rename</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
+    <property name="window_position">center-on-parent</property>
     <property name="type_hint">dialog</property>
-    <signal name="delete_event" handler="gtk_widget_hide" object="rename_node"/>
+    <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox7">
+      <object class="GtkBox" id="dialog-vbox7">
         <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
-        <child>
-          <object class="GtkHBox" id="hbox13">
-            <property name="visible">True</property>
-            <property name="border_width">5</property>
-            <property name="spacing">12</property>
-            <child>
-              <object class="GtkLabel" id="label23">
-                <property name="visible">True</property>
-                <property name="label" translatable="yes">_New Name:</property>
-                <property name="use_underline">True</property>
-                <property name="mnemonic_widget">nameentry</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="nameentry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="activates_default">True</property>
-              </object>
-              <packing>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area7">
+          <object class="GtkButtonBox" id="dialog-action_area7">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancelbutton1">
@@ -61,7 +30,7 @@
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="rename_node"/>
+                <signal name="clicked" handler="gtk_widget_hide" object="rename_node" swapped="yes"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -88,8 +57,46 @@
           </object>
           <packing>
             <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">5</property>
+            <property name="row_spacing">6</property>
+            <property name="column_spacing">12</property>
+            <child>
+              <object class="GtkLabel" id="label23">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_New Name:</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="nameentry">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="activates_default">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
@@ -98,5 +105,8 @@
       <action-widget response="0">cancelbutton1</action-widget>
       <action-widget response="-5">namechangebtn</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>

--- a/src/ui/auth_dialog.c
+++ b/src/ui/auth_dialog.c
@@ -99,7 +99,7 @@ auth_dialog_load (AuthDialog *ad,
 	ad->priv->subscription = subscription;
 	ad->priv->flags = flags;
 	
-	uri = xmlParseURI (BAD_CAST subscription_get_source (ad->priv->subscription));
+	uri = xmlParseURI (subscription_get_source (ad->priv->subscription));
 	
 	if (uri) {
 		if (uri->user) {
@@ -116,7 +116,7 @@ auth_dialog_load (AuthDialog *ad,
 		}
 		xmlFree (uri->user);
 		uri->user = NULL;
-		source = xmlSaveUri (uri);
+		source = (gchar *) xmlSaveUri (uri);
 		xmlFreeURI (uri);
 	}
 	

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -983,17 +983,12 @@ item_list_view_select (ItemListView *ilv, itemPtr item)
 {
 	GtkTreeView		*treeview = ilv->priv->treeview;
 	GtkTreeSelection	*selection;
+	GtkTreeIter		iter;
 	
 	selection = gtk_tree_view_get_selection (treeview);
 	
-	if (item) {
-		GtkTreeIter		iter;
-		GtkTreePath		*path;		
-		if (!item_list_view_id_to_iter(ilv, item->id, &iter))
-			/* This is an evil hack to fix SF #1870052: crash
-			   upon hitting <enter> when no headline selected.
-			   FIXME: This code is rotten! Rewrite it! Now! */
-			itemlist_selection_changed (NULL);
+	if (item && item_list_view_id_to_iter(ilv, item->id, &iter)){
+		GtkTreePath	*path = NULL;
 
 		path = gtk_tree_model_get_path (gtk_tree_view_get_model (treeview), &iter);
 		if (path) {
@@ -1002,6 +997,8 @@ item_list_view_select (ItemListView *ilv, itemPtr item)
 			gtk_tree_path_free (path);
 		}
 	} else {
+		if (item)
+			g_warning ("item_list_view_select : attempt to select an item which is not present in the view.");
 		gtk_tree_selection_unselect_all (selection);
 	}
 }

--- a/src/ui/liferea_htmlview.c
+++ b/src/ui/liferea_htmlview.c
@@ -149,6 +149,7 @@ liferea_htmlview_finalize (GObject *object)
 	LifereaHtmlView *htmlview = LIFEREA_HTMLVIEW (object);
 
 	browser_history_free (htmlview->priv->history);
+	g_clear_object (&htmlview->priv->container);
 
 	g_signal_handlers_disconnect_by_data (network_monitor_get (), object);
 
@@ -215,6 +216,7 @@ liferea_htmlview_init (LifereaHtmlView *htmlview)
 	htmlview->priv->impl = htmlview_get_impl ();
 	htmlview->priv->renderWidget = RENDERER (htmlview)->create (htmlview);
 	htmlview->priv->container = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
+	g_object_ref_sink (htmlview->priv->container);
 	htmlview->priv->history = browser_history_new ();
 	htmlview->priv->toolbar = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
 	

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -1270,10 +1270,8 @@ liferea_shell_create (GtkApplication *app, const gchar *overrideWindowState)
 	
 	debug0 (DEBUG_GUI, "Setting up widget containers");
 
-	gtk_box_pack_start (GTK_BOX (liferea_shell_lookup ("vbox1")), shell->priv->toolbar, FALSE, FALSE, 0);
-	gtk_box_reorder_child (GTK_BOX (liferea_shell_lookup ("vbox1")), shell->priv->toolbar, 0);
-	gtk_box_pack_start (GTK_BOX (liferea_shell_lookup ("vbox1")), shell->priv->menubar, FALSE, FALSE, 0);
-	gtk_box_reorder_child (GTK_BOX (liferea_shell_lookup ("vbox1")), shell->priv->menubar, 0);
+	gtk_grid_attach_next_to (GTK_GRID (liferea_shell_lookup ("vbox1")), shell->priv->toolbar, NULL, GTK_POS_TOP, 1,1);
+	gtk_grid_attach_next_to (GTK_GRID (liferea_shell_lookup ("vbox1")), shell->priv->menubar, NULL, GTK_POS_TOP, 1,1);
 
 	gtk_widget_show_all(GTK_WIDGET(shell->priv->toolbar));
 

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -596,8 +596,8 @@ on_key_press_event (GtkWidget *widget, GdkEventKey *event, gpointer data)
 {
 	gboolean	modifier_matches = FALSE;
 	guint		default_modifiers;
-	const gchar	*type;
-	GtkWidget	*focusw;
+	const gchar	*type = NULL;
+	GtkWidget	*focusw = NULL;
 	gint		browse_key_setting;
 
 	if (event->type == GDK_KEY_PRESS) {
@@ -621,7 +621,8 @@ on_key_press_event (GtkWidget *widget, GdkEventKey *event, gpointer data)
 
 						/* pass through space keys only if HTML widget has the focus */
 						focusw = gtk_window_get_focus (GTK_WINDOW (widget));
-						type = g_type_name (G_OBJECT_TYPE (focusw));
+						if (focusw)
+							type = g_type_name (G_OBJECT_TYPE (focusw));
 						if (type && (g_str_equal (type, "LifereaWebView")))
 							return FALSE;
 						break;


### PR DESCRIPTION
And also the deprecated call to gtk_widget_reparent. It is replaced by
gtk_container_remove/add. The widget is temporarily outside any
container, which would destroy it if it isn't owned by something else.
I modified LifereaHtmlView to make it own the reference.
