### PR TITLE
Fix save/restore position issues with tray icon

### DIFF
--- a/plugins/trayicon.py
+++ b/plugins/trayicon.py
@@ -133,7 +133,8 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
             self.window.hide()
 
     def trayicon_click(self, widget, data = None):
-        self.shell.toggle_visibility()
+        # Always show the window on click, as some window managers misbehave.
+        self.shell.show_window()
 
     def trayicon_minimize_on_close(self, widget, event):
         self.shell.save_position()

--- a/plugins/trayicon.py
+++ b/plugins/trayicon.py
@@ -144,7 +144,7 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
         self.shell.toggle_visibility()
 
     def trayicon_quit(self, widget, data = None):
-        Liferea.shutdown()
+        Liferea.Application.shutdown()
 
     def trayicon_popup(self, widget, button, time, data = None):
         self.menu.popup(None, None, self.staticon.position_menu, self.staticon, 3, time)

--- a/plugins/trayicon.py
+++ b/plugins/trayicon.py
@@ -129,13 +129,14 @@ class TrayiconPlugin (GObject.Object, Liferea.ShellActivatable):
         "Hide window when minimize"
         if event.changed_mask & event.new_window_state & Gdk.WindowState.ICONIFIED:
             self.window.deiconify()
+            self.shell.save_position()
             self.window.hide()
 
     def trayicon_click(self, widget, data = None):
-        self.window.deiconify()
-        self.window.show()
+        self.shell.toggle_visibility()
 
     def trayicon_minimize_on_close(self, widget, event):
+        self.shell.save_position()
         self.window.hide()
         return True
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,6 +94,7 @@ Liferea_3_0_gir_FILES = \
 	item.h \
 	itemlist.c itemlist.h \
 	itemset.c itemset.h \
+	liferea_application.h \
 	node.h node.c \
 	node_view.h \
 	social.c social.h \

--- a/src/liferea_application.c
+++ b/src/liferea_application.c
@@ -53,10 +53,6 @@ struct _LifereaApplication {
 	gulong		debug_flags;
 };
 
-struct _LifereaApplicationClass {
-	GtkApplicationClass parent;
-};
-
 G_DEFINE_TYPE (LifereaApplication, liferea_application, GTK_TYPE_APPLICATION)
 
 static LifereaApplication *liferea_app = NULL;
@@ -344,7 +340,7 @@ liferea_application_new (int argc, char *argv[])
 
 	g_assert (NULL == liferea_app);
 
-	liferea_app = g_object_new (LIFEREA_TYPE_APPLICATION,
+	liferea_app = g_object_new (LIFEREA_APPLICATION_TYPE,
 		                    "flags", G_APPLICATION_HANDLES_OPEN,
 		                    "application-id", "net.sourceforge.liferea",
 		                    NULL);

--- a/src/liferea_application.h
+++ b/src/liferea_application.h
@@ -24,32 +24,29 @@
 #include <glib-object.h>
 #include <gtk/gtk.h>
 
-#define LIFEREA_TYPE_APPLICATION (liferea_application_get_type ())
-#define LIFEREA_APPLICATION(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), LIFEREA_TYPE_APPLICATION, LifereaApplication))
-#define IS_LIFEREA_APPLICATION(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), LIFEREA_APPLICATION_TYPE))
-#define LIFEREA_APPLICATION_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), LIFEREA_TYPE_APPLICATION, LifereaApplicationClass))
-#define IS_LIFEREA_APPLICATION_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), LIFEREA_TYPE_APPLICATION))
-#define LIFEREA_APPLICATION_GET_CLASS(obj) (G_TYPE_INSTANCE_GET_CLASS ((obj), LIFEREA_TYPE_APPLICATION, LifereaApplicationClass))
+G_BEGIN_DECLS
 
-typedef struct _LifereaApplication LifereaApplication;
+#define LIFEREA_APPLICATION_TYPE (liferea_application_get_type ())
+G_DECLARE_FINAL_TYPE (LifereaApplication, liferea_application, LIFEREA, APPLICATION, GtkApplication)
 
-typedef struct _LifereaApplicationClass LifereaApplicationClass;
-
-GType liferea_application_get_type ();
-
-/*
- * Start a new GApplication representing Liferea
+/**
+ * liferea_application_new: (skip)
+ * @argc: number of arguments
+ * @argv: arguments
  *
- * @param argc  number of arguments
- * @param argv  arguments
+ * Start a new GApplication representing Liferea
  *
  * Returns: exit code
  */
 gint liferea_application_new (int argc, char *argv[]);
 
-/*
+/**
+ * liferea_application_shutdown:
+ *
  * Shutdown GApplication
  */
 void liferea_application_shutdown (void);
+
+G_END_DECLS
 
 #endif

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -1352,15 +1352,28 @@ liferea_shell_present (void)
 	gtk_window_present (shell->window);
 }
 
+static gboolean
+liferea_shell_window_is_on_other_desktop(GdkWindow *gdkwindow)
+{
+#ifdef GDK_WINDOWING_X11
+	return GDK_IS_X11_DISPLAY (gdk_window_get_display (gdkwindow)) &&
+	    (gdk_x11_window_get_desktop (gdkwindow) !=
+	     gdk_x11_screen_get_current_desktop (gdk_window_get_screen (gdkwindow)));
+#else
+	return FALSE;
+#endif
+}
+
 void
 liferea_shell_toggle_visibility (void)
 {
 	GtkWidget *mainwindow = GTK_WIDGET (shell->window);
 	GdkWindow *gdkwindow = gtk_widget_get_window (mainwindow);
 
-	if (gdk_x11_window_get_desktop (gdkwindow) !=
-	    gdk_x11_screen_get_current_desktop (gdk_window_get_screen (gdkwindow))) {
+	if (liferea_shell_window_is_on_other_desktop (gdkwindow)) {
+#ifdef GDK_WINDOWING_X11
 		gdk_x11_window_move_to_current_desktop (gdkwindow);
+#endif
 		liferea_shell_restore_position ();
 		gtk_window_deiconify (GTK_WINDOW (mainwindow));
 		gtk_window_present (shell->window);

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -26,6 +26,7 @@
 #include "ui/liferea_shell.h"
 
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 #include <gdk/gdkkeysyms.h>
 #include <libpeas/peas-extension-set.h>
 
@@ -263,7 +264,7 @@ liferea_shell_restore_position (void)
 
 }
 
-static void
+void
 liferea_shell_save_position (void)
 {
 	GtkWidget	*pane;
@@ -1355,23 +1356,15 @@ void
 liferea_shell_toggle_visibility (void)
 {
 	GtkWidget *mainwindow = GTK_WIDGET (shell->window);
+	GdkWindow *gdkwindow = gtk_widget_get_window (mainwindow);
 
-	if (gdk_window_get_state (gtk_widget_get_window (mainwindow)) & GDK_WINDOW_STATE_ICONIFIED) {
-		/* The window is either iconified, or on another workspace */
-		/* Raise it in one click */
-		if (gtk_widget_get_visible (mainwindow)) {
-			liferea_shell_save_position ();
-			gtk_widget_hide (mainwindow);
-		}
+	if (gdk_x11_window_get_desktop (gdkwindow) !=
+	    gdk_x11_screen_get_current_desktop (gdk_window_get_screen (gdkwindow))) {
+		gdk_x11_window_move_to_current_desktop (gdkwindow);
 		liferea_shell_restore_position ();
-		/* Note: Without deiconify() desktop moving doesn't work in
-		   GNOME+metacity. The window would be moved correctly by
-		   present() but not become visible. */
 		gtk_window_deiconify (GTK_WINDOW (mainwindow));
-		gtk_window_present (GTK_WINDOW (mainwindow));
-	}
-	else if (!gtk_widget_get_visible (mainwindow)) {
-		/* The window is neither iconified nor on another workspace, but is not visible */
+		gtk_window_present (shell->window);
+	} else if (!gtk_widget_get_visible (mainwindow)) {
 		liferea_shell_restore_position ();
 		gtk_window_deiconify (GTK_WINDOW (mainwindow));
 		gtk_window_present (shell->window);

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -1373,21 +1373,27 @@ liferea_shell_window_move_to_current_desktop(GdkWindow *gdkwindow)
 #endif
 }
 
+void liferea_shell_show_window (void)
+{
+	GtkWidget *mainwindow = GTK_WIDGET (shell->window);
+	GdkWindow *gdkwindow = gtk_widget_get_window (mainwindow);
+
+	liferea_shell_window_move_to_current_desktop (gdkwindow);
+	if (!gtk_widget_get_visible (GTK_WIDGET (mainwindow)))
+		liferea_shell_restore_position ();
+	gtk_window_deiconify (GTK_WINDOW (mainwindow));
+	gtk_window_present (shell->window);
+}
+
 void
 liferea_shell_toggle_visibility (void)
 {
 	GtkWidget *mainwindow = GTK_WIDGET (shell->window);
 	GdkWindow *gdkwindow = gtk_widget_get_window (mainwindow);
 
-	if (liferea_shell_window_is_on_other_desktop (gdkwindow)) {
-		liferea_shell_window_move_to_current_desktop (gdkwindow);
-		liferea_shell_restore_position ();
-		gtk_window_deiconify (GTK_WINDOW (mainwindow));
-		gtk_window_present (shell->window);
-	} else if (!gtk_widget_get_visible (mainwindow)) {
-		liferea_shell_restore_position ();
-		gtk_window_deiconify (GTK_WINDOW (mainwindow));
-		gtk_window_present (shell->window);
+	if (liferea_shell_window_is_on_other_desktop (gdkwindow) ||
+	    !gtk_widget_get_visible (mainwindow)) {
+		liferea_shell_show_window ();
 	} else {
 		liferea_shell_save_position ();
 		gtk_widget_hide (mainwindow);

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -1364,6 +1364,15 @@ liferea_shell_window_is_on_other_desktop(GdkWindow *gdkwindow)
 #endif
 }
 
+static void
+liferea_shell_window_move_to_current_desktop(GdkWindow *gdkwindow)
+{
+#ifdef GDK_WINDOWING_X11
+	if (GDK_IS_X11_DISPLAY (gdk_window_get_display (gdkwindow)))
+	    gdk_x11_window_move_to_current_desktop (gdkwindow);
+#endif
+}
+
 void
 liferea_shell_toggle_visibility (void)
 {
@@ -1371,9 +1380,7 @@ liferea_shell_toggle_visibility (void)
 	GdkWindow *gdkwindow = gtk_widget_get_window (mainwindow);
 
 	if (liferea_shell_window_is_on_other_desktop (gdkwindow)) {
-#ifdef GDK_WINDOWING_X11
-		gdk_x11_window_move_to_current_desktop (gdkwindow);
-#endif
+		liferea_shell_window_move_to_current_desktop (gdkwindow);
 		liferea_shell_restore_position ();
 		gtk_window_deiconify (GTK_WINDOW (mainwindow));
 		gtk_window_present (shell->window);

--- a/src/ui/liferea_shell.h
+++ b/src/ui/liferea_shell.h
@@ -54,6 +54,14 @@ G_DECLARE_FINAL_TYPE (LifereaShell, liferea_shell, LIFEREA, SHELL, GObject)
 GtkWidget * liferea_shell_lookup (const gchar *name);
 
 /**
+ * liferea_shell_save_position
+ *
+ * Save the position of the Liferea main window.
+ */
+void
+liferea_shell_save_position (void);
+
+/**
  * liferea_shell_create: (skip)
  * @app:	                the GtkApplication to attach the main window to
  * @overrideWindowState:	optional parameter for window state (or NULL)

--- a/src/ui/liferea_shell.h
+++ b/src/ui/liferea_shell.h
@@ -86,6 +86,13 @@ void liferea_shell_destroy (void);
 void liferea_shell_present (void);
 
 /**
+ * liferea_shell_show_window:
+ *
+ * Show the main window.
+ */
+void liferea_shell_show_window (void);
+
+/**
  * liferea_shell_toggle_visibility:
  *
  * Toggles main window visibility.

--- a/src/ui/liferea_shell.h
+++ b/src/ui/liferea_shell.h
@@ -186,8 +186,6 @@ void liferea_shell_set_important_status_bar (const char *format, ...);
  */
 GtkWidget * liferea_shell_get_window (void);
 
-void liferea_shutdown (void);
-
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
There were a few issues with tray icon save/restore:

* Fix raising Liferea from another workspace using official GDK API.
* Clicking the tray icon didn't save position. Now we just call toggle.
* Closing or minimizing the window wouldn't save position either.