### PR TITLE
Fixes #645, #646: unread count of vfolder

### DIFF
--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -28,6 +28,7 @@
 #include "itemlist.h"
 #include "itemview.h"
 #include "node.h"
+#include "vfolder.h"
 #include "ui/ui_common.h"
 #include "ui/enclosure_list_view.h"
 #include "ui/liferea_shell.h"
@@ -327,7 +328,7 @@ itemview_update (void)
 	}
 
 	if (itemview->priv->node)
-		liferea_shell_update_allitems_actions (0 != itemview->priv->node->itemCount, 0 != itemview->priv->node->unreadCount);
+		liferea_shell_update_allitems_actions (0 != itemview->priv->node->itemCount, (0 != itemview->priv->node->unreadCount) || IS_VFOLDER (itemview->priv->node));
 }
 
 void

--- a/src/vfolder.c
+++ b/src/vfolder.c
@@ -253,13 +253,11 @@ static void vfolder_save (nodePtr node) { }
 static void
 vfolder_update_counters (nodePtr node) 
 {
-	/* There is no unread handling for search folders for performance reasons.
-	   Still the unread count controls menu/toolbar sensitivity. So as a
-	   workaround (see github#280) we set the number to 1 and rely on it
-	   being rendered nowhere (currently we always render the item counter
-	   for search folders in the feed list treeview) */
+	/* There is no unread handling for search folders for performance
+	 * reasons.So set everything to 0 here and don't bother with GUI
+	 * updates... */
 	node->needsUpdate = TRUE;
-	node->unreadCount = 1;
+	node->unreadCount = 0;
 	node->itemCount = db_search_folder_get_item_count (node->id);
 }
 


### PR DESCRIPTION
The workaround for #280 in 8923577a9573c74c3a412fab1dba01c6626b4434 was
causing an infinite loop in `feedlist_unread_scan` (the assert that
should have stopped it doesn't work because `scanState` is equal to
`UNREAD_SCAN_FOUND_SELECTED` at that point).

This is a different workaround to keep "Mark all as read" enabled for
vfolders.

I hope I'm not breaking anything else by setting that unreadCount back to zero :)

Edit: This fixes #645 and #646 not #245 and #246 ... I knew I was breaking *something* :)