### PR TITLE
Support HTTP 308 Permanent Redirect (RFC 7538)

### DIFF
--- a/src/subscription.c
+++ b/src/subscription.c
@@ -205,7 +205,7 @@ subscription_process_update_result (const struct updateResult * const result, gp
 
 	g_assert (subscription->updateJob);
 	/* update the subscription URL on permanent redirects */
-	if ((301 == result->httpstatus) && result->source && !g_str_equal (result->source, subscription->updateJob->request->source)) {
+	if ((301 == result->httpstatus || 308 == result->httpstatus) && result->source && !g_str_equal (result->source, subscription->updateJob->request->source)) {
 		debug2 (DEBUG_UPDATE, "The URL of \"%s\" has changed permanently and was updated with \"%s\"", node_get_title(node), result->source);
 		subscription_set_source (subscription, result->source);
 		liferea_shell_set_status_bar (_("The URL of \"%s\" has changed permanently and was updated"), node_get_title(node));


### PR DESCRIPTION
The only difference between 301 and 308 responses is irrelevant for Liferea.

> This status code is similar to 301 (Moved Permanently) RFC7231, Section 6.4.2, except that it does not allow changing the request method from POST to GET.

https://tools.ietf.org/html/rfc7538