### PR TITLE
Resize both panes in normal and wide view

### DIFF
--- a/glade/mainwindow.ui
+++ b/glade/mainwindow.ui
@@ -81,7 +81,7 @@
                             </child>
                           </object>
                           <packing>
-                            <property name="resize">False</property>
+                            <property name="resize">True</property>
                             <property name="shrink">True</property>
                           </packing>
                         </child>
@@ -140,7 +140,7 @@
                             </child>
                           </object>
                           <packing>
-                            <property name="resize">False</property>
+                            <property name="resize">True</property>
                             <property name="shrink">True</property>
                           </packing>
                         </child>


### PR DESCRIPTION
By making both children of the GtkPaned resize, we avoid having one
"squeezed" into a tiny space and not expanding again when the window is
resized.

This fixes or mitigates #540, I'm not sure the ratio is always kept.