### PR TITLE
Fix cache revalidation, source suggested update interval from average of rss2:ttl, syn:update*, and Cache-Control: max-age

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -23,6 +23,7 @@
 
 #include <glib.h>
 #include <libsoup/soup.h>
+#include <math.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -119,7 +120,7 @@ network_process_callback (SoupSession *session, SoupMessage *msg, gpointer user_
 						}
 					}
 					if (0 < maxage) {
-						job->result->updateState->maxAgeMinutes = maxage / 60;
+						job->result->updateState->maxAgeMinutes = ceil ( (float) (maxage / 60));
 					}
 				}
 			}

--- a/src/parsers/ns_syn.c
+++ b/src/parsers/ns_syn.c
@@ -42,6 +42,7 @@ ns_syn_parse_tag (feedParserCtxtPtr ctxt, xmlNodePtr cur)
 	xmlChar	*tmp;
 	gint	period;
 	gint	frequency = 1;
+	gint	maxage = ctxt->subscription->updateState->maxAgeMinutes;
 	
 	period = subscription_get_default_update_interval (ctxt->subscription);
 	if (!xmlStrcmp (cur->name, BAD_CAST"updatePeriod")) {
@@ -55,7 +56,7 @@ ns_syn_parse_tag (feedParserCtxtPtr ctxt, xmlNodePtr cur)
 				period = 7*24*60;
 			else if (!xmlStrcmp (tmp, BAD_CAST"monthly"))
 				/* FIXME: not really exact...*/
-				period = 31*7*24*60;	
+				period = 30*7*24*60;	
 			else if (!xmlStrcmp (tmp, BAD_CAST"yearly"))
 				period = 365*24*60;
 
@@ -73,7 +74,8 @@ ns_syn_parse_tag (feedParserCtxtPtr ctxt, xmlNodePtr cur)
 	if (0 != frequency)
 		period /= frequency;
 
-	subscription_set_default_update_interval (ctxt->subscription, period);
+	/* override maxage only when period is longer */
+	ctxt->subscription->updateState->maxAgeMinutes = ((period >= maxage) ? period : maxage);
 }
 
 static void

--- a/src/parsers/ns_syn.c
+++ b/src/parsers/ns_syn.c
@@ -40,11 +40,9 @@ static void
 ns_syn_parse_tag (feedParserCtxtPtr ctxt, xmlNodePtr cur)
 {
 	xmlChar	*tmp;
-	gint	period;
+	gint	period = 0;
 	gint	frequency = 1;
-	gint	maxage = ctxt->subscription->updateState->maxAgeMinutes;
-	
-	period = subscription_get_default_update_interval (ctxt->subscription);
+
 	if (!xmlStrcmp (cur->name, BAD_CAST"updatePeriod")) {
 		if (NULL != (tmp = xmlNodeListGetString (cur->doc, cur->xmlChildrenNode, 1))) {
 
@@ -60,22 +58,19 @@ ns_syn_parse_tag (feedParserCtxtPtr ctxt, xmlNodePtr cur)
 			else if (!xmlStrcmp (tmp, BAD_CAST"yearly"))
 				period = 365*24*60;
 
+			ctxt->subscription->updateState->synPeriod = period;
 			xmlFree (tmp);
 		}
 	} else if (!xmlStrcmp (cur->name, BAD_CAST"updateFrequency")) {
 		tmp = xmlNodeListGetString (cur->doc, cur->xmlChildrenNode, 1);
 		if (tmp) {
 			frequency = atoi ((gchar *)tmp);
+
+			ctxt->subscription->updateState->synFrequency = frequency;
 			xmlFree (tmp);
 		}
 	}
-	
-	/* postprocessing */
-	if (0 != frequency)
-		period /= frequency;
 
-	/* override maxage only when period is longer */
-	ctxt->subscription->updateState->maxAgeMinutes = ((period >= maxage) ? period : maxage);
 }
 
 static void

--- a/src/parsers/rss_channel.c
+++ b/src/parsers/rss_channel.c
@@ -64,7 +64,6 @@ static void parseChannel(feedParserCtxtPtr ctxt, xmlNodePtr cur) {
 	gchar			*tmp, *tmp2, *tmp3;
 	NsHandler		*nsh;
 	parseChannelTagFunc	pf;
-	gint maxage = ctxt->subscription->updateState->maxAgeMinutes;
 	
 	g_assert(NULL != cur);
 			
@@ -105,8 +104,7 @@ static void parseChannel(feedParserCtxtPtr ctxt, xmlNodePtr cur) {
 		} 
 		else if(!xmlStrcmp(cur->name, BAD_CAST"ttl")) {
  			if(NULL != (tmp = (gchar *)xmlNodeListGetString(ctxt->doc, cur->xmlChildrenNode, TRUE))) {
-				/* override maxage only when time-to-live is longer */
-				ctxt->subscription->updateState->maxAgeMinutes = ((atoi(tmp) >= maxage) ? atoi(tmp) : maxage);
+				ctxt->subscription->updateState->timeToLive = atoi (tmp);
 				g_free(tmp);
 			}
 		}

--- a/src/parsers/rss_channel.c
+++ b/src/parsers/rss_channel.c
@@ -64,6 +64,7 @@ static void parseChannel(feedParserCtxtPtr ctxt, xmlNodePtr cur) {
 	gchar			*tmp, *tmp2, *tmp3;
 	NsHandler		*nsh;
 	parseChannelTagFunc	pf;
+	gint maxage = ctxt->subscription->updateState->maxAgeMinutes;
 	
 	g_assert(NULL != cur);
 			
@@ -104,7 +105,8 @@ static void parseChannel(feedParserCtxtPtr ctxt, xmlNodePtr cur) {
 		} 
 		else if(!xmlStrcmp(cur->name, BAD_CAST"ttl")) {
  			if(NULL != (tmp = (gchar *)xmlNodeListGetString(ctxt->doc, cur->xmlChildrenNode, TRUE))) {
-				subscription_set_default_update_interval(ctxt->subscription, atoi(tmp));
+				/* override maxage only when time-to-live is longer */
+				ctxt->subscription->updateState->maxAgeMinutes = ((atoi(tmp) >= maxage) ? atoi(tmp) : maxage);
 				g_free(tmp);
 			}
 		}

--- a/src/update.c
+++ b/src/update.c
@@ -93,6 +93,21 @@ update_state_set_etag (updateStatePtr state, const gchar *etag)
 		state->etag = g_strdup(etag);
 }
 
+void
+update_state_set_cache_maxage (updateStatePtr state, const gint maxage)
+{
+	if (0 < maxage)
+		state->maxAgeMinutes = maxage;
+	else
+		state->maxAgeMinutes = -1;
+}
+
+gint
+update_state_get_cache_maxage (updateStatePtr state)
+{
+	return state->maxAgeMinutes;
+}
+
 const gchar *
 update_state_get_cookies (updateStatePtr state)
 {

--- a/src/update.h
+++ b/src/update.h
@@ -83,6 +83,7 @@ typedef struct updateState {
 	gint		maxAgeMinutes;		/**< default update interval, greatest value sourced from HTTP and XML */
 	gint		synFrequency;		/**< syn:updateFrequency */
 	gint		synPeriod;		/**< syn:updatePeriod */
+	gint		timeToLive;		/**< ttl */
 } *updateStatePtr;
 
 /** structure describing a HTTP update request */

--- a/src/update.h
+++ b/src/update.h
@@ -80,6 +80,7 @@ typedef struct updateState {
 	GTimeVal	lastFaviconPoll;	/**< time at which the feeds favicon was last updated */
 	gchar		*cookies;		/**< cookies to be used */	
 	gchar		*etag;			/**< ETag sent by the server */
+	gint		maxAgeMinutes;		/**< default update interval, greatest value sourced from HTTP and XML */
 } *updateStatePtr;
 
 /** structure describing a HTTP update request */
@@ -134,6 +135,9 @@ void update_state_set_lastmodified (updateStatePtr state, glong lastmodified);
 
 const gchar * update_state_get_etag (updateStatePtr state);
 void update_state_set_etag (updateStatePtr state, const gchar *etag);
+
+gint update_state_get_cache_maxage (updateStatePtr state);
+void update_state_set_cache_maxage (updateStatePtr state, const gint maxage);
 
 const gchar * update_state_get_cookies (updateStatePtr state);
 void update_state_set_cookies (updateStatePtr state, const gchar *cookies);

--- a/src/update.h
+++ b/src/update.h
@@ -81,6 +81,8 @@ typedef struct updateState {
 	gchar		*cookies;		/**< cookies to be used */	
 	gchar		*etag;			/**< ETag sent by the server */
 	gint		maxAgeMinutes;		/**< default update interval, greatest value sourced from HTTP and XML */
+	gint		synFrequency;		/**< syn:updateFrequency */
+	gint		synPeriod;		/**< syn:updatePeriod */
 } *updateStatePtr;
 
 /** structure describing a HTTP update request */


### PR DESCRIPTION
The Cache-Control: max-age header field contains the number of seconds a response  is considered fresh. This suggests a default update interval similar to syn:* and channel/ttl.

This implementation looks at syn:updatePeriod/updateFrequency, ttl, and maxage (minus any Age header); and uses the average suggested update time from all three time sources (whichever is set). Fixes an issue where syn namespace wasn’t used if updateFrequency appeared above updatePeriod in the feed (as it would in most alphanumerically sorted feeds).

A new 5 minute minimum suggested update interval is enforced.

The definition of syn:updateFrequency:monthly is changed from 31 to 30 days (much more common).

https://tools.ietf.org/html/rfc7234#section-5.2.2.8
https://tools.ietf.org/html/rfc7234#section-4.2.3

Resolves issue #259.