### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -56,10 +56,10 @@ typedef struct node {
 	guint			popupCount;	/*<< number of items to be notified */
 	guint			newCount;	/*<< number of recently downloaded items */
 
-	gchar			*title;		/**< the label of the node in the feed list */
-	gpointer		icon;		/**< favicon GdkPixBuf (or NULL) */
-	gboolean		available;	/**< availability of this node (usually the last downloading state) */
-	gboolean		expanded;	/**< expansion state (for nodes with childs) */
+	gchar			*title;		/*<< the label of the node in the feed list */
+	gpointer		icon;		/*<< favicon GdkPixBuf (or NULL) */
+	gboolean		available;	/*<< availability of this node (usually the last downloading state) */
+	gboolean		expanded;	/*<< expansion state (for nodes with childs) */
 
 	/* item list state properties of this node */
 	nodeViewType		viewMode;	/*<< Viewing mode for this node (one of NODE_VIEW_MODE_*) */

--- a/src/ui/icons.c
+++ b/src/ui/icons.c
@@ -26,7 +26,7 @@
 
 #include "common.h"
 
-static GIcon *icons[MAX_ICONS];	/**< list of icon assignments */
+static GIcon *icons[MAX_ICONS];	/**<< list of icon assignments */
 
 static gchar *
 icon_find_pixmap_file (const gchar *filename)

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -557,7 +557,7 @@ on_close (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
 	guint signal_id = g_signal_lookup ("delete_event",  GTK_TYPE_WINDOW);
 
-	if (g_signal_has_handler_pending(widget, signal_id, NULL, TRUE))
+	if (g_signal_has_handler_pending(widget, signal_id, (GQuark) 0, TRUE))
 		return FALSE;
 	liferea_shutdown ();
 	return TRUE;

--- a/src/ui/preferences_dialog.c
+++ b/src/ui/preferences_dialog.c
@@ -686,16 +686,13 @@ preferences_dialog_init (PreferencesDialog *pd)
 	pd->priv->plugins_box = liferea_dialog_lookup (pd->priv->dialog, "plugins_box");
 	g_assert (pd->priv->plugins_box != NULL);
 
-	GtkWidget *alignment;
-
-	alignment = gtk_alignment_new (0., 0., 1., 1.);
-	gtk_alignment_set_padding (GTK_ALIGNMENT (alignment), 12, 12, 12, 12);
-
 	widget = peas_gtk_plugin_manager_new (NULL);
 	g_assert (widget != NULL);
-
-	gtk_container_add (GTK_CONTAINER (alignment), widget);
-	gtk_box_pack_start (GTK_BOX (pd->priv->plugins_box), alignment, TRUE, TRUE, 0);
+	gtk_widget_set_margin_start(widget, 12);
+	gtk_widget_set_margin_end(widget, 12);
+	gtk_widget_set_margin_top(widget, 12);
+	gtk_widget_set_margin_bottom(widget, 12);
+	gtk_box_pack_start (GTK_BOX (pd->priv->plugins_box), widget, TRUE, TRUE, 0);
 
 	g_signal_connect_object (pd->priv->dialog, "destroy", G_CALLBACK (preferences_dialog_destroy_cb), pd, 0);
 


### PR DESCRIPTION
Fix a few compile-time warnings about
* deprecation (GtkAlignment)
* documentation
* implicit cast