### PR TITLE
Let normal view have an horizontal scrollbar, Fixes #549

### DIFF
--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -801,10 +801,7 @@ item_list_view_create (gboolean wide)
 	g_object_ref_sink (ilv->priv->ilscrolledwindow);
 	gtk_widget_show (ilv->priv->ilscrolledwindow);
 
-	if (wide)
-		gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (ilv->priv->ilscrolledwindow), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-	else
-		gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (ilv->priv->ilscrolledwindow), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (ilv->priv->ilscrolledwindow), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 	gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (ilv->priv->ilscrolledwindow), GTK_SHADOW_IN);
 
 	ilv->priv->treeview = GTK_TREE_VIEW (gtk_tree_view_new ());


### PR DESCRIPTION
This fixes #549 by having an horizontal scrollbar in the item list in normal view, that way the widget size doesn't grow "out" of the window and the vertical scrollbar stays on the side.

@lwindolf I don't know if you want to solve it this way, but I'm posting it here in case people want to use it while waiting for a better solution.