### PR TITLE
appdata: Set the component type to desktop-application

### DIFF
--- a/liferea.appdata.xml.in
+++ b/liferea.appdata.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component>
+<component type="desktop-application">
   <id>net.sourceforge.liferea.desktop</id>
   <metadata_license>CC0</metadata_license>
   <name>Liferea</name>


### PR DESCRIPTION
Appstream spec says type must be set for desktop applications components
https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html

Fixes liferea showing up in current gnome-software