### PR TITLE
Replaces deprecated gtk_menu_popup

### DIFF
--- a/src/ui/enclosure_list_view.c
+++ b/src/ui/enclosure_list_view.c
@@ -97,7 +97,7 @@ enclosure_list_view_get_selected_enclosure (EnclosureListView *elv, GtkTreeIter 
 }
 
 static gboolean
-on_enclosure_list_button_press (GtkWidget *treeview, GdkEventButton *event, gpointer user_data)
+on_enclosure_list_button_press (GtkWidget *treeview, GdkEvent *event, gpointer user_data)
 {
 	GdkEventButton		*eb = (GdkEventButton *)event;
 	GtkTreePath		*path;
@@ -108,14 +108,14 @@ on_enclosure_list_button_press (GtkWidget *treeview, GdkEventButton *event, gpoi
 		return FALSE;
 
 	/* avoid handling header clicks */
-	if (event->window != gtk_tree_view_get_bin_window (GTK_TREE_VIEW (treeview)))
+	if (eb->window != gtk_tree_view_get_bin_window (GTK_TREE_VIEW (treeview)))
 		return FALSE;
 
-	if (!gtk_tree_view_get_path_at_pos (GTK_TREE_VIEW (treeview), (gint)event->x, (gint)event->y, &path, NULL, NULL, NULL))
+	if (!gtk_tree_view_get_path_at_pos (GTK_TREE_VIEW (treeview), (gint)eb->x, (gint)eb->y, &path, NULL, NULL, NULL))
 		return FALSE;
 
 	if (gtk_tree_model_get_iter (GTK_TREE_MODEL (elv->treestore), &iter, path))
-		ui_popup_enclosure_menu (enclosure_list_view_get_selected_enclosure (elv, &iter), eb->button, eb->time);
+		ui_popup_enclosure_menu (enclosure_list_view_get_selected_enclosure (elv, &iter), event);
 
 	return TRUE;
 }
@@ -129,7 +129,7 @@ on_enclosure_list_popup_menu (GtkWidget *widget, gpointer user_data)
 	EnclosureListView 	*elv = (EnclosureListView *)user_data;
 
 	if (gtk_tree_selection_get_selected (gtk_tree_view_get_selection (treeview), &model, &iter)) {
-		ui_popup_enclosure_menu (enclosure_list_view_get_selected_enclosure (elv, &iter), 3, 0);
+		ui_popup_enclosure_menu (enclosure_list_view_get_selected_enclosure (elv, &iter), NULL);
 		return TRUE;
 	}
 

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -637,23 +637,26 @@ on_item_list_view_query_tooltip (GtkWidget *widget, gint x, gint y, gboolean key
 }
 
 static gboolean
-on_item_list_view_button_press_event (GtkWidget *treeview, GdkEventButton *event, gpointer user_data)
+on_item_list_view_button_press_event (GtkWidget *treeview, GdkEvent *event, gpointer user_data)
 {
 	ItemListView		*ilv = ITEM_LIST_VIEW (user_data);
 	GtkTreePath		*path;
 	GtkTreeIter		iter;
 	GtkTreeViewColumn	*column;
+	GdkEventButton 		*eb;
 	itemPtr			item = NULL;
 	gboolean		result = FALSE;
 
 	if (event->type != GDK_BUTTON_PRESS)
 		return FALSE;
 
+	eb = (GdkEventButton*) event;
+
 	/* avoid handling header clicks */
-	if (event->window != gtk_tree_view_get_bin_window (ilv->treeview))
+	if (eb->window != gtk_tree_view_get_bin_window (ilv->treeview))
 		return FALSE;
 
-	if (!gtk_tree_view_get_path_at_pos (ilv->treeview, (gint)event->x, (gint)event->y, &path, &column, NULL, NULL))
+	if (!gtk_tree_view_get_path_at_pos (ilv->treeview, (gint)eb->x, (gint)eb->y, &path, &column, NULL, NULL))
 		return FALSE;
 
 	if (gtk_tree_model_get_iter (gtk_tree_view_get_model (ilv->treeview), &iter, path))
@@ -662,7 +665,6 @@ on_item_list_view_button_press_event (GtkWidget *treeview, GdkEventButton *event
 	gtk_tree_path_free (path);
 
 	if (item) {
-		GdkEventButton *eb = (GdkEventButton*)event;
 		switch (eb->button) {
 			case 1:
 				if (column == g_hash_table_lookup(ilv->columns, "favicon") ||
@@ -677,7 +679,7 @@ on_item_list_view_button_press_event (GtkWidget *treeview, GdkEventButton *event
 				result = TRUE;
 				break;
 			case 3:
-				ui_popup_item_menu (item, eb->button, eb->time);
+				ui_popup_item_menu (item, event);
 				result = TRUE;
 				break;
 			default:
@@ -699,7 +701,7 @@ on_item_list_view_popup_menu (GtkWidget *widget, gpointer user_data)
 
 	if (gtk_tree_selection_get_selected (gtk_tree_view_get_selection (treeview), &model, &iter)) {
 		itemPtr item = item_load (item_list_view_iter_to_id (ITEM_LIST_VIEW (user_data), &iter));
-		ui_popup_item_menu (item, 3, 0);
+		ui_popup_item_menu (item, NULL);
 		item_unload (item);
 		return TRUE;
 	}

--- a/src/ui/popup_menu.c
+++ b/src/ui/popup_menu.c
@@ -43,21 +43,12 @@
 
 #define UI_POPUP_ITEM_IS_TOGGLE		1
 
-
 static void
-ui_popup_menu_at_pos (GtkWidget *menu, GtkMenuPositionFunc func, guint button, guint32 activate_time, gpointer user_data)
+ui_popup_menu (GtkWidget *menu, const GdkEvent *event)
 {
 	g_signal_connect_after (G_OBJECT(menu), "unmap-event", G_CALLBACK(gtk_widget_destroy), NULL);
-
 	gtk_widget_show_all (menu);
-
-	gtk_menu_popup (GTK_MENU(menu), NULL, NULL, func, user_data, button, activate_time);
-}
-
-static void
-ui_popup_menu (GtkWidget *menu, guint button, guint32 activate_time)
-{
-	ui_popup_menu_at_pos(menu, NULL, button, activate_time, NULL);
+	gtk_menu_popup_at_pointer (GTK_MENU(menu), event);
 }
 
 static GtkWidget*
@@ -92,7 +83,7 @@ static const GActionEntry ui_popup_item_gaction_entries[] = {
 };
 
 void
-ui_popup_item_menu (itemPtr item, guint button, guint32 activate_time)
+ui_popup_item_menu (itemPtr item, const GdkEvent *event)
 {
 	GtkWidget	*menu;
 	GMenu		*menu_model, *section;
@@ -196,12 +187,11 @@ ui_popup_item_menu (itemPtr item, guint button, guint32 activate_time)
 	/* The menu has to be attached to an application window or one of its children for access to app actions.*/
 	gtk_menu_attach_to_widget (GTK_MENU (menu), liferea_shell_lookup ("mainwindow"), NULL);
 	g_object_unref (menu_model);
-	ui_popup_menu (menu, button, activate_time);
+	ui_popup_menu (menu, event);
 }
 
 void
-ui_popup_enclosure_menu (enclosurePtr enclosure, guint button,
-			 guint32 activate_time)
+ui_popup_enclosure_menu (enclosurePtr enclosure, const GdkEvent *event)
 {
 	GtkWidget	*menu;
 
@@ -211,7 +201,7 @@ ui_popup_enclosure_menu (enclosurePtr enclosure, guint button,
 	ui_popup_add_menuitem (menu, _("Save As..."), on_popup_save_enclosure, enclosure, 0);
 	ui_popup_add_menuitem (menu, _("Copy Link Location"), on_popup_copy_enclosure, enclosure, 0);
 
-	ui_popup_menu (menu, button, activate_time);
+	ui_popup_menu (menu, event);
 }
 
 /* popup callback wrappers */
@@ -264,7 +254,7 @@ static const GActionEntry ui_popup_node_gaction_entries[] = {
  * node type.
  */
 static void
-ui_popup_node_menu (nodePtr node, gboolean validSelection, guint button, guint32 activate_time)
+ui_popup_node_menu (nodePtr node, gboolean validSelection, const GdkEvent *event)
 {
 	GtkWidget		*menu;
 	GMenu 			*menu_model, *section;
@@ -365,13 +355,13 @@ ui_popup_node_menu (nodePtr node, gboolean validSelection, guint button, guint32
 	gtk_menu_attach_to_widget (GTK_MENU (menu), liferea_shell_lookup ("mainwindow"), NULL);
 	g_object_unref (menu_model);
 
-	ui_popup_menu (menu, button, activate_time);
+	ui_popup_menu (menu, event);
 }
 
 /* mouse button handler */
 gboolean
 on_mainfeedlist_button_press_event (GtkWidget *widget,
-                                    GdkEventButton *event,
+                                    GdkEvent *event,
                                     gpointer user_data)
 {
 	GdkEventButton 	*eb;
@@ -390,7 +380,7 @@ on_mainfeedlist_button_press_event (GtkWidget *widget,
 	eb = (GdkEventButton*)event;
 
 	/* determine node */
-	if (gtk_tree_view_get_path_at_pos (GTK_TREE_VIEW (treeview), event->x, event->y, &path, NULL, NULL, NULL)) {
+	if (gtk_tree_view_get_path_at_pos (GTK_TREE_VIEW (treeview), eb->x, eb->y, &path, NULL, NULL, NULL)) {
 		model = gtk_tree_view_get_model (GTK_TREE_VIEW (treeview));
 		gtk_tree_model_get_iter (model, &iter, path);
 		gtk_tree_path_free (path);
@@ -422,7 +412,7 @@ on_mainfeedlist_button_press_event (GtkWidget *widget,
 			}
 
 			gtk_widget_grab_focus (widget);
-			ui_popup_node_menu (node, selected, eb->button, eb->time);
+			ui_popup_node_menu (node, selected, event);
 			break;
 	}
 
@@ -450,6 +440,6 @@ on_mainfeedlist_popup_menu (GtkWidget *widget,
 		node = feedlist_get_root ();
 	}
 
-	ui_popup_node_menu (node, selected, 3, gtk_get_current_event_time ());
+	ui_popup_node_menu (node, selected, NULL);
 	return TRUE;
 }

--- a/src/ui/popup_menu.h
+++ b/src/ui/popup_menu.h
@@ -34,28 +34,25 @@
  * (Open Link, Copy Item, Copy Link...)
  *
  * @param item	the selected item
- * @param button	the mouse button which was pressed to initiate the event
- * @param activate_time	the time at which the activation event occurred
+ * @param event The event that triggered the popup
  */
-void ui_popup_item_menu (itemPtr item, guint button, guint32 activate_time);
+void ui_popup_item_menu (itemPtr item, const GdkEvent *event);
 
 /**
  * Shows a popup menu for the enclosure list view.
  * (Save As, Open With...)
  *
  * @param enclosure	the enclosure
- * @param button	the mouse button which was pressed to initiate the event
- * @param activate_time	the time at which the activation event occurred
+ * @param event		the event that triggered the popup
  */
-void ui_popup_enclosure_menu (enclosurePtr enclosure, guint button,
-			      guint32 activate_time);
+void ui_popup_enclosure_menu (enclosurePtr enclosure, const GdkEvent *event);
 
 /* GUI callbacks */
 
 gboolean
 on_mainfeedlist_button_press_event     (GtkWidget       *widget,
-                                        GdkEventButton  *event,
-                                        gpointer         user_data);
+                                        GdkEvent 	*event,
+                                        gpointer 	user_data);
 
 gboolean
 on_mainfeedlist_popup_menu (GtkWidget *widget,

--- a/src/webkit/liferea_web_view.c
+++ b/src/webkit/liferea_web_view.c
@@ -146,8 +146,6 @@ liferea_web_view_on_menu (WebKitWebView 	*view,
 	gchar			*link_uri = NULL;
 	gchar			*link_title = NULL;
 	gboolean 		link, image;
-	guint 			event_button = 0;
-	guint32			event_time = 0;
 
 	if (webkit_hit_test_result_context_is_link (hit_result))
 		g_object_get (hit_result, "link-uri", &link_uri, "link-title", &link_title, NULL);
@@ -229,16 +227,7 @@ liferea_web_view_on_menu (WebKitWebView 	*view,
 	menu = gtk_menu_new_from_model (G_MENU_MODEL (menu_model));
 	gtk_menu_attach_to_widget (GTK_MENU (menu), GTK_WIDGET (view), NULL);
 
-	/* Event can be GDK_NOTHING, which is code word for NULL */
-	if (event) {
-		gdk_event_get_button (event, &event_button);
-		event_time = gdk_event_get_time (event);
-	} else {
-		event_time = gtk_get_current_event_time ();
-		event_button = 0;
-	}
-
-	gtk_menu_popup(GTK_MENU (menu), NULL,NULL,NULL,NULL, event_button, event_time);
+	gtk_menu_popup_at_pointer (GTK_MENU (menu), event);
 
 	return TRUE; // TRUE to ignore WebKit's menu as we make our own menu.
 }


### PR DESCRIPTION
This replaces the deprecated `gtk_menu_popup` function with `gtk_menu_popup_at_pointer`. The behavior appears to be the same as in master. But maybe we should handle the menus from the "popup-menu" signal (Shift + F10) differently : currently it appears where the pointer is but is not related to what is under the pointer.