### PR TITLE
Fix #693 - Add option to disable minimizing to tray.

### DIFF
--- a/doc/html/faq_en.html
+++ b/doc/html/faq_en.html
@@ -68,12 +68,11 @@ do work.</dd>
 </dd>
 
 <dt>Q: Liferea is buggy! It does not close when I click on the window
-managers close button and the tray icon is activated.</dt>
+manager's close button and the tray icon is activated.</dt>
 <dd>A: 
 This is a pretty disputed topic. We see this as a useful feature, other
-people don't. If you don't like the behaviour you can change it in the
-preferences under "GUI". There you can enable the check box "Terminate
-instead of minimizing to tray icon".
+people don't. If you don't like the behaviour you can change it by right-clicking 
+the tray icon and toggling the checkbox labelled "Minimize to tray on close."
 </dd>
 
 <dt>Q: I want cookies!</dt>

--- a/plugins/trayicon.py
+++ b/plugins/trayicon.py
@@ -104,9 +104,10 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
         menuitem_close_behavior = Gtk.CheckMenuItem("Minimize to tray on close")
         menuitem_quit = Gtk.MenuItem("Quit")
 
-        min_enabled = self.get_config()
+        self.config_path = self.get_config_path()
+        self.min_enabled = self.get_config()
 
-        if min_enabled == "True":
+        if self.min_enabled == "True":
             menuitem_close_behavior.set_active(True)
         else:
             menuitem_close_behavior.set_active(False)
@@ -157,9 +158,8 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
 
     def get_config(self):
         """Load configuration file"""
-        config_path = self.get_config_path()
         try:
-            with open(config_path, "r") as f:
+            with open(self.config_path, "r") as f:
                 setting = f.readline()
             if setting == "":
                 setting = "True"
@@ -171,8 +171,7 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
 
     def save_config(self, minimize_setting):
         """Save configuration file"""
-        config_path = self.get_config_path()
-        with open(config_path, "w") as f:
+        with open(self.config_path, "w") as f:
             f.write(minimize_setting)
 
     def trayicon_click(self, widget, data = None):
@@ -191,7 +190,7 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
             self.min_enabled = "True"
         else:
             self.min_enabled = "False"
-        save_config(self.min_enabled)
+        self.save_config(self.min_enabled)
 
     def trayicon_toggle(self, widget, data = None):
         self.shell.toggle_visibility()
@@ -257,4 +256,3 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
         del self.staticon
         del self.window
         del self.menu
-


### PR DESCRIPTION
This closes #693 by extending the Trayicon plugin, allowing the user to choose what Liferea does when closing the main window. Let me know if you have any questions, or would like anything changed.