### PR TITLE
Fixes #500 Connects browser entry to callback

### DIFF
--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -736,16 +736,6 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkComboBox" id="browserpopup">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
-                      </packing>
-                    </child>
-                    <child>
                       <object class="GtkLabel" id="manuallabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -765,6 +755,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="activates_default">True</property>
+                        <signal name="changed" handler="on_browsercmd_changed" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -784,6 +775,16 @@
                       <packing>
                         <property name="left_attach">1</property>
                         <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="browserpopup">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
                       </packing>
                     </child>
                     <child>
@@ -1422,5 +1423,8 @@
     <action-widgets>
       <action-widget response="-7">prefclosebtn</action-widget>
     </action-widgets>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>


### PR DESCRIPTION
Glade copy/paste doesn't copy the signals/callbacks part. I missed that one when updating the ui file.