### PR TITLE
Skip current item when finding next unread item

### DIFF
--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -1101,7 +1101,8 @@ item_list_view_find_unread_item (ItemListView *ilv, gulong startId)
 	while (valid) {
 		itemPtr	item = item_load (item_list_view_iter_to_id (ilv, &iter));
 		if (item) {
-			if (!item->readStatus)
+			/* Skip the selected item */
+			if (!item->readStatus && item->id != startId)
 				return item;
 			item_unload (item);
 		}

--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -362,6 +362,10 @@ itemview_find_unread_item (gulong startId)
 	if (!result)
 		result = item_list_view_find_unread_item (itemview->itemListView, 0);
 
+	/* Return NULL if not found, or only the selected item is unread */
+	if (result && result->id == startId) 
+		return NULL;
+
 	return result;
 }
 


### PR DESCRIPTION
This is a possible fix for #787. When looking for the next item, the code will now skip over the current selected index.

The main fix is in item_list_view.c. If the code hasn't moved past startId, don't return that entry.

The change in itemview.c is needed because itemview_find_unread_item will restart the search from the top of the list, returning to startId which may have been marked unread.