### PR TITLE
Embed YouTube videos

### DIFF
--- a/xslt/item.xml.in
+++ b/xslt/item.xml.in
@@ -4,6 +4,7 @@
 /**
  * Rendering stylesheet for Liferea (item view: item rendering)
  *
+ * Copyright (C) 2009-2019 Mikel Olasagasti Uranga <mikel@olasagasti.info>
  * Copyright (C) 2006-2019 Lars Windolf <lars.windolf@gmx.de>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -307,6 +308,12 @@
     <!-- optional MediaRSS thumbnail -->
     <xsl:if test="attributes/attribute[ @name = 'mediathumbnail' ]">
       <img align='left' class='thumbnail' src="{attributes/attribute[ @name = 'mediathumbnail' ]}"/>
+    </xsl:if>
+    <!-- optional MediaRSS YouTube links-->
+    <xsl:variable name="url"><xsl:value-of select="source"/></xsl:variable>
+    <xsl:if test="contains($url,'https://www.youtube.com/watch?v=')">
+      <xsl:variable name="youtubeid" select="substring-after($url,'https://www.youtube.com/watch?v=')"/>
+      <p><iframe width="640" height="480" src="https://www.youtube.com/embed/{$youtubeid}" frameborder="0" allowfullscreen="1"></iframe></p>
     </xsl:if>
     <!-- optional MediaRSS description -->
     <xsl:if test="attributes/attribute[ @name = 'mediadescription' ]">


### PR DESCRIPTION
Extend xslt to render YouTube's embeded code if source is a YouTube video.

Another option would be to check the YT namespace, but adding another parser
might be overkill. Also, I was not able to find the YT schema.

Privacy wise, there would be a request everytime a feed is rendered, but this
should only happen if the feed is a YT MediaRSS feed or if the feed has a YT
link as main link. If description has a YT url, the embed code won't show.

Signed-off-by: Mikel Olasagasti Uranga <mikel@olasagasti.info>