### PR TITLE
Add aria2 and Transmission (Gtk) to the list of download tools

### DIFF
--- a/src/ui/preferences_dialog.c
+++ b/src/ui/preferences_dialog.c
@@ -73,11 +73,13 @@ static const gchar * enclosure_download_commands[] = {
 	"steadyflow add %s",
 	"dbus-send --session --print-reply --dest=org.gnome.gwget.ApplicationService /org/gnome/gwget/Gwget org.gnome.gwget.Application.OpenURI string:%s uint32:0",
 	"kget %s",
-	"uget-gtk %s"
+	"uget-gtk %s",
+	"transmission-gtk %s",
+	"aria2 %s"
 };
 
 /** order must match enclosure_download_commands[] */
-static const gchar *enclosure_download_tool_options[] = { "steadyflow", "gwget", "kget", "uget", NULL };
+static const gchar *enclosure_download_tool_options[] = { "Steadyflow", "gwget", "KGet", "uGet", "Transmission (Gtk)", "aria2", NULL };
 
 /** GConf representation of toolbar styles */
 static const gchar * gui_toolbar_style_values[] = { "", "both", "both-horiz", "icons", "text", NULL };


### PR DESCRIPTION
Adds support for megalinks, Magnet URIs, BitTorrent, and other download descriptors. Both aria2 and Transmission are active and maintained projects.