### PR TITLE
Fix redirect location updates, and add HTTP 308 (RFC 7538) support

### DIFF
--- a/src/subscription.c
+++ b/src/subscription.c
@@ -205,8 +205,8 @@ subscription_process_update_result (const struct updateResult * const result, gp
 
 	g_assert (subscription->updateJob);
 	/* update the subscription URL on permanent redirects */
-	if ((301 == result->httpstatus) && result->source && !g_str_equal (result->source, subscription->updateJob->request->source)) {
-		debug2 (DEBUG_UPDATE, "The URL of \"%s\" has changed permanently and was updated with \"%s\"", node_get_title(node), result->source);
+	if ((301 == result->returncode || 308 == result->returncode) && result->source && !g_str_equal (result->source, subscription->updateJob->request->source)) {
+		debug2 (DEBUG_UPDATE, "The URL of \"%s\" has changed permanently and was updated to \"%s\"", node_get_title(node), result->source);
 		subscription_set_source (subscription, result->source);
 		liferea_shell_set_status_bar (_("The URL of \"%s\" has changed permanently and was updated"), node_get_title(node));
 	}


### PR DESCRIPTION
New `network_process_redirect_callback` handles updating source locations for HTTP 301 and 308 permanent redirects. There are no practical differences between these two status codes for Liferea.

> This status code is similar to 301 (Moved Permanently) RFC7231, Section 6.4.2, except that it does not allow changing the request method from POST to GET.

https://tools.ietf.org/html/rfc7538#section-3

This replaces pull request #576.