### PR TITLE
Workaround to avoid GtkPaned shrinking

### DIFF
--- a/glade/mainwindow.ui
+++ b/glade/mainwindow.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.20.2 -->
 <interface>
   <requires lib="gtk+" version="3.14"/>
   <object class="GtkAdjustment" id="adjustment6">
@@ -81,7 +81,7 @@
                             </child>
                           </object>
                           <packing>
-                            <property name="resize">True</property>
+                            <property name="resize">False</property>
                             <property name="shrink">True</property>
                           </packing>
                         </child>
@@ -140,7 +140,7 @@
                             </child>
                           </object>
                           <packing>
-                            <property name="resize">True</property>
+                            <property name="resize">False</property>
                             <property name="shrink">True</property>
                           </packing>
                         </child>
@@ -356,7 +356,7 @@
         </child>
       </object>
     </child>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
   </object>

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -570,10 +570,15 @@ on_window_state_event (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 		GdkWindowState changed = ((GdkEventWindowState*)event)->changed_mask, state = ((GdkEventWindowState*)event)->new_window_state;
 
 		if (changed == GDK_WINDOW_STATE_MAXIMIZED && !(state & GDK_WINDOW_STATE_WITHDRAWN)) {
-			if (state & GDK_WINDOW_STATE_MAXIMIZED)
+			if (state & GDK_WINDOW_STATE_MAXIMIZED) {
 				conf_set_bool_value (LAST_WINDOW_MAXIMIZED, TRUE);
-			else
+			} else {
 				conf_set_bool_value (LAST_WINDOW_MAXIMIZED, FALSE);
+				gtk_container_child_set (GTK_CONTAINER (liferea_shell_lookup ("normalViewPane")), liferea_shell_lookup ("normalViewItems"),
+					"resize", TRUE, NULL);
+				gtk_container_child_set (GTK_CONTAINER (liferea_shell_lookup ("wideViewPane")), liferea_shell_lookup ("wideViewItems"),
+					"resize", TRUE, NULL);
+			}
 		}
 		if (state & GDK_WINDOW_STATE_ICONIFIED)
 			conf_set_int_value (LAST_WINDOW_STATE, MAINWINDOW_ICONIFIED);
@@ -1113,6 +1118,7 @@ liferea_shell_restore_state (const gchar *overrideWindowState)
 	gchar		*toolbar_style, *accels_file;
 	gint		last_vpane_pos, last_hpane_pos, last_wpane_pos;
 	gint		resultState;
+	gboolean 	last_window_maximized;
 	
 	debug0 (DEBUG_GUI, "Setting toolbar style");
 	
@@ -1178,6 +1184,13 @@ liferea_shell_restore_state (const gchar *overrideWindowState)
 	if (last_wpane_pos)
 		gtk_paned_set_position (GTK_PANED (liferea_shell_lookup ("wideViewPane")), last_wpane_pos);
 
+	conf_get_bool_value (LAST_WINDOW_MAXIMIZED, &last_window_maximized);
+	if (!last_window_maximized) {
+		gtk_container_child_set (GTK_CONTAINER (liferea_shell_lookup ("normalViewPane")), liferea_shell_lookup ("normalViewItems"),
+			"resize", TRUE, NULL);
+		gtk_container_child_set (GTK_CONTAINER (liferea_shell_lookup ("wideViewPane")), liferea_shell_lookup ("wideViewItems"),
+			"resize", TRUE, NULL);
+	}
 }
 
 void


### PR DESCRIPTION
Workaround for Gtk+ bug :
https://bugzilla.gnome.org/show_bug.cgi?id=733638

When trying to restore the position of the GtkPaned separator with both
children set to resize and a maximized window, the GtkPaned
automatically modifies its position after it is set.

To avoid this the resize property of the first child of the wide view
and normal view GtkPaned is set to TRUE only if Liferea isn't started
maximized. The LAST_WINDOW_MAXIMIZED setting is used for this because
`gtk_window_is_maximized` doesn't return a correct value at start (due
to window manager operations being asynchronous).

If the user unmaximize the window both children are set to resize, so
that they resize with the window. It is not necessary to disable resize
again when maximizing the window as the problem only occur when setting
the position.

The vertical separator in wide view still doesn't completely respect
the given position ...