### PR TITLE
Adds settings for custom download command, Fixes #575

### DIFF
--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.20.4 -->
 <interface>
   <requires lib="gtk+" version="3.14"/>
   <object class="GtkAdjustment" id="adjustment2">
@@ -12,24 +12,6 @@
     <property name="upper">1000000</property>
     <property name="value">1</property>
     <property name="step_increment">1</property>
-  </object>
-  <object class="GtkListStore" id="liststore1">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
-  </object>
-  <object class="GtkListStore" id="liststore2">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
-  </object>
-  <object class="GtkListStore" id="liststore3">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
   </object>
   <object class="GtkDialog" id="prefs">
     <property name="visible">True</property>
@@ -278,7 +260,6 @@
                       <object class="GtkComboBox" id="globalRefreshIntervalUnitComboBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="model">liststore5</property>
                         <child>
                           <object class="GtkCellRendererText" id="cellrenderertext5"/>
                           <attributes>
@@ -505,7 +486,6 @@
                       <object class="GtkComboBox" id="skimKeyCombo">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="model">liststore3</property>
                         <child>
                           <object class="GtkCellRendererText" id="cellrenderertext3"/>
                           <attributes>
@@ -522,7 +502,6 @@
                       <object class="GtkComboBox" id="defaultViewModeCombo">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="model">liststore3</property>
                         <child>
                           <object class="GtkCellRendererText" id="cellrenderertext4"/>
                           <attributes>
@@ -872,7 +851,6 @@
                   <object class="GtkComboBox" id="toolbarCombo">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="model">liststore2</property>
                     <child>
                       <object class="GtkCellRendererText" id="cellrenderertext2"/>
                       <attributes>
@@ -1279,7 +1257,7 @@
                       <packing>
                         <property name="left_attach">0</property>
                         <property name="top_attach">0</property>
-                        <property name="width">2</property>
+                        <property name="width">3</property>
                       </packing>
                     </child>
                     <child>
@@ -1297,10 +1275,56 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkRadioButton" id="predefinedDownload">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_enclosure_download_predefined_toggled" swapped="no"/>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="customDownload">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">predefinedDownload</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">&lt;small&gt;(%s for URL)&lt;/small&gt;</property>
+                        <property name="use_markup">True</property>
+                        <property name="xalign">1</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkComboBox" id="downloadToolCombo">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="model">liststore1</property>
                         <child>
                           <object class="GtkCellRendererText" id="cellrenderertext1"/>
                           <attributes>
@@ -1309,8 +1333,20 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
+                        <property name="left_attach">2</property>
                         <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="customDownloadEntry">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="placeholder_text" translatable="yes">custom-command %s</property>
+                        <signal name="changed" handler="on_enclosure_download_custom_command_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">2</property>
+                        <property name="top_attach">2</property>
                       </packing>
                     </child>
                   </object>
@@ -1475,11 +1511,8 @@
     <action-widgets>
       <action-widget response="-7">prefclosebtn</action-widget>
     </action-widgets>
-  </object>
-  <object class="GtkListStore" id="liststore5">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
+    <child>
+      <placeholder/>
+    </child>
   </object>
 </interface>

--- a/net.sf.liferea.gschema.xml.in
+++ b/net.sf.liferea.gschema.xml.in
@@ -122,10 +122,20 @@
       <summary>Filter feeds without unread items from feed list.</summary>
       <description>If this option is enabled the feed list will contain only feeds that have unread items.</description>
     </key>
+    <key name="download-custom-command" type="s">
+      <default>''</default>
+      <summary>Custom download command.</summary>
+      <description>A command used to download enclosures if download-use-custom-command is true. %s in the command will be replaced by the URL.</description>
+    </key>
     <key name="download-tool" type="i">
       <default>0</default>
       <summary>Which tool to download enclosures.</summary>
       <description>This options determines which download tool Liferea uses to download enclosures (0 = steadyflow, 1 = gwget, 2=kget).</description>
+    </key>
+    <key name="download-use-custom-command" type="b">
+      <default>false</default>
+      <summary>Whether to use the custom command or one of the predefined command.</summary>
+      <description>Set to true to use the command defined in download-custom-command, false to use the predefined command set in download-tool.</description>
     </key>
     <key name="proxy-detect-mode" type="i">
       <default>0</default>

--- a/src/conf.h
+++ b/src/conf.h
@@ -41,7 +41,9 @@
 #define ENABLE_PLUGINS			"enable-plugins"
 
 /* enclosure handling */
+#define DOWNLOAD_CUSTOM_COMMAND 	"download-custom-command"
 #define DOWNLOAD_TOOL			"download-tool"
+#define DOWNLOAD_USE_CUSTOM_COMMAND	"download-use-custom-command"
 
 /* feed handling settings */
 #define DEFAULT_MAX_ITEMS		"maxitemcount"

--- a/src/enclosure.c
+++ b/src/enclosure.c
@@ -286,7 +286,7 @@ enclosure_download (encTypePtr type, const gchar *url, gboolean interactive)
 		debug2 (DEBUG_UPDATE, "passing URL %s to command %s...", urlQ, type->cmd);
 		cmd = g_strdup_printf ("%s %s", type->cmd, urlQ);
 	} else {
-		const gchar *toolCmd = prefs_get_download_command ();
+		gchar *toolCmd = prefs_get_download_command ();
 		if(!toolCmd) {
 			if (interactive)
 				ui_show_error_box (_("You have not configured a download tool yet! Please do so in the 'Enclosures' tab in Tools/Preferences."));
@@ -295,6 +295,7 @@ enclosure_download (encTypePtr type, const gchar *url, gboolean interactive)
 
 		debug2 (DEBUG_UPDATE, "downloading URL %s with %s...", urlQ, toolCmd);
 		cmd = g_strdup_printf (toolCmd, urlQ);
+		g_free (toolCmd);
 	}
 
 	g_free (urlQ);

--- a/src/ui/preferences_dialog.h
+++ b/src/ui/preferences_dialog.h
@@ -54,11 +54,11 @@ struct PreferencesDialogClass
 GType preferences_dialog_get_type	(void);
 
 /**
- * Returns a download tool definition.
+ * prefs_get_download_command:
  *
- * @return the download command definition
+ * Returns: (transfer full): The download command.
  */
-const gchar * prefs_get_download_command (void);
+gchar * prefs_get_download_command (void);
 
 /**
  * Show the preferences dialog.
@@ -77,6 +77,8 @@ void on_enableplugins_toggled (GtkToggleButton *togglebutton, gpointer user_data
 void on_itemCountBtn_value_changed (GtkSpinButton *spinbutton, gpointer user_data);
 void on_default_update_interval_value_changed (GtkSpinButton *spinbutton, gpointer user_data);
 void on_useProxyAuth_toggled (GtkToggleButton *button, gpointer user_data);
+void on_enclosure_download_custom_command_changed (GtkEditable *entry, gpointer user_data);
+void on_enclosure_download_predefined_toggled (GtkToggleButton *button, gpointer user_data);
 void on_enc_action_change_btn_clicked (GtkButton *button, gpointer user_data);
 void on_enc_action_remove_btn_clicked (GtkButton *button, gpointer user_data);
 void on_hidetoolbar_toggled (GtkToggleButton *button, gpointer user_data);


### PR DESCRIPTION
This adds radio buttons and an entry for a custom download command. I didn't put a file explorer because it is simpler for us and allows more complex commands if users add the `%s` for the URL anywhere in the command (like for the custom browser command).

I also removed the unused liststores from the ui file (new ones are created and filled in prefs.c).

This should solve issues #575 and #624.