### PR TITLE
Allow dnd item list view column reorder

### DIFF
--- a/plugins/trayicon.py
+++ b/plugins/trayicon.py
@@ -108,10 +108,12 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
         self.menu.show_all()
 
         self.window = self.shell.get_window()
-        self.minimize_to_tray_delete_handler = self.window.connect("delete_event",
-                                                                   self.trayicon_minimize_on_close)
-        self.minimize_to_tray_minimize_handler = self.window.connect("window-state-event",
-                                                                     self.window_state_event_cb)
+        self.delete_signal_id = GObject.signal_lookup("delete_event", Gtk.Window)
+        GObject.signal_handlers_block_matched (self.window,
+                                               GObject.SignalMatchType.ID | GObject.SignalMatchType.DATA,
+                                               self.delete_signal_id, 0, None, None, None)
+        self.window.connect("delete_event", self.trayicon_minimize_on_close)
+        self.window.connect("window-state-event", self.window_state_event_cb)
 
         # show the window if it is hidden when starting liferea
         self.window.deiconify()
@@ -133,7 +135,7 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
         self.window.deiconify()
         self.window.show()
 
-    def trayicon_minimize_on_close(self, widget, data = None):
+    def trayicon_minimize_on_close(self, widget, event):
         self.window.hide()
         return True
 
@@ -186,8 +188,11 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
 
     def do_deactivate(self):
         self.staticon.set_visible(False)
-        self.window.disconnect(self.minimize_to_tray_delete_handler)
-        self.window.disconnect(self.minimize_to_tray_minimize_handler)
+        self.window.disconnect_by_func(self.trayicon_minimize_on_close)
+        GObject.signal_handlers_unblock_matched (self.window,
+                                                 GObject.SignalMatchType.ID | GObject.SignalMatchType.DATA,
+                                                 self.delete_signal_id, 0, None,None,None)
+        self.window.disconnect_by_func(self.window_state_event_cb)
 
         self.feedlist.disconnect(self.feedlist_new_items_cb_id)
 

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -732,7 +732,6 @@ on_item_list_row_activated (GtkTreeView *treeview,
 static void
 on_item_list_view_columns_changed (GtkTreeView *treeview, ItemListView *ilv)
 {
-	gint n = gtk_tree_view_get_n_columns(treeview);
 	gint i = 0;
 	GList *columns;
 	GHashTableIter iter;
@@ -742,20 +741,20 @@ on_item_list_view_columns_changed (GtkTreeView *treeview, ItemListView *ilv)
 	/* This handler is only used for drag and drop reordering, so it
 	   should not be hooked up with less than the full number of columns
 	   eg: on item_list_view creation or teardown */
-	g_return_if_fail (n == 5);
+	g_return_if_fail (gtk_tree_view_get_n_columns(treeview) == 5);
 
 	columns = gtk_tree_view_get_columns (treeview);
 	for (GList *li = columns; li; li = li->next) {
 		g_hash_table_iter_init (&iter, ilv->priv->columns);
 		while (g_hash_table_iter_next (&iter, &colname, &colptr)) {
 			if (li->data == colptr) {
-				strv[i++] = g_strdup (colname);
+				strv[i++] = colname;
 				strv[i] = NULL;
 				break;
 			}
 		}
 	}
-	conf_set_strv_value (LIST_VIEW_COLUMN_ORDER, &strv);
+	conf_set_strv_value (LIST_VIEW_COLUMN_ORDER, strv);
 
 	g_list_free (columns);
 }
@@ -790,7 +789,7 @@ item_list_view_create (gboolean wide)
 	ItemListView		*ilv;
 	GtkCellRenderer		*renderer;
 	GtkTreeViewColumn 	*column, *headline_column;
-	gchar			**conf_column_order, **li;
+	gchar			**conf_column_order;
 
 	ilv = g_object_new (ITEM_LIST_VIEW_TYPE, NULL);
 	ilv->priv->wideView = wide;
@@ -867,7 +866,7 @@ item_list_view_create (gboolean wide)
 		gtk_tree_view_column_set_visible (column, FALSE);
 
 	conf_get_strv_value (LIST_VIEW_COLUMN_ORDER, &conf_column_order);
-	for (li = conf_column_order; *li; *li++) {
+	for (gchar **li = conf_column_order; *li; li++) {
 		column = g_hash_table_lookup (ilv->priv->columns, *li);
 		g_object_set (column, "reorderable", TRUE, NULL);
 		gtk_tree_view_append_column (ilv->priv->treeview, column);

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -142,6 +142,8 @@ item_list_view_finalize (GObject *object)
 	/* Disconnect the treeview signals to avoid spurious calls during teardown */
 	g_signal_handlers_disconnect_by_data (G_OBJECT (priv->treeview), object);
 
+	g_hash_table_destroy (priv->columns);
+
 	g_slist_free (priv->item_ids);
 	if (priv->batch_itemstore)
 		g_object_unref (priv->batch_itemstore);

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -139,6 +139,9 @@ item_list_view_finalize (GObject *object)
 {
 	ItemListViewPrivate *priv = ITEM_LIST_VIEW_GET_PRIVATE (object);
 
+	/* Disconnect the treeview signals to avoid spurious calls during teardown */
+	g_signal_handlers_disconnect_by_data (G_OBJECT (priv->treeview), object);
+
 	g_slist_free (priv->item_ids);
 	if (priv->batch_itemstore)
 		g_object_unref (priv->batch_itemstore);
@@ -724,6 +727,37 @@ on_item_list_row_activated (GtkTreeView *treeview,
 	}
 }
 
+static void
+on_item_list_view_columns_changed (GtkTreeView *treeview, ItemListView *ilv)
+{
+	gint n = gtk_tree_view_get_n_columns(treeview);
+	gint i = 0;
+	GList *columns;
+	GHashTableIter iter;
+	gpointer colname, colptr;
+	gchar *strv[6];
+
+	/* This handler is only used for drag and drop reordering, so it
+	   should not be hooked up with less than the full number of columns
+	   eg: on item_list_view creation or teardown */
+	g_return_if_fail (n == 5);
+
+	columns = gtk_tree_view_get_columns (treeview);
+	for (GList *li = columns; li; li = li->next) {
+		g_hash_table_iter_init (&iter, ilv->priv->columns);
+		while (g_hash_table_iter_next (&iter, &colname, &colptr)) {
+			if (li->data == colptr) {
+				strv[i++] = g_strdup (colname);
+				strv[i] = NULL;
+				break;
+			}
+		}
+	}
+	conf_set_strv_value (LIST_VIEW_COLUMN_ORDER, &strv);
+
+	g_list_free (columns);
+}
+
 GtkWidget *
 item_list_view_get_widget (ItemListView *ilv)
 {
@@ -831,13 +865,16 @@ item_list_view_create (gboolean wide)
 		gtk_tree_view_column_set_visible (column, FALSE);
 
 	conf_get_strv_value (LIST_VIEW_COLUMN_ORDER, &conf_column_order);
-	li = conf_column_order;
-	while (*li)
-		gtk_tree_view_append_column (ilv->priv->treeview, g_hash_table_lookup (ilv->priv->columns, *li++));
+	for (li = conf_column_order; *li; *li++) {
+		column = g_hash_table_lookup (ilv->priv->columns, *li);
+		g_object_set (column, "reorderable", TRUE, NULL);
+		gtk_tree_view_append_column (ilv->priv->treeview, column);
+	}
 	g_strfreev (conf_column_order);
 
 	/* And connect signals */
 	g_signal_connect (G_OBJECT (ilv->priv->treeview), "button_press_event", G_CALLBACK (on_item_list_view_button_press_event), ilv);
+	g_signal_connect (G_OBJECT (ilv->priv->treeview), "columns_changed", G_CALLBACK (on_item_list_view_columns_changed), ilv);
 	g_signal_connect (G_OBJECT (ilv->priv->treeview), "row_activated", G_CALLBACK (on_item_list_row_activated), ilv);
 	g_signal_connect (G_OBJECT (ilv->priv->treeview), "key-press-event", G_CALLBACK (on_item_list_view_key_press_event), ilv);
 	g_signal_connect (G_OBJECT (ilv->priv->treeview), "popup_menu", G_CALLBACK (on_item_list_view_popup_menu), ilv);

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -1186,7 +1186,7 @@ liferea_shell_create (GtkApplication *app, const gchar *overrideWindowState, gin
 	g_signal_connect ((gpointer) liferea_shell_lookup ("itemtabs"), "scroll_event",
 	                  G_CALLBACK (on_notebook_scroll_event_null_cb), NULL);
 	
-	g_signal_connect (G_OBJECT (shell->priv->window), "delete_event", G_CALLBACK(on_close), shell->priv);
+	g_signal_connect (G_OBJECT (shell->priv->window), "delete_event", G_CALLBACK(on_close), NULL);
 	g_signal_connect (G_OBJECT (shell->priv->window), "window_state_event", G_CALLBACK(on_window_state_event), shell->priv);
 	g_signal_connect (G_OBJECT (shell->priv->window), "key_press_event", G_CALLBACK(on_key_press_event), shell->priv);
 	

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -569,10 +569,6 @@ on_notebook_scroll_event_null_cb (GtkWidget *widget, GdkEventScroll *event)
 static gboolean
 on_close (GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
-	guint signal_id = g_signal_lookup ("delete_event",  GTK_TYPE_WINDOW);
-
-	if (g_signal_has_handler_pending(widget, signal_id, (GQuark) 0, TRUE))
-		return FALSE;
 	liferea_shutdown ();
 	return TRUE;
 }


### PR DESCRIPTION
So as continuation of #587 and #589  allow column reordering by drag and drop.
Save the order in the setting introduced in #589 

The are two commits here. The first one is the reorder patch.
The second one is a cleanup of liferea shutdown on window close button, someone that can use the trayicon plugin should probably check that it does what it means