### PR TITLE
WIP: Removing GTimeVal references

### DIFF
--- a/src/date.c
+++ b/src/date.c
@@ -203,7 +203,6 @@ date_format (gint64 date, const gchar *date_format)
 gint64
 date_parse_ISO8601 (const gchar *date)
 {
-	GTimeVal 	timeval;
 	GDateTime 	*datetime = NULL;
 	gboolean 	result;
 	guint64 	year, month, day;
@@ -219,9 +218,13 @@ date_parse_ISO8601 (const gchar *date)
 	 */
 
 	/* full specified variant */
-	result = g_time_val_from_iso8601 (date, &timeval);
-	if (result)
-		return timeval.tv_sec;
+	datetime = g_date_time_new_from_iso8601 (date, NULL);
+  if (datetime) {
+		t = g_date_time_to_unix (datetime);
+		g_date_time_unref (datetime);
+    if (t)
+      return t;
+	}
 
 
 	/* only date */

--- a/src/date.c
+++ b/src/date.c
@@ -219,11 +219,11 @@ date_parse_ISO8601 (const gchar *date)
 
 	/* full specified variant */
 	datetime = g_date_time_new_from_iso8601 (date, NULL);
-  if (datetime) {
+	if (datetime) {
 		t = g_date_time_to_unix (datetime);
 		g_date_time_unref (datetime);
-    if (t)
-      return t;
+		if (t)
+			return t;
 	}
 
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -102,7 +102,7 @@ debug_start_measurement_func (const char * function)
 		g_hash_table_insert (startTimes, g_strdup(function), startTime);
 	}
 
-  *startTime = g_get_monotonic_time();
+	*startTime = g_get_monotonic_time();
 }
 
 void
@@ -126,24 +126,24 @@ debug_end_measurement_func (const char * function,
 	if (!startTime) 
 		return;
 		
-  endTime = g_get_monotonic_time();
-  duration = endTime - *startTime;
-  if (duration < 1000)
-    return;
-	
+	endTime = g_get_monotonic_time();
+	duration = endTime - *startTime;
+	if (duration < 1000)
+		return;
+
 	g_print ("%s: ", debug_get_prefix (flags));
 	if (debug_level & DEBUG_TRACE)
 		g_print ("[%p] ", g_thread_self ());
 	for (i = 0; i < debug_get_depth (); i++) 
 		g_print ("   ");
 	g_print ("= %s took %01ld,%03lds\n", name, 
-	                                   duration / 1000000, 
-					   duration/1000);
-					     
+					duration / 1000000, 
+					duration/1000);
+
 	if (duration > 250)
 		debug2 (DEBUG_PERF, "function \"%s\" is slow! Took %dms.", name, duration);
 }
- 
+
 void
 set_debug_level (unsigned long level)
 {

--- a/src/debug.c
+++ b/src/debug.c
@@ -86,7 +86,7 @@ debug_get_depth (void)
 void
 debug_start_measurement_func (const char * function)
 {
-	GTimeVal	*startTime = NULL;
+	gint64	*startTime = NULL;
 	
 	if (!function)
 		return;
@@ -94,15 +94,15 @@ debug_start_measurement_func (const char * function)
 	if (!startTimes)
 		startTimes = g_hash_table_new (g_str_hash, g_str_equal);
 	
-	startTime = (GTimeVal *) g_hash_table_lookup (startTimes, function);
+	startTime = (gint64 *) g_hash_table_lookup (startTimes, function);
 	
 	if (!startTime)
 	{
-		startTime = g_new0 (GTimeVal, 1);
+		startTime = g_new0 (gint64, 1);
 		g_hash_table_insert (startTimes, g_strdup(function), startTime);
 	}
 
-	g_get_current_time (startTime);
+  *startTime = g_get_monotonic_time();
 }
 
 void
@@ -110,8 +110,8 @@ debug_end_measurement_func (const char * function,
                             unsigned long flags, 
 			    const char *name)
 {
-	GTimeVal	*startTime = NULL;
-	GTimeVal	endTime;
+	gint64	*startTime = NULL;
+	gint64	endTime;
 	unsigned long	duration = 0;
 	int		i;
 		
@@ -126,12 +126,10 @@ debug_end_measurement_func (const char * function,
 	if (!startTime) 
 		return;
 		
-	g_get_current_time (&endTime);
-	g_time_val_add (&endTime, (-1) * startTime->tv_usec);
-	
-	if ((0 == endTime.tv_sec - startTime->tv_sec) &&
-	    (0 == endTime.tv_usec/1000))
-		return;
+  endTime = g_get_monotonic_time();
+  duration = endTime - *startTime;
+  if (duration < 1000)
+    return;
 	
 	g_print ("%s: ", debug_get_prefix (flags));
 	if (debug_level & DEBUG_TRACE)
@@ -139,10 +137,9 @@ debug_end_measurement_func (const char * function,
 	for (i = 0; i < debug_get_depth (); i++) 
 		g_print ("   ");
 	g_print ("= %s took %01ld,%03lds\n", name, 
-	                                   endTime.tv_sec - startTime->tv_sec, 
-					   endTime.tv_usec/1000);
+	                                   duration / 1000000, 
+					   duration/1000);
 					     
-	duration = (endTime.tv_sec - startTime->tv_sec)*1000 + endTime.tv_usec/1000;
 	if (duration > 250)
 		debug2 (DEBUG_PERF, "function \"%s\" is slow! Took %dms.", name, duration);
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -137,8 +137,8 @@ debug_end_measurement_func (const char * function,
 	for (i = 0; i < debug_get_depth (); i++) 
 		g_print ("   ");
 	g_print ("= %s took %01ld,%03lds\n", name, 
-					duration / 1000000, 
-					duration/1000);
+					duration / G_USEC_PER_SEC, 
+					duration / 1000);
 
 	if (duration > 250)
 		debug2 (DEBUG_PERF, "function \"%s\" is slow! Took %dms.", name, duration);

--- a/src/feedlist.c
+++ b/src/feedlist.c
@@ -650,12 +650,12 @@ feedlist_save (void)
 void
 feedlist_reset_update_counters (nodePtr node)
 {
-	GTimeVal now;
+	guint64 now;
 
 	if (!node)
 		node = feedlist_get_root ();
 
-	g_get_current_time (&now);
+	now = g_get_real_time();
 	node_foreach_child_data (node, node_reset_update_counter, &now);
 }
 

--- a/src/fl_sources/opml_source.c
+++ b/src/fl_sources/opml_source.c
@@ -299,12 +299,12 @@ opml_source_remove (nodePtr node)
 static void
 opml_source_auto_update (nodePtr node)
 {
-	GTimeVal	now;
+	guint64	now;
 	
-	g_get_current_time (&now);
+	now = g_get_real_time();
 	
 	/* do daily updates for the feed list and feed updates according to the default interval */
-	if (node->subscription->updateState->lastPoll.tv_sec + OPML_SOURCE_UPDATE_INTERVAL <= now.tv_sec)
+	if (node->subscription->updateState->lastPoll / 1000000 + OPML_SOURCE_UPDATE_INTERVAL <= now / 1000000)
 		node_source_update (node);
 }
 

--- a/src/fl_sources/opml_source.c
+++ b/src/fl_sources/opml_source.c
@@ -304,7 +304,7 @@ opml_source_auto_update (nodePtr node)
 	now = g_get_real_time();
 	
 	/* do daily updates for the feed list and feed updates according to the default interval */
-	if (node->subscription->updateState->lastPoll + OPML_SOURCE_UPDATE_INTERVAL * G_USEC_PER_SEC<= now)
+	if (node->subscription->updateState->lastPoll + (guint64)OPML_SOURCE_UPDATE_INTERVAL * (guint64)G_USEC_PER_SEC <= now)
 		node_source_update (node);
 }
 

--- a/src/fl_sources/opml_source.c
+++ b/src/fl_sources/opml_source.c
@@ -304,7 +304,7 @@ opml_source_auto_update (nodePtr node)
 	now = g_get_real_time();
 	
 	/* do daily updates for the feed list and feed updates according to the default interval */
-	if (node->subscription->updateState->lastPoll / 1000000 + OPML_SOURCE_UPDATE_INTERVAL <= now / 1000000)
+	if (node->subscription->updateState->lastPoll + OPML_SOURCE_UPDATE_INTERVAL * G_USEC_PER_SEC<= now)
 		node_source_update (node);
 }
 

--- a/src/fl_sources/reedah_source.c
+++ b/src/fl_sources/reedah_source.c
@@ -45,7 +45,7 @@
 #include "fl_sources/reedah_source_feed_list.h"
 
 /** default Reedah subscription list update interval = once a day */
-#define NODE_SOURCE_UPDATE_INTERVAL 60*60*24
+#define NODE_SOURCE_UPDATE_INTERVAL 60*60*24*1000*1000
 
 /** create a Reedah source with given node as root */ 
 static ReedahSourcePtr
@@ -149,7 +149,7 @@ reedah_source_login (ReedahSourcePtr source, guint32 flags)
 static void
 reedah_source_auto_update (nodePtr node)
 {
-	GTimeVal	now;
+	guint64	now;
 	ReedahSourcePtr source = (ReedahSourcePtr) node->data;
 
 	if (node->source->loginState == NODE_SOURCE_STATE_NONE) {
@@ -162,17 +162,17 @@ reedah_source_auto_update (nodePtr node)
 
 	debug0 (DEBUG_UPDATE, "reedah_source_auto_update()");
 
-	g_get_current_time (&now);
+	now = g_get_real_time();
 	
 	/* do daily updates for the feed list and feed updates according to the default interval */
-	if (node->subscription->updateState->lastPoll.tv_sec + NODE_SOURCE_UPDATE_INTERVAL <= now.tv_sec) {
+	if (node->subscription->updateState->lastPoll + NODE_SOURCE_UPDATE_INTERVAL <= now) {
 		subscription_update (node->subscription, 0);
-		g_get_current_time (&source->lastQuickUpdate);
+		source->lastQuickUpdate = g_get_real_time();
 	}
-	else if (source->lastQuickUpdate.tv_sec + REEDAH_SOURCE_QUICK_UPDATE_INTERVAL <= now.tv_sec) {
+	else if (source->lastQuickUpdate + REEDAH_SOURCE_QUICK_UPDATE_INTERVAL <= now) {
 		reedah_source_opml_quick_update (source);
 		google_reader_api_edit_process (node->source);
-		g_get_current_time (&source->lastQuickUpdate);
+		source->lastQuickUpdate = g_get_real_time();
 	}
 }
 

--- a/src/fl_sources/reedah_source.c
+++ b/src/fl_sources/reedah_source.c
@@ -45,7 +45,7 @@
 #include "fl_sources/reedah_source_feed_list.h"
 
 /** default Reedah subscription list update interval = once a day */
-#define NODE_SOURCE_UPDATE_INTERVAL 60*60*24*1000*1000
+#define NODE_SOURCE_UPDATE_INTERVAL 60*60*24 * G_USEC_PER_SEC
 
 /** create a Reedah source with given node as root */ 
 static ReedahSourcePtr

--- a/src/fl_sources/reedah_source.c
+++ b/src/fl_sources/reedah_source.c
@@ -45,7 +45,7 @@
 #include "fl_sources/reedah_source_feed_list.h"
 
 /** default Reedah subscription list update interval = once a day */
-#define NODE_SOURCE_UPDATE_INTERVAL 60*60*24 * G_USEC_PER_SEC
+#define NODE_SOURCE_UPDATE_INTERVAL (guint64)(60*60*24) * (guint64)G_USEC_PER_SEC
 
 /** create a Reedah source with given node as root */ 
 static ReedahSourcePtr

--- a/src/fl_sources/reedah_source.h
+++ b/src/fl_sources/reedah_source.h
@@ -38,7 +38,7 @@ typedef struct ReedahSource {
 	/**
 	 * A timestamp when the last Quick update took place.
 	 */
-	GTimeVal        lastQuickUpdate;
+	guint64         lastQuickUpdate;
 } *ReedahSourcePtr;
 
 /**
@@ -60,8 +60,8 @@ typedef struct ReedahSource {
 #define REEDAH_READER_LOGIN_URL "https://www.reedah.com/accounts/ClientLogin" 
 #define REEDAH_READER_LOGIN_POST "service=reader&Email=%s&Passwd=%s&source=liferea&continue=http://www.reedah.com"
 
-/** Interval (in seconds) for doing a Quick Update: 10min */
-#define REEDAH_SOURCE_QUICK_UPDATE_INTERVAL 600
+/** Interval (in micro seconds) for doing a Quick Update: 10min */
+#define REEDAH_SOURCE_QUICK_UPDATE_INTERVAL 600 * 1000 * 1000
 
 /**
  * @returns Reedah source type implementation info.

--- a/src/fl_sources/reedah_source.h
+++ b/src/fl_sources/reedah_source.h
@@ -61,7 +61,7 @@ typedef struct ReedahSource {
 #define REEDAH_READER_LOGIN_POST "service=reader&Email=%s&Passwd=%s&source=liferea&continue=http://www.reedah.com"
 
 /** Interval (in micro seconds) for doing a Quick Update: 10min */
-#define REEDAH_SOURCE_QUICK_UPDATE_INTERVAL 600 * 1000 * 1000
+#define REEDAH_SOURCE_QUICK_UPDATE_INTERVAL 600 * G_USEC_PER_SEC
 
 /**
  * @returns Reedah source type implementation info.

--- a/src/fl_sources/theoldreader_source.c
+++ b/src/fl_sources/theoldreader_source.c
@@ -150,7 +150,7 @@ theoldreader_source_login (TheOldReaderSourcePtr source, guint32 flags)
 static void
 theoldreader_source_auto_update (nodePtr node)
 {
-	GTimeVal	now;
+	guint64	now;
 	TheOldReaderSourcePtr source = (TheOldReaderSourcePtr) node->data;
 
 	if (node->source->loginState == NODE_SOURCE_STATE_NONE) {
@@ -161,23 +161,23 @@ theoldreader_source_auto_update (nodePtr node)
 	if (node->source->loginState == NODE_SOURCE_STATE_IN_PROGRESS) 
 		return; /* the update will start automatically anyway */
 
-	g_get_current_time (&now);
+	now = g_get_real_time();
 	
 	/* do daily updates for the feed list and feed updates according to the default interval */
-/*	if (node->subscription->updateState->lastPoll.tv_sec + NODE_SOURCE_UPDATE_INTERVAL <= now.tv_sec) {
+/*	if (node->subscription->updateState->lastPoll + NODE_SOURCE_UPDATE_INTERVAL <= now) {
 		subscription_update (node->subscription, 0);
-		g_get_current_time (&source->lastQuickUpdate);
+		source->lastQuickUpdate = g_get_real_time();
 	}
-	else if (source->lastQuickUpdate.tv_sec + NODE_SOURCE_QUICK_UPDATE_INTERVAL <= now.tv_sec) {
+	else if (source->lastQuickUpdate + NODE_SOURCE_QUICK_UPDATE_INTERVAL <= now) {
 		theoldreader_source_opml_quick_update (source);
 		google_reader_api_edit_process (node->source);
-		g_get_current_time (&source->lastQuickUpdate);
+		source->lastQuickUpdate = g_get_real_time();
 	}*/
 
 	// FIXME: Don't do below, but above logic!
-	if (source->lastQuickUpdate.tv_sec + THEOLDREADER_SOURCE_QUICK_UPDATE_INTERVAL <= now.tv_sec) {
+	if (source->lastQuickUpdate + THEOLDREADER_SOURCE_QUICK_UPDATE_INTERVAL <= now) {
 		subscription_update (node->subscription, 0);
-		g_get_current_time (&source->lastQuickUpdate);
+		source->lastQuickUpdate = g_get_real_time();
 	}
 }
 

--- a/src/fl_sources/theoldreader_source.h
+++ b/src/fl_sources/theoldreader_source.h
@@ -61,7 +61,7 @@ typedef struct TheOldReaderSource {
 #define THEOLDREADER_READER_LOGIN_POST "service=reader&Email=%s&Passwd=%s&source=liferea&continue=http://theoldreader.com"
 
 /** Interval (in seconds) for doing a Quick Update: 10min */
-#define THEOLDREADER_SOURCE_QUICK_UPDATE_INTERVAL 600 * 1000 * 1000
+#define THEOLDREADER_SOURCE_QUICK_UPDATE_INTERVAL 600 * G_USEC_PER_SEC
 
 /**
  * @returns TheOldReader source type implementation info.

--- a/src/fl_sources/theoldreader_source.h
+++ b/src/fl_sources/theoldreader_source.h
@@ -38,7 +38,7 @@ typedef struct TheOldReaderSource {
 	/**
 	 * A timestamp when the last Quick update took place.
 	 */
-	GTimeVal        lastQuickUpdate;
+	guint64         lastQuickUpdate;
 
 	GHashTable	*folderToCategory;	/**< Lookup hash for folder node id to TTRSS category id */
 } *TheOldReaderSourcePtr;
@@ -61,7 +61,7 @@ typedef struct TheOldReaderSource {
 #define THEOLDREADER_READER_LOGIN_POST "service=reader&Email=%s&Passwd=%s&source=liferea&continue=http://theoldreader.com"
 
 /** Interval (in seconds) for doing a Quick Update: 10min */
-#define THEOLDREADER_SOURCE_QUICK_UPDATE_INTERVAL 600
+#define THEOLDREADER_SOURCE_QUICK_UPDATE_INTERVAL 600 * 1000 * 1000
 
 /**
  * @returns TheOldReader source type implementation info.

--- a/src/node.c
+++ b/src/node.c
@@ -123,8 +123,8 @@ node_set_subscription (nodePtr node, subscriptionPtr subscription)
 	/* Besides the favicon age we have no persistent
 	   update state field, so everything else goes NULL */
 	if (node->iconFile && !strstr(node->iconFile, "default.png")) {
-		subscription->updateState->lastFaviconPoll.tv_sec = common_get_mod_time (node->iconFile);
-		debug2 (DEBUG_UPDATE, "Setting last favicon poll time for %s to %lu", node->id, subscription->updateState->lastFaviconPoll.tv_sec);
+		subscription->updateState->lastFaviconPoll = common_get_mod_time (node->iconFile) * 1000000;
+		debug2 (DEBUG_UPDATE, "Setting last favicon poll time for %s to %lu", node->id, subscription->updateState->lastFaviconPoll / 1000000);
 	}
 }
 
@@ -157,7 +157,7 @@ node_auto_update_subscription (nodePtr node)
 }
 
 void
-node_reset_update_counter (nodePtr node, GTimeVal *now)
+node_reset_update_counter (nodePtr node, guint64 *now)
 {
 	subscription_reset_update_counter (node->subscription, now);
 

--- a/src/node.c
+++ b/src/node.c
@@ -123,8 +123,8 @@ node_set_subscription (nodePtr node, subscriptionPtr subscription)
 	/* Besides the favicon age we have no persistent
 	   update state field, so everything else goes NULL */
 	if (node->iconFile && !strstr(node->iconFile, "default.png")) {
-		subscription->updateState->lastFaviconPoll = common_get_mod_time (node->iconFile) * 1000000;
-		debug2 (DEBUG_UPDATE, "Setting last favicon poll time for %s to %lu", node->id, subscription->updateState->lastFaviconPoll / 1000000);
+		subscription->updateState->lastFaviconPoll = common_get_mod_time (node->iconFile) * G_USEC_PER_SEC;
+		debug2 (DEBUG_UPDATE, "Setting last favicon poll time for %s to %lu", node->id, subscription->updateState->lastFaviconPoll / G_USEC_PER_SEC);
 	}
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -181,7 +181,7 @@ void node_auto_update_subscription (nodePtr node);
  * Helper function to be used with node_foreach_child()
  * to mass-auto-update subscriptions.
  */
-void node_reset_update_counter (nodePtr node, GTimeVal *now);
+void node_reset_update_counter (nodePtr node, guint64 *now);
 
 /**
  * node_is_ancestor: (skip)

--- a/src/subscription.c
+++ b/src/subscription.c
@@ -120,13 +120,13 @@ subscription_can_be_updated (subscriptionPtr subscription)
 }
 
 void
-subscription_reset_update_counter (subscriptionPtr subscription, GTimeVal *now)
+subscription_reset_update_counter (subscriptionPtr subscription, guint64 *now)
 {
 	if (!subscription)
 		return;
 
-	subscription->updateState->lastPoll.tv_sec = now->tv_sec;
-	debug2 (DEBUG_UPDATE, "Resetting last poll counter of %s to %ld.", subscription->source, subscription->updateState->lastPoll.tv_sec);
+	subscription->updateState->lastPoll = now;
+	debug2 (DEBUG_UPDATE, "Resetting last poll counter of %s to %ld.", subscription->source, subscription->updateState->lastPoll / 1000 / 1000);
 }
 
 /**
@@ -177,7 +177,7 @@ subscription_process_update_result (const struct updateResult * const result, gp
 	subscriptionPtr subscription = (subscriptionPtr)user_data;
 	nodePtr		node = subscription->node;
 	gboolean	processing = FALSE;
-	GTimeVal	now;
+	guint64	now;
 	gint		next_update = 0;
 	gint		update_time_sources = 0;
 	gint		maxage = -1;
@@ -220,15 +220,15 @@ subscription_process_update_result (const struct updateResult * const result, gp
 	      to ensure we have valid baseUrl for feed nodes...
 
 	      check creation date and update favicon if older than one month */
-	g_get_current_time (&now);
-	if (now.tv_sec > (subscription->updateState->lastFaviconPoll.tv_sec + 60*60*24*31))
+	now = g_get_real_time();
+	if (now > (subscription->updateState->lastFaviconPoll + 60*60*24*31*1000*1000))
 		subscription_icon_update (subscription);
 
 	/* 4. generic postprocessing */
 	update_state_set_lastmodified (subscription->updateState, update_state_get_lastmodified (result->updateState));
 	update_state_set_cookies (subscription->updateState, update_state_get_cookies (result->updateState));
 	update_state_set_etag (subscription->updateState, update_state_get_etag (result->updateState));
-	g_get_current_time (&subscription->updateState->lastPoll);
+  subscription->updateState->lastPoll = g_get_real_time();
 
 	// FIXME: use new-items signal in itemview class
 	itemview_update_node_info (subscription->node);
@@ -247,7 +247,7 @@ void
 subscription_update (subscriptionPtr subscription, guint flags)
 {
 	updateRequestPtr		request;
-	GTimeVal			now;
+	guint64			now;
 
 	if (!subscription)
 		return;
@@ -260,7 +260,7 @@ subscription_update (subscriptionPtr subscription, guint flags)
 	if (subscription_can_be_updated (subscription)) {
 		liferea_shell_set_status_bar (_("Updating \"%s\""), node_get_title (subscription->node));
 
-		g_get_current_time (&now);
+		now = g_get_real_time();
 		subscription_reset_update_counter (subscription, &now);
 
 		request = update_request_new ();
@@ -282,7 +282,7 @@ subscription_auto_update (subscriptionPtr subscription)
 {
 	gint		interval;
 	guint		flags = 0;
-	GTimeVal	now;
+	guint64	now;
 
 	if (!subscription)
 		return;
@@ -294,9 +294,9 @@ subscription_auto_update (subscriptionPtr subscription)
 	if (-2 >= interval || 0 == interval)
 		return;		/* don't update this subscription */
 
-	g_get_current_time (&now);
+	now = g_get_real_time();
 
-	if (subscription->updateState->lastPoll.tv_sec + interval*60 <= now.tv_sec)
+	if (subscription->updateState->lastPoll + interval*60*1000*1000 <= now)
 		subscription_update (subscription, flags);
 }
 

--- a/src/subscription.c
+++ b/src/subscription.c
@@ -228,7 +228,7 @@ subscription_process_update_result (const struct updateResult * const result, gp
 	update_state_set_lastmodified (subscription->updateState, update_state_get_lastmodified (result->updateState));
 	update_state_set_cookies (subscription->updateState, update_state_get_cookies (result->updateState));
 	update_state_set_etag (subscription->updateState, update_state_get_etag (result->updateState));
-  subscription->updateState->lastPoll = g_get_real_time();
+	subscription->updateState->lastPoll = g_get_real_time();
 
 	// FIXME: use new-items signal in itemview class
 	itemview_update_node_info (subscription->node);

--- a/src/subscription.c
+++ b/src/subscription.c
@@ -41,6 +41,8 @@
 #define FEED_PROTOCOL_PREFIX "feed://"
 #define FEED_PROTOCOL_PREFIX2 "feed:"
 
+#define ONE_MONTH_MICROSECONDS (guint64)(60*60*24*31) * (guint64)G_USEC_PER_SEC
+
 subscriptionPtr
 subscription_new (const gchar *source,
                   const gchar *filter,
@@ -125,7 +127,7 @@ subscription_reset_update_counter (subscriptionPtr subscription, guint64 *now)
 	if (!subscription)
 		return;
 
-	subscription->updateState->lastPoll = now;
+	subscription->updateState->lastPoll = *now;
 	debug2 (DEBUG_UPDATE, "Resetting last poll counter of %s to %ld.", subscription->source, subscription->updateState->lastPoll / G_USEC_PER_SEC);
 }
 
@@ -177,7 +179,7 @@ subscription_process_update_result (const struct updateResult * const result, gp
 	subscriptionPtr subscription = (subscriptionPtr)user_data;
 	nodePtr		node = subscription->node;
 	gboolean	processing = FALSE;
-	guint64	now;
+	guint64		now;
 	gint		next_update = 0;
 	gint		update_time_sources = 0;
 	gint		maxage = -1;
@@ -221,7 +223,7 @@ subscription_process_update_result (const struct updateResult * const result, gp
 
 	      check creation date and update favicon if older than one month */
 	now = g_get_real_time();
-	if (now > (subscription->updateState->lastFaviconPoll + 60*60*24*31 * G_USEC_PER_SEC))
+	if (now > (subscription->updateState->lastFaviconPoll + ONE_MONTH_MICROSECONDS))
 		subscription_icon_update (subscription);
 
 	/* 4. generic postprocessing */

--- a/src/subscription.c
+++ b/src/subscription.c
@@ -126,7 +126,7 @@ subscription_reset_update_counter (subscriptionPtr subscription, guint64 *now)
 		return;
 
 	subscription->updateState->lastPoll = now;
-	debug2 (DEBUG_UPDATE, "Resetting last poll counter of %s to %ld.", subscription->source, subscription->updateState->lastPoll / 1000 / 1000);
+	debug2 (DEBUG_UPDATE, "Resetting last poll counter of %s to %ld.", subscription->source, subscription->updateState->lastPoll / G_USEC_PER_SEC);
 }
 
 /**
@@ -221,7 +221,7 @@ subscription_process_update_result (const struct updateResult * const result, gp
 
 	      check creation date and update favicon if older than one month */
 	now = g_get_real_time();
-	if (now > (subscription->updateState->lastFaviconPoll + 60*60*24*31*1000*1000))
+	if (now > (subscription->updateState->lastFaviconPoll + 60*60*24*31 * G_USEC_PER_SEC))
 		subscription_icon_update (subscription);
 
 	/* 4. generic postprocessing */

--- a/src/subscription.h
+++ b/src/subscription.h
@@ -173,7 +173,7 @@ void subscription_set_default_update_interval(subscriptionPtr subscription, guin
  *
  * @param subscription	the subscription
  */
-void subscription_reset_update_counter (subscriptionPtr subscription, GTimeVal *now);
+void subscription_reset_update_counter (subscriptionPtr subscription, guint64 *now);
 
 void subscription_update_favicon (subscriptionPtr subscription);
 

--- a/src/subscription_icon.c
+++ b/src/subscription_icon.c
@@ -160,7 +160,7 @@ subscription_icon_update (subscriptionPtr subscription)
 	iconDownloadCtxtPtr	ctxt;
 
 	debug1 (DEBUG_UPDATE, "trying to download favicon.ico for \"%s\"", node_get_title (subscription->node));
-	g_get_current_time (&subscription->updateState->lastFaviconPoll);
+  subscription->updateState->lastFaviconPoll = g_get_real_time();
 
 	ctxt = subscription_icon_download_ctxt_new ();
 	ctxt->id = g_strdup (subscription->node->id);

--- a/src/update.h
+++ b/src/update.h
@@ -76,8 +76,8 @@ typedef struct updateOptions {
 /** defines all state data an updatable object (e.g. a feed) needs */
 typedef struct updateState {
 	glong		lastModified;		/**< Last modified string as sent by the server */
-	GTimeVal	lastPoll;		/**< time at which the feed was last updated */
-	GTimeVal	lastFaviconPoll;	/**< time at which the feeds favicon was last updated */
+	guint64  	lastPoll;		/**< time at which the feed was last updated */
+	guint64 	lastFaviconPoll;	/**< time at which the feeds favicon was last updated */
 	gchar		*cookies;		/**< cookies to be used */	
 	gchar		*etag;			/**< ETag sent by the server */
 	gint		maxAgeMinutes;		/**< default update interval, greatest value sourced from HTTP and XML */


### PR DESCRIPTION
I'm looking at removing the GTimeVal references (#829) and could use some feedback. Looking at the usage, it looks like most of these references are used to calculate time elapsed. Since most of these are just comparisons, using guint64 and g_get_real_time sounds like a simpler approach to maintain than creating a new GDateTime object that needs to be unrefd later on. Is this a reasonable approach?

Are there tests I can run to validate the subscription or debug code? Some of these are hard to manually verify (like updating the favicon after a month!)