### PR TITLE
Allow drag and drop reordering and save position of the date column

### DIFF
--- a/net.sf.liferea.gschema.xml.in
+++ b/net.sf.liferea.gschema.xml.in
@@ -232,6 +232,11 @@
       <summary>Send "Do Not Track" header</summary>
       <description>Configures wether the "DNT" header is to be sent. If enabled sends "DNT: 1", meaning Do Not Track.</description>
     </key>
+    <key name="last-date-column-pos" type="i">
+      <default>-1</default>
+      <summary>Date column position</summary>
+      <description>The position of the date column in the item list view. Automatically saved after being reordered by dragging. Default is last.</description>
+    </key>
 
   </schema>
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -67,6 +67,7 @@
 #define LAST_WPANE_POS			"last-wpane-pos"
 #define LAST_ZOOMLEVEL			"last-zoomlevel"
 #define LAST_NODE_SELECTED		"last-node-selected"
+#define LAST_DATE_COLUMN_POS 		"last-date-column-pos"
 
 /* networking settings */
 #define PROXY_DETECT_MODE		"proxy-detect-mode"

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -31,6 +31,7 @@
 
 #include "browser.h"
 #include "common.h"
+#include "conf.h"
 #include "date.h"
 #include "debug.h"
 #include "feed.h"
@@ -644,6 +645,22 @@ on_item_list_view_query_tooltip (GtkWidget *widget, gint x, gint y, gboolean key
 	return ret;
 }
 
+static void
+on_item_list_view_columns_changed_event (GtkTreeView *treeview, GtkTreeViewColumn *date_column)
+{
+	int	current_date_col_pos;
+	GList	*columns;
+
+	/* Drag and drop reordering only happens with full column list, currently 5 */
+	if (gtk_tree_view_get_n_columns(treeview) != 5)
+		return;
+
+	columns = gtk_tree_view_get_columns (treeview);
+	current_date_col_pos = g_list_index (columns, date_column);
+	conf_set_int_value (LAST_DATE_COLUMN_POS, current_date_col_pos);
+	g_list_free (columns);
+}
+
 static gboolean
 on_item_list_view_button_press_event (GtkWidget *treeview, GdkEventButton *event, gpointer user_data)
 {
@@ -765,6 +782,7 @@ item_list_view_create (gboolean wide)
 	ItemListView		*ilv;
 	GtkCellRenderer		*renderer;
 	GtkTreeViewColumn 	*column, *headline_column;
+	int			date_column_pos = -1;
 
 	ilv = g_object_new (ITEM_LIST_VIEW_TYPE, NULL);
 	ilv->priv->wideView = wide;
@@ -837,12 +855,15 @@ item_list_view_create (gboolean wide)
 	                                                   "weight", ITEMSTORE_WEIGHT,
 							   NULL);
 	gtk_tree_view_column_set_sizing(column, GTK_TREE_VIEW_COLUMN_GROW_ONLY);
-	gtk_tree_view_append_column (ilv->priv->treeview, column);
+	conf_get_int_value(LAST_DATE_COLUMN_POS, &date_column_pos);
+	gtk_tree_view_insert_column (ilv->priv->treeview, column, date_column_pos);
+	g_object_set (column, "reorderable", TRUE, NULL);
 	gtk_tree_view_column_set_sort_column_id(column, IS_TIME);
 	if (wide)
 		gtk_tree_view_column_set_visible (column, FALSE);
 
 	/* And connect signals */
+	g_signal_connect (G_OBJECT (ilv->priv->treeview), "columns_changed", G_CALLBACK (on_item_list_view_columns_changed_event), column);
 	g_signal_connect (G_OBJECT (ilv->priv->treeview), "button_press_event", G_CALLBACK (on_item_list_view_button_press_event), ilv);
 	g_signal_connect (G_OBJECT (ilv->priv->treeview), "row_activated", G_CALLBACK (on_Itemlist_row_activated), ilv);
 	g_signal_connect (G_OBJECT (ilv->priv->treeview), "key-press-event", G_CALLBACK (on_item_list_view_key_press_event), ilv);

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -667,6 +667,7 @@ on_item_list_view_button_press_event (GtkWidget *treeview, GdkEventButton *event
 	ItemListView		*ilv = ITEM_LIST_VIEW (user_data);
 	GtkTreePath		*path;
 	GtkTreeIter		iter;
+	GtkTreeViewColumn	*column;
 	itemPtr			item = NULL;
 	gboolean		result = FALSE;
 
@@ -677,7 +678,7 @@ on_item_list_view_button_press_event (GtkWidget *treeview, GdkEventButton *event
 	if (event->window != gtk_tree_view_get_bin_window (ilv->priv->treeview))
 		return FALSE;
 
-	if (!gtk_tree_view_get_path_at_pos (ilv->priv->treeview, (gint)event->x, (gint)event->y, &path, NULL, NULL, NULL))
+	if (!gtk_tree_view_get_path_at_pos (ilv->priv->treeview, (gint)event->x, (gint)event->y, &path, &column, NULL, NULL))
 		return FALSE;
 
 	if (gtk_tree_model_get_iter (gtk_tree_view_get_model (ilv->priv->treeview), &iter, path))
@@ -689,21 +690,9 @@ on_item_list_view_button_press_event (GtkWidget *treeview, GdkEventButton *event
 		GdkEventButton *eb = (GdkEventButton*)event;
 		switch (eb->button) {
 			case 1:
-				/* Allow flag toggling when left clicking in the
-				   state or favicon column. We depend
-				   on the fact that those columns are all left
-				   of the headline column !!! */
-				if(gtk_tree_view_column_get_visible (ilv->priv->faviconColumn)){
-					if (event->x <= (gtk_tree_view_column_get_width (ilv->priv->faviconColumn))) {
-						itemlist_toggle_flag (item);
-						result = TRUE;
-					}
-				}
-				else{
-					if (event->x <= (gtk_tree_view_column_get_width (ilv->priv->stateColumn))) {
-						itemlist_toggle_flag (item);
-						result = TRUE;
-					}
+				if (column == ilv->priv->faviconColumn || column == ilv->priv->stateColumn) {
+					itemlist_toggle_flag (item);
+					result = TRUE;
 				}
 				break;
 			case 2:


### PR DESCRIPTION
New configuration option - last-date-column-pos,
updated on each drag and drop reordering of the date column.

an attempt to pacify the unrest in #579