### PR TITLE
Webkit Widget : replace deprecated GdkScreen functions for font size

### DIFF
--- a/src/webkit/webkit.c
+++ b/src/webkit/webkit.c
@@ -1,7 +1,7 @@
 /**
  * @file webkit.c  WebKit2 browser module for Liferea
  *
- * Copyright (C) 2016 Leiaz <leiaz@free.fr>
+ * Copyright (C) 2016-2019 Leiaz <leiaz@free.fr>
  * Copyright (C) 2007-2010 Lars Windolf <lars.windolf@gmx.de>
  * Copyright (C) 2008 Lars Strojny <lars@strojny.net>
  * Copyright (C) 2009-2012 Emilio Pozuelo Monfort <pochu27@gmail.com>

--- a/src/webkit/webkit.c
+++ b/src/webkit/webkit.c
@@ -151,33 +151,40 @@ liferea_webkit_enable_plugins_cb (GSettings *gsettings,
 /* Font size math from Epiphany embed/ephy-embed-prefs.c to get font size in
  * pixels according to actual screen dpi. */
 static gdouble
-get_screen_dpi (GdkScreen *screen)
+get_screen_dpi (GdkMonitor *monitor)
 {
 	gdouble dpi;
 	gdouble dp, di;
+	GdkRectangle rect;
 
-	dpi = gdk_screen_get_resolution (screen);
-	if (dpi != -1)
-		return dpi;
-
-	dp = hypot (gdk_screen_get_width (screen), gdk_screen_get_height (screen));
-	di = hypot (gdk_screen_get_width_mm (screen), gdk_screen_get_height_mm (screen)) / 25.4;
+	gdk_monitor_get_workarea (monitor, &rect);
+	dp = hypot (rect.width, rect.height);
+	di = hypot (gdk_monitor_get_width_mm (monitor), gdk_monitor_get_height_mm (monitor)) / 25.4;
 
 	return dp / di;
 }
 
 static guint
-normalize_font_size (gdouble font_size)
+normalize_font_size (gdouble font_size, GtkWidget *widget)
 {
 	/* WebKit2 uses font sizes in pixels. */
+	GdkDisplay *display;
+	GdkMonitor *monitor;
 	GdkScreen *screen;
 	gdouble dpi;
 
-	/* FIXME: We should use the view screen instead of the detault one
-	 * but we don't have access to the view here.
-	 */
-	screen = gdk_screen_get_default ();
-	dpi = screen ? get_screen_dpi (screen) : 96;
+	display = gtk_widget_get_display (widget);
+	screen = gtk_widget_get_screen (widget);
+	monitor = gdk_display_get_monitor_at_window (display, gtk_widget_get_window (widget));
+
+	if (screen) {
+		dpi = gdk_screen_get_resolution (screen);
+		if (dpi == -1)
+			dpi = get_screen_dpi(monitor);
+
+	}
+	else
+		dpi = 96;
 
 	return font_size / 72.0 * dpi;
 }
@@ -373,37 +380,12 @@ static void
 liferea_webkit_impl_init (LifereaWebKitImpl *self)
 {
 	gboolean	disable_javascript, enable_plugins;
-	gchar		*font;
-	guint		fontSize;
 	WebKitSecurityManager *security_manager;
 	self->dbus_connections = NULL;
 	self->settings = webkit_settings_new ();
-	font = webkit_get_font (&fontSize);
 
 	security_manager = webkit_web_context_get_security_manager (webkit_web_context_get_default ());
 	webkit_security_manager_register_uri_scheme_as_local (security_manager, "liferea");
-
-	if (font) {
-		g_object_set (
-			self->settings,
-			"default-font-family",
-			font,
-			NULL
-		);
-		g_object_set (
-			self->settings,
-			"default-font-size",
-			normalize_font_size (fontSize),
-			NULL
-		);
-		g_free (font);
-	}
-	g_object_set (
-		self->settings,
-		"minimum-font-size",
-		normalize_font_size (7),
-		NULL
-	);
 	conf_get_bool_value (DISABLE_JAVASCRIPT, &disable_javascript);
 	g_object_set (
 		self->settings,
@@ -485,6 +467,45 @@ liferea_webkit_write_html (
 	g_bytes_unref (string_bytes);
 }
 
+static void
+liferea_webkit_set_font_size (GtkWidget *widget, gpointer user_data)
+{
+	gchar		*font;
+	guint		fontSize;
+
+	if (!gtk_widget_get_realized (widget))
+		return;
+
+	font = webkit_get_font (&fontSize);
+
+	if (font) {
+		g_object_set (
+			liferea_webkit_impl->settings,
+			"default-font-family",
+			font,
+			NULL
+		);
+		g_object_set (
+			liferea_webkit_impl->settings,
+			"default-font-size",
+			normalize_font_size (fontSize, widget),
+			NULL
+		);
+		g_free (font);
+	}
+	g_object_set (
+		liferea_webkit_impl->settings,
+		"minimum-font-size",
+		normalize_font_size (7, widget),
+		NULL
+	);
+}
+
+static void
+liferea_webkit_screen_changed (GtkWidget *widget, GdkScreen *previous_screen, gpointer user_data)
+{
+	liferea_webkit_set_font_size (widget, user_data);
+}
 /**
  * Initializes WebKit
  *
@@ -512,6 +533,9 @@ liferea_webkit_new (LifereaHtmlView *htmlview)
 		"htmlview",
 		htmlview
 	);
+
+	g_signal_connect (G_OBJECT (view), "screen_changed", G_CALLBACK (liferea_webkit_screen_changed), NULL);
+	g_signal_connect (G_OBJECT (view), "realize", G_CALLBACK (liferea_webkit_set_font_size), NULL);
 
 	gtk_widget_show (GTK_WIDGET (view));
 	return GTK_WIDGET (view);


### PR DESCRIPTION
This replaces deprecated gdk_screen_get_width/height.

I connect both the "realize" and "screen-changed" signals because "screen-changed" is emitted when the widget doesn't have a GdkWindow set yet (is not realized yet). The idea is to handle both setting the font at boot and when changing screen when running.

I have only one low dpi screen so I didn't test completely.