### PR TITLE
Fixes #602 CSS stylesheet not picking link colors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,9 @@ To be released
 	* #495: New command line option --disable-plugins (-p) to start
 	  with all plugins disabled.
 
+	* Fixes #602: CSS style for GTK link colors not used
+	  (reported by pupyc)
+
 	* #594: Update of Polish default feed list
 	  (wmyrda)
 	* #584: Fixes broken OPML feed list entries

--- a/src/render.c
+++ b/src/render.c
@@ -237,7 +237,7 @@ render_init_theme_colors (GtkWidget *widget)
 
 	gtk_style_context_get_color (sctxt, GTK_STATE_FLAG_LINK, &rgba);
 	rgba_to_color (&color, &rgba);
-	themeColors = g_slist_append (themeColors, render_calculate_theme_color ("GTK-COLOR-LINK", color));
+	themeColors = g_slist_append (themeColors, render_calculate_theme_color ("GTK-COLOR-NORMAL-LINK", color));
 
 	gtk_style_context_get_color (sctxt, GTK_STATE_FLAG_VISITED, &rgba);
 	rgba_to_color (&color, &rgba);


### PR DESCRIPTION
Directly extracting link-color and visited-link-color from GtkStyle seems to have been broken since a while.

Partially migrates color extraction to GtkStyleContext. Fully migrating doesn't seem to be possible as light and dark styles are not exposed by GtkStyleContext as far as I understand it. Might become a problem in GTK4