### PR TITLE
Fixing unread item count for remote sources, #557

### DIFF
--- a/src/itemset.c
+++ b/src/itemset.c
@@ -29,6 +29,7 @@
 #include "feed.h"
 #include "itemlist.h"
 #include "itemset.h"
+#include "item_state.h"
 #include "metadata.h"
 #include "node.h"
 #include "rule.h"
@@ -180,9 +181,9 @@ itemset_generic_merge_check (GList *items, itemPtr newItem, gint maxChecks, gboo
 					/* To avoid notification spam from external
 					   sources: never set read items to unread again! */
 					if ((!oldItem->readStatus) && (newItem->readStatus))
-						oldItem->readStatus = newItem->readStatus;
+						item_read_state_changed (oldItem, newItem->readStatus);
 
-					oldItem->flagStatus = newItem->flagStatus;
+					item_flag_state_changed (oldItem, newItem->flagStatus);
 				}
 				
 				db_item_update (oldItem);


### PR DESCRIPTION
When merging received items with the existing list, if the item state
has changed in the remote source, the new state is directly assigned to
the existing item.

This replaces the direct assignment with calls to
`item_read_state_changed`, `item_flag_state_changed` which performs
related operations like updating the unread count.

This should fix #557.