### PR TITLE
first part fix #519  single update to treeview, lookup; adding item_ids

### DIFF
--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -417,7 +417,7 @@ item_list_view_clear (ItemListView *ilv)
 	GtkTreeStore		*itemstore;
 	GtkTreeSelection	*select;
 
-	itemstore = GTK_TREE_STORE (gtk_tree_view_get_model (ilv->treeview));
+        itemstore = GTK_TREE_STORE (gtk_tree_view_get_model (ilv->treeview));
 
 	/* unselecting all items is important to remove items
 	   whose removal is deferred until unselecting */
@@ -441,6 +441,8 @@ item_list_view_clear (ItemListView *ilv)
 	/* enable batch mode for following item adds */
 	ilv->batch_mode = TRUE;
 	ilv->batch_itemstore = item_list_view_create_tree_store ();
+        gtk_widget_freeze_child_notify((GtkWidget *)ilv->treeview);
+	gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (ilv->batch_itemstore), NULL, NULL, NULL);
 }
 
 static gfloat
@@ -462,11 +464,10 @@ item_list_title_alignment (gchar *title)
 		return 1.;
 }
 
-void
-item_list_view_update_item (ItemListView *ilv, itemPtr item)
+static void 
+item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, GtkTreeIter *iter, nodePtr node)
 {
 	GtkTreeStore	*itemstore;
-	GtkTreeIter	iter;
 	gchar		*title, *time_str;
 	const GIcon	*state_icon;
 	gint		state = 0;
@@ -475,9 +476,6 @@ item_list_view_update_item (ItemListView *ilv, itemPtr item)
 		state += 2;
 	if (!item->readStatus)
 		state += 1;
-
-	if (!item_list_view_id_to_iter (ilv, item->id, &iter))
-		return;
 
 	time_str = (0 != item->time) ? date_format ((time_t)item->time, NULL) : g_strdup ("");
 
@@ -510,19 +508,49 @@ item_list_view_update_item (ItemListView *ilv, itemPtr item)
 	else
 		itemstore = GTK_TREE_STORE (gtk_tree_view_get_model (ilv->treeview));
 
-	gtk_tree_store_set (itemstore,
-	                    &iter,
+        if (NULL == node) {
+                gtk_tree_store_set (itemstore, iter,
 		            IS_LABEL, title,
 	                    IS_TIME, item->time,
 			    IS_TIME_STR, time_str,
+                            IS_NR, item->id,
 			    IS_STATEICON, state_icon,
 			    ITEMSTORE_ALIGN, item_list_title_alignment (title),
+                            IS_ENCICON, item->hasEnclosure?icon_get (ICON_ENCLOSURE):NULL,
+                            IS_ENCLOSURE, item->hasEnclosure,
 		            IS_STATE, state,
 	                    ITEMSTORE_WEIGHT, item->readStatus ? PANGO_WEIGHT_NORMAL : PANGO_WEIGHT_BOLD,
 			    -1);
+        } else {
+                gtk_tree_store_set (itemstore, iter,
+		            IS_LABEL, title,
+                            IS_TIME, item->time,
+			    IS_TIME_STR, time_str,
+                            IS_NR, item->id,
+			    IS_STATEICON, state_icon,
+                            IS_PARENT, node,
+                            IS_FAVICON, node_get_icon (node),
+                            IS_ENCICON, item->hasEnclosure?icon_get (ICON_ENCLOSURE):NULL,
+                            IS_ENCLOSURE, item->hasEnclosure,
+                            IS_SOURCE, node,
+                            IS_STATE, state,
+	                    ITEMSTORE_WEIGHT, item->readStatus ? PANGO_WEIGHT_NORMAL : PANGO_WEIGHT_BOLD,
+                            -1);
+        }
 
 	g_free (time_str);
 	g_free (title);
+}
+
+void
+item_list_view_update_item (ItemListView *ilv, itemPtr item)
+{
+	GtkTreeIter	iter;
+
+	if (!item_list_view_id_to_iter (ilv, item->id, &iter))
+		return;
+
+        item_list_view_update_item_internal (ilv, item, &iter, NULL);
 }
 
 static void
@@ -567,6 +595,7 @@ item_list_view_update (ItemListView *ilv, gboolean hasEnclosures)
 	gtk_tree_view_column_set_visible (g_hash_table_lookup(ilv->columns, "enclosure"), hasEnclosures);
 
 	if (ilv->batch_mode) {
+                gtk_widget_thaw_child_notify((GtkWidget *)ilv->treeview);
 		item_list_view_set_tree_store (ilv, ilv->batch_itemstore);
 		ilv->batch_mode = FALSE;
 	} else {
@@ -894,35 +923,22 @@ item_list_view_add_item_to_tree_store (ItemListView *ilv, GtkTreeStore *itemstor
 	gint		state = 0;
 	nodePtr		node;
 	GtkTreeIter	iter;
-	gboolean	exists;
-
-	if (item->flagStatus)
-		state += 2;
-	if (!item->readStatus)
-		state += 1;
+	gboolean	exists = FALSE;
 
 	node = node_from_id (item->nodeId);
 	if(!node)
 		return;	/* comment items do cause this... maybe filtering them earlier would be a good idea... */
 
-	exists = item_list_view_id_to_iter (ilv, item->id, &iter);
+        if (!ilv->batch_mode)
+            exists = item_list_view_id_to_iter (ilv, item->id, &iter);
 
 	if (!exists)
 	{
 		gtk_tree_store_prepend (itemstore, &iter, NULL);
-		ilv->item_ids = g_slist_append (ilv->item_ids, GUINT_TO_POINTER (item->id));
+		ilv->item_ids = g_slist_prepend (ilv->item_ids, GUINT_TO_POINTER (item->id));
 	}
 
-	gtk_tree_store_set (itemstore, &iter,
-		                       IS_TIME, item->time,
-		                       IS_NR, item->id,
-				       IS_PARENT, node,
-		                       IS_FAVICON, node_get_icon (node),
-		                       IS_ENCICON, item->hasEnclosure?icon_get (ICON_ENCLOSURE):NULL,
-				       IS_ENCLOSURE, item->hasEnclosure,
-				       IS_SOURCE, node,
-				       IS_STATE, state,
-		                       -1);
+	item_list_view_update_item_internal (ilv, item, &iter, node);
 }
 
 void
@@ -938,8 +954,6 @@ item_list_view_add_item (ItemListView *ilv, itemPtr item)
 		itemstore = GTK_TREE_STORE (gtk_tree_view_get_model (ilv->treeview));
 		item_list_view_add_item_to_tree_store (ilv, itemstore, item);
 	}
-
-	item_list_view_update_item (ilv, item);
 }
 
 void


### PR DESCRIPTION
first part fix #519  single update to treeview, lookup; and adding item to item_ids
    - per https://developer.gnome.org/glib/stable/glib-Singly-Linked-Lists.html
      change g_slist_append() to g_slist_prepend() as g_slist_append() seeks to the end of the list
      and is inefficient
      + during batch add, don't lookup item in the empty list
      + item add is always followed by item update, pass the just inserted item id into update internal
    - per https://stackoverflow.com/questions/3547743/gtktreeview-insert-update-performance-penalty-because-of-sorting (3)
      + ref. https://eccentric.one/misc/pygtk/pygtkfaq.html#13.43
      + turn off the sorting
      + freeze child notify
      + batch insert into tree
      + thaw child notify
      + turn on sorting

After changes, folder switch update time reduced 80%, (15s to 2.5s, 48s to 9.48, (large) to ~30s).