### PR TITLE
Respect global refresh interval for TheOldReader

### DIFF
--- a/src/fl_sources/theoldreader_source.c
+++ b/src/fl_sources/theoldreader_source.c
@@ -150,35 +150,16 @@ theoldreader_source_login (TheOldReaderSourcePtr source, guint32 flags)
 static void
 theoldreader_source_auto_update (nodePtr node)
 {
-	GTimeVal	now;
-	TheOldReaderSourcePtr source = (TheOldReaderSourcePtr) node->data;
-
 	if (node->source->loginState == NODE_SOURCE_STATE_NONE) {
 		node_source_update (node);
 		return;
 	}
 
-	if (node->source->loginState == NODE_SOURCE_STATE_IN_PROGRESS) 
+	if (node->source->loginState == NODE_SOURCE_STATE_IN_PROGRESS)
 		return; /* the update will start automatically anyway */
 
-	g_get_current_time (&now);
-	
-	/* do daily updates for the feed list and feed updates according to the default interval */
-/*	if (node->subscription->updateState->lastPoll.tv_sec + NODE_SOURCE_UPDATE_INTERVAL <= now.tv_sec) {
-		subscription_update (node->subscription, 0);
-		g_get_current_time (&source->lastQuickUpdate);
-	}
-	else if (source->lastQuickUpdate.tv_sec + NODE_SOURCE_QUICK_UPDATE_INTERVAL <= now.tv_sec) {
-		theoldreader_source_opml_quick_update (source);
-		google_reader_api_edit_process (node->source);
-		g_get_current_time (&source->lastQuickUpdate);
-	}*/
-
-	// FIXME: Don't do below, but above logic!
-	if (source->lastQuickUpdate.tv_sec + THEOLDREADER_SOURCE_QUICK_UPDATE_INTERVAL <= now.tv_sec) {
-		subscription_update (node->subscription, 0);
-		g_get_current_time (&source->lastQuickUpdate);
-	}
+	debug0 (DEBUG_UPDATE, "theoldreader_source_auto_update()");
+	subscription_auto_update (node->subscription);
 }
 
 static

--- a/src/fl_sources/theoldreader_source.h
+++ b/src/fl_sources/theoldreader_source.h
@@ -35,11 +35,6 @@ typedef struct TheOldReaderSource {
 	 */
 	GHashTable      *lastTimestampMap; 
 
-	/**
-	 * A timestamp when the last Quick update took place.
-	 */
-	GTimeVal        lastQuickUpdate;
-
 	GHashTable	*folderToCategory;	/**< Lookup hash for folder node id to TTRSS category id */
 } *TheOldReaderSourcePtr;
 
@@ -60,9 +55,6 @@ typedef struct TheOldReaderSource {
 #define THEOLDREADER_READER_LOGIN_URL "https://theoldreader.com/accounts/ClientLogin" 
 #define THEOLDREADER_READER_LOGIN_POST "service=reader&Email=%s&Passwd=%s&source=liferea&continue=http://theoldreader.com"
 
-/** Interval (in seconds) for doing a Quick Update: 10min */
-#define THEOLDREADER_SOURCE_QUICK_UPDATE_INTERVAL 600
-
 /**
  * @returns TheOldReader source type implementation info.
  */
@@ -77,18 +69,6 @@ nodeSourceTypePtr theoldreader_source_get_type (void);
  * @returns a node (or NULL)
  */
 nodePtr theoldreader_source_get_node_from_source (TheOldReaderSourcePtr gsource, const gchar* source);
-
-/**
- * Tries to update the entire source quickly, by updating only those feeds
- * which are known to be updated. Suitable for g_timeout_add. This is an 
- * internal function.
- *
- * @param data A pointer to a node id of the source. This pointer will
- *             be g_free'd if the update fails.
- *
- * @returns FALSE on update failure
- */
-gboolean theoldreader_source_quick_update_timeout (gpointer gsource);
 
 /**
  * Migrate a google source child-node from a Liferea 1.4 style read-only

--- a/src/fl_sources/theoldreader_source_feed_list.h
+++ b/src/fl_sources/theoldreader_source_feed_list.h
@@ -28,10 +28,3 @@
  */
 nodePtr theoldreader_source_opml_get_node_by_source(TheOldReaderSourcePtr gsource,
 					 const gchar *source);
-
-/**
- * Perform a quick update of the TheOldReader source.
- *
- * @param gsource	the TheOldReader source
- */
-gboolean theoldreader_source_opml_quick_update (TheOldReaderSourcePtr gsource);


### PR DESCRIPTION
TheOldReader was refreshing all feeds at a hardcoded 10 minute interval.
This respects the global refresh interval.

Remnants of "quick update" were also removed, since the underlying code
was removed some time ago.

Fixes #470.