### PR TITLE
Change headerbar mark-read button to act on selected feed, not all feeds

### DIFF
--- a/plugins/headerbar.py
+++ b/plugins/headerbar.py
@@ -66,7 +66,7 @@ class HeaderBarPlugin (GObject.Object, Liferea.ShellActivatable):
         icon = Gio.ThemedIcon(name="emblem-ok-symbolic")
         image = Gtk.Image.new_from_gicon(icon, Gtk.IconSize.BUTTON)
         button.add(image)
-        button.set_action_name("app.mark-all-feeds-read")
+        button.set_action_name("app.mark-selected-feed-as-read")
         box.add(button)
 
         self.hb.pack_start(box)


### PR DESCRIPTION
Addresses #685, which is about consistency with the non-headerbar version of the button.

