### PR TITLE
Fixes #865: Fixes view mode switch

### DIFF
--- a/src/feedlist.c
+++ b/src/feedlist.c
@@ -568,7 +568,7 @@ feedlist_selection_changed (gpointer obj, gchar * nodeId, gpointer data)
 			/* Load items of new selected node. */
 			SELECTED = node;
 			if (SELECTED) {
-				itemlist_set_view_mode (node_get_view_mode (SELECTED));
+				liferea_shell_set_view_mode (node_get_view_mode (SELECTED));
 				itemlist_load (SELECTED);
 			} else {
 				itemview_clear ();

--- a/src/itemlist.c
+++ b/src/itemlist.c
@@ -594,8 +594,8 @@ itemlist_get_view_mode (void)
 	return itemlist->priv->viewMode;
 }
 
-void
-itemlist_set_view_mode (guint newMode)
+static void
+itemlist_set_view_mode (nodeViewType newMode)
 {
 	nodePtr		node;
 	itemPtr		item;
@@ -626,9 +626,18 @@ itemlist_set_view_mode (guint newMode)
 void
 on_view_activate (GSimpleAction *action, GVariant *value, gpointer user_data)
 {
-
 	const gchar *s_val = g_variant_get_string (value, NULL);
-	gint val = 0;
+	GVariant *cur_state = g_action_get_state (G_ACTION(action));
+	const gchar *s_cur_state = g_variant_get_string (cur_state,NULL);
+	/* If requested state is the same as current state, leave without doing
+	 * anything. */
+	if (!g_strcmp0 (s_val,s_cur_state)) {
+		g_variant_unref (cur_state);
+		return;
+	}
+	g_variant_unref (cur_state);
+
+	nodeViewType val = 0;
 	if (!g_strcmp0 ("normal",s_val))
 	{
 		val = NODE_VIEW_MODE_NORMAL;
@@ -639,10 +648,27 @@ on_view_activate (GSimpleAction *action, GVariant *value, gpointer user_data)
 	}
 	if (!g_strcmp0 ("combined",s_val))
 	{
-		val = NODE_VIEW_MODE_COMBINED;
+		/* Combined is removed : default to normal */
+		val = NODE_VIEW_MODE_NORMAL;
 	}
 	itemlist_set_view_mode (val);
-	g_simple_action_set_state (action, value);
+	g_variant_unref (value);
+
+	/* Getting the actual value to reflect current state even if for some
+	 * reason, other functions couldn't make the requested change.
+	 * May be overkill. */
+	val = itemlist_get_view_mode ();
+	switch (val)
+	{
+	  case NODE_VIEW_MODE_NORMAL:
+	  case NODE_VIEW_MODE_DEFAULT:
+	  case NODE_VIEW_MODE_COMBINED:
+		g_simple_action_set_state (action, g_variant_new_string("normal"));
+		break;
+	  case NODE_VIEW_MODE_WIDE:
+		g_simple_action_set_state (action, g_variant_new_string("wide"));
+		break;
+	}
 }
 
 static void

--- a/src/itemlist.c
+++ b/src/itemlist.c
@@ -652,7 +652,6 @@ on_view_activate (GSimpleAction *action, GVariant *value, gpointer user_data)
 		val = NODE_VIEW_MODE_NORMAL;
 	}
 	itemlist_set_view_mode (val);
-	g_variant_unref (value);
 
 	/* Getting the actual value to reflect current state even if for some
 	 * reason, other functions couldn't make the requested change.

--- a/src/itemlist.h
+++ b/src/itemlist.h
@@ -119,16 +119,6 @@ void itemlist_load (struct node *node);
 void itemlist_unload (gboolean markRead);
 
 /**
- * itemlist_set_view_mode:
- * @newMode:	0 = normal, 1 = wide, 2 = combined view
- *
- * Changes the viewing mode property of the item list.
- * Do not use this method to change the viewing mode
- * of a displayed node!
- */
-void itemlist_set_view_mode (guint newMode);
-
-/**
  * itemlist_get_view_mode:
  *
  * Returns the viewing mode property of the currently displayed item set.

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -1425,3 +1425,24 @@ liferea_shell_get_window (void)
 {
 	return GTK_WIDGET (shell->window);
 }
+
+void
+liferea_shell_set_view_mode (nodeViewType newMode)
+{
+	GAction       *action;
+
+	action = g_action_map_lookup_action (G_ACTION_MAP(shell->generalActions), "set-view-mode");
+
+	switch (newMode)
+	{
+	  case NODE_VIEW_MODE_NORMAL:
+	  case NODE_VIEW_MODE_DEFAULT:
+	  case NODE_VIEW_MODE_COMBINED:
+	    /* Combined is removed, default to normal */
+		g_action_change_state (action, g_variant_new_string("normal"));
+		break;
+	  case NODE_VIEW_MODE_WIDE:
+		g_action_change_state (action, g_variant_new_string("wide"));
+		break;
+	}
+}

--- a/src/ui/liferea_shell.h
+++ b/src/ui/liferea_shell.h
@@ -193,6 +193,16 @@ void liferea_shell_set_important_status_bar (const char *format, ...);
  */
 GtkWidget * liferea_shell_get_window (void);
 
+/**
+ * liferea_shell_set_view_mode:
+ * @newMode:	the new mode
+ *
+ * Changes the view mode programmatically. Used to change the mode when
+ * selecting another feed. Convenience function to trigger the stateful action
+ * set-view-mode.
+ */
+void liferea_shell_set_view_mode (nodeViewType newMode);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
The way it works : `on_view_activate` is the callback to the stateful action "set-view-mode".
Changing "set-view-mode"'s state calls this function.
The callback calls on `itemlist_set_view_mode` which calls`itemview_set_layout`, etc ...

To keep things in sync, the view mode should only be set through changing the action state. I restore the `liferea_shell_set_view_mode` function in liferea_shell.c (I had it in my old 2015 gaction branch but it looks like I dropped it when I cherry picked the commits in the branch that was merged). It is a convenience function to get the action and change it's state : this triggers the callback and the view mode change.

I make `itemlist_set_view_mode` static so that it won't be used directly. I replace it with `liferea_shell_set_view_mode` in feedlist.c.
I also modified the callback so the view mode change only happens when a mode different from the current one is requested. I hope this doesn't break anything.
