### PR TITLE
Warning for unsupported proxy settings

### DIFF
--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -938,7 +938,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="top_attach">2</property>
                   </packing>
                 </child>
                 <child>
@@ -956,7 +956,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">2</property>
+                    <property name="top_attach">3</property>
                   </packing>
                 </child>
                 <child>
@@ -974,7 +974,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">3</property>
+                    <property name="top_attach">4</property>
                   </packing>
                 </child>
                 <child>
@@ -1127,7 +1127,66 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">4</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkInfoBar" id="proxyDisabledInfobar">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="message_type">warning</property>
+                    <child internal-child="action_area">
+                      <object class="GtkButtonBox">
+                        <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
+                        <property name="layout_style">end</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child internal-child="content_area">
+                      <object class="GtkBox">
+                        <property name="can_focus">False</property>
+                        <property name="spacing">16</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Your version of WebKitGTK+ is older than 2.15.3. It doesn't support per application proxy settings. The system's default proxy settings will be used.</property>
+                            <property name="wrap">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
                   </packing>
                 </child>
               </object>

--- a/src/conf.c
+++ b/src/conf.c
@@ -23,6 +23,7 @@
 #include <libxml/uri.h>
 #include <string.h>
 #include <time.h>
+#include <webkit2/webkit2.h>
 
 #include "common.h"
 #include "conf.h"
@@ -164,13 +165,29 @@ conf_proxy_reset_settings_cb (GSettings *settings,
 	gint		proxyport;
 	gint		proxydetectmode;
 	gboolean	proxyuseauth;
+	GtkWidget 	*dialog = NULL;
 
 	proxyname = NULL;
 	proxyport = 0;
 	proxyusername = NULL;
 	proxypassword = NULL;
-
 	conf_get_int_value (PROXY_DETECT_MODE, &proxydetectmode);
+
+#if !WEBKIT_CHECK_VERSION (2, 15, 3)
+	if (proxydetectmode != PROXY_DETECT_MODE_AUTO)
+	{
+		dialog = gtk_message_dialog_new (NULL,
+			0,
+			GTK_MESSAGE_INFO,
+			GTK_BUTTONS_CLOSE,
+			_("Your version of WebKitGTK+ doesn't support changing the proxy settings from Liferea. The system's default proxy settings will be used."));
+		gtk_dialog_run (GTK_DIALOG (dialog));
+		gtk_widget_destroy (dialog);
+
+		conf_set_int_value (PROXY_DETECT_MODE, PROXY_DETECT_MODE_AUTO);
+		return;
+	}
+#endif
 	switch (proxydetectmode) {
 		default:
 		case 0:

--- a/src/ui/preferences_dialog.c
+++ b/src/ui/preferences_dialog.c
@@ -27,6 +27,7 @@
 #endif
 
 #include <libpeas-gtk/peas-gtk-plugin-manager.h>
+#include <webkit2/webkit2.h>
 
 #include "common.h"
 #include "conf.h"
@@ -593,6 +594,9 @@ preferences_dialog_init (PreferencesDialog *pd)
 	                            i);
 
 	/* ================= panel 5 "proxy" ======================== */
+
+#if WEBKIT_CHECK_VERSION (2, 15, 3)
+	gtk_widget_destroy (GTK_WIDGET (liferea_dialog_lookup (pd->priv->dialog, "proxyDisabledInfobar")));
 	conf_get_str_value (PROXY_HOST, &proxy_host);
 	gtk_entry_set_text (GTK_ENTRY (liferea_dialog_lookup (pd->priv->dialog, "proxyhostentry")), proxy_host);
 	g_free (proxy_host);
@@ -639,6 +643,13 @@ preferences_dialog_init (PreferencesDialog *pd)
 	g_signal_connect (G_OBJECT (liferea_dialog_lookup (pd->priv->dialog, "proxyportentry")), "changed", G_CALLBACK (on_proxyportentry_changed), pd);
 	g_signal_connect (G_OBJECT (liferea_dialog_lookup (pd->priv->dialog, "proxyusernameentry")), "changed", G_CALLBACK (on_proxyusernameentry_changed), pd);
 	g_signal_connect (G_OBJECT (liferea_dialog_lookup (pd->priv->dialog, "proxypasswordentry")), "changed", G_CALLBACK (on_proxypasswordentry_changed), pd);
+#else
+	gtk_widget_show (GTK_WIDGET (liferea_dialog_lookup (pd->priv->dialog, "proxyDisabledInfobar")));
+	gtk_widget_set_sensitive (GTK_WIDGET (liferea_dialog_lookup (pd->priv->dialog, "proxybox")), FALSE);
+	gtk_widget_set_sensitive (GTK_WIDGET (liferea_dialog_lookup (pd->priv->dialog, "proxyAutoDetectRadio")), TRUE);
+	gtk_widget_set_sensitive (GTK_WIDGET (liferea_dialog_lookup (pd->priv->dialog, "noProxyRadio")), FALSE);
+	gtk_widget_set_sensitive (GTK_WIDGET (liferea_dialog_lookup (pd->priv->dialog, "manualProxyRadio")), FALSE);
+#endif
 
 	/* ================= panel 6 "Privacy" ======================== */
 


### PR DESCRIPTION
This is a proposal to "fix" problems like #503. With proxy settings other than auto and older WebKit, Liferea behaves in a way that would be hard to explain to non-tech people.

This shows a dialog on start to warn the user and change proxy settings to "auto" if WebKitGTK+ version doesn't allow setting the proxy (only if the setting isn't "auto" already).

It also shows an orange "warning" infobar and deactivate proxy settings other than "auto".

I pushed a first commit where I was calling `ui_show_info_box` from `liferea_shell_create`. I didn't put it in `conf_proxy_reset_cb` because the main window doesn't exist yet when it is called and `ui_show_info_box` uses it as parent for the dialog. But we can also create a GtkMessageDialog there without a parent so I amended that commit ... In a way it makes sense as it prevents setting the proxy mode to anything other than auto even with external tools, but I'm not sure it is good style to run a dialog here (as oppoed to having some ... signal ? flag ? to tell the mainwindow to show some notice when it is up, perhaps ?). 
