### PR TITLE
Zoom : going back to normal size

### DIFF
--- a/glade/liferea_menu.ui
+++ b/glade/liferea_menu.ui
@@ -140,13 +140,17 @@
       <section>
         <item>
           <attribute name="action">app.zoom-in</attribute>
-          <attribute name="label" translatable="yes">_Increase Text Size</attribute>
+          <attribute name="label" translatable="yes">Zoom _In</attribute>
         </item>
         <item>
           <attribute name="action">app.zoom-out</attribute>
-          <attribute name="label" translatable="yes">_Decrease Text Size</attribute>
+          <attribute name="label" translatable="yes">Zoom _Out</attribute>
         </item>
-      </section>
+        <item>
+          <attribute name="action">app.zoom-reset</attribute>
+          <attribute name="label" translatable="yes">_Normal size</attribute>
+        </item>
+       </section>
       <section>
         <item>
           <attribute name="action">app.set-view-mode</attribute>

--- a/src/ui/browser_tabs.c
+++ b/src/ui/browser_tabs.c
@@ -384,7 +384,7 @@ browser_tabs_get_active_htmlview (void)
 }
 
 void
-browser_tabs_do_zoom (gboolean in)
+browser_tabs_do_zoom (gint zoom)
 {
-	liferea_htmlview_do_zoom (browser_tabs_get_active_htmlview (), in);
+	liferea_htmlview_do_zoom (browser_tabs_get_active_htmlview (), zoom);
 }

--- a/src/ui/browser_tabs.h
+++ b/src/ui/browser_tabs.h
@@ -71,11 +71,11 @@ LifereaHtmlView * browser_tabs_get_active_htmlview (void);
 
 /**
  * browser_tabs_do_zoom:
- * @in:	TRUE if zooming in, FALSE for zooming out
+ * @zoom:	1 for zoom in, -1 for zoom out, 0 for reset
  *
  * Requests the tab to change zoom level.
  */
-void browser_tabs_do_zoom (gboolean in);
+void browser_tabs_do_zoom (gint zoom);
 
 G_END_DECLS
 

--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -502,10 +502,10 @@ itemview_launch_URL (const gchar *url, gboolean forceInternal)
 }
 
 void
-itemview_do_zoom (gboolean in)
+itemview_do_zoom (gint zoom)
 {
 	if (itemview->htmlview == NULL)
 		return;
 
-	liferea_htmlview_do_zoom (itemview->htmlview, in);
+	liferea_htmlview_do_zoom (itemview->htmlview, zoom);
 }

--- a/src/ui/itemview.h
+++ b/src/ui/itemview.h
@@ -227,11 +227,11 @@ void itemview_launch_URL (const gchar *url, gboolean internal);
 
 /**
  * itemview_do_zoom:
- * @in:	TRUE if zooming in, FALSE for zooming out
+ * @zoom:	1 for zoom in, -1 for zoom out, 0 for reset
  *
  * Requests the item view to change zoom level.
  */
-void itemview_do_zoom (gboolean in);
+void itemview_do_zoom (gint zoom);
 
 G_END_DECLS
 

--- a/src/ui/liferea_htmlview.c
+++ b/src/ui/liferea_htmlview.c
@@ -528,9 +528,13 @@ liferea_htmlview_scroll (LifereaHtmlView *htmlview)
 }
 
 void
-liferea_htmlview_do_zoom (LifereaHtmlView *htmlview, gboolean in)
+liferea_htmlview_do_zoom (LifereaHtmlView *htmlview, gint zoom)
 {
-	gfloat factor = in?1.2:0.8;
+	if (!zoom)
+		liferea_htmlview_set_zoom (htmlview, 1.0);
+	else if (zoom > 0)
+		liferea_htmlview_set_zoom (htmlview, 1.2 * liferea_htmlview_get_zoom (htmlview));
+	else
+		liferea_htmlview_set_zoom (htmlview, 0.8 * liferea_htmlview_get_zoom (htmlview));
 
-	liferea_htmlview_set_zoom (htmlview, factor * liferea_htmlview_get_zoom (htmlview));
 }

--- a/src/ui/liferea_htmlview.h
+++ b/src/ui/liferea_htmlview.h
@@ -156,12 +156,12 @@ void liferea_htmlview_scroll (LifereaHtmlView *htmlview);
 /**
  * liferea_htmlview_do_zoom:
  * @htmlview:	the html view
- * @in:		TRUE if zoom is to be increased
+ * @zoom:	1 for zoom in, -1 for zoom out, 0 for reset
  *
  * To be called when HTML view needs to change the text size
  * of the rendering widget implementation.
  */
-void liferea_htmlview_do_zoom (LifereaHtmlView *htmlview, gboolean in);
+void liferea_htmlview_do_zoom (LifereaHtmlView *htmlview, gint zoom);
 
 G_END_DECLS
 

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -662,23 +662,6 @@ on_key_press_event (GtkWidget *widget, GdkEventKey *event, gpointer data)
 				break;
 		}
 
-		/* some <Ctrl> hotkeys that overrule the HTML view */
-		if ((event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK) {
-			switch (event->keyval) {
-				case GDK_KEY_KP_Add:
-				case GDK_KEY_equal:
-				case GDK_KEY_plus:
-					liferea_shell_do_zoom (1);
-					return TRUE;
-					break;
-				case GDK_KEY_KP_Subtract:
-				case GDK_KEY_minus:
-					liferea_shell_do_zoom (-1);
-					return TRUE;
-					break;
-			}
-		}
-
 		/* prevent usage of navigation keys in entries */
 		focusw = gtk_window_get_focus (GTK_WINDOW (widget));
 		if (!focusw || GTK_IS_ENTRY (focusw))
@@ -1165,7 +1148,7 @@ static const gchar * liferea_accels_prev_read_item[] = {"<Control><Shift>n", NUL
 static const gchar * liferea_accels_toggle_item_read_status[] = {"<Control>m", NULL};
 static const gchar * liferea_accels_toggle_item_flag[] = {"<Control>t", NULL};
 static const gchar * liferea_accels_fullscreen[] = {"F11", NULL};
-static const gchar * liferea_accels_zoom_in[] = {"<Control>plus", NULL};
+static const gchar * liferea_accels_zoom_in[] = {"<Control>plus", "<Control>equal",NULL};
 static const gchar * liferea_accels_zoom_out[] = {"<Control>minus", NULL};
 static const gchar * liferea_accels_zoom_reset[] = {"<Control>0", NULL};
 static const gchar * liferea_accels_search_feeds[] = {"<Control>f", NULL};

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -532,16 +532,17 @@ liferea_shell_set_important_status_bar (const char *format, ...)
 	g_idle_add ((GSourceFunc)liferea_shell_set_status_bar_important_cb, (gpointer)text);
 }
 
+/* For zoom in : zoom = 1, for zoom out : zoom= -1, for reset : zoom = 0 */
 static void
-liferea_shell_do_zoom (gboolean in)
+liferea_shell_do_zoom (gint zoom)
 {
 	/* We must apply the zoom either to the item view
 	   or to an open tab, depending on the browser tabs
 	   GtkNotebook page that is active... */
 	if (!browser_tabs_get_active_htmlview ())
-		itemview_do_zoom (in);
+		itemview_do_zoom (zoom);
 	else
-		browser_tabs_do_zoom (in);
+		browser_tabs_do_zoom (zoom);
 }
 
 static gboolean
@@ -667,12 +668,12 @@ on_key_press_event (GtkWidget *widget, GdkEventKey *event, gpointer data)
 				case GDK_KEY_KP_Add:
 				case GDK_KEY_equal:
 				case GDK_KEY_plus:
-					liferea_shell_do_zoom (TRUE);
+					liferea_shell_do_zoom (1);
 					return TRUE;
 					break;
 				case GDK_KEY_KP_Subtract:
 				case GDK_KEY_minus:
-					liferea_shell_do_zoom (FALSE);
+					liferea_shell_do_zoom (-1);
 					return TRUE;
 					break;
 			}
@@ -799,15 +800,21 @@ on_menu_fullscreen_activate (GSimpleAction *action, GVariant *parameter, gpointe
 }
 
 static void
-on_menu_zoomin_selected (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+on_action_zoomin_activate (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
-	liferea_shell_do_zoom (TRUE);
+	liferea_shell_do_zoom (1);
 }
 
 static void
-on_menu_zoomout_selected (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+on_action_zoomout_activate (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
-	liferea_shell_do_zoom (FALSE);
+	liferea_shell_do_zoom (-1);
+}
+
+static void
+on_action_zoomreset_activate (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+{
+	liferea_shell_do_zoom (0);
 }
 
 static void
@@ -922,8 +929,9 @@ static const GActionEntry liferea_shell_gaction_entries[] = {
 	{"prev-read-item", on_prev_read_item_activate, NULL, NULL, NULL},
 	{"next-read-item", on_next_read_item_activate, NULL, NULL, NULL},
 	{"next-unread-item", on_next_unread_item_activate, NULL, NULL, NULL},
-	{"zoom-in", on_menu_zoomin_selected, NULL, NULL, NULL},
-	{"zoom-out", on_menu_zoomout_selected, NULL, NULL, NULL},
+	{"zoom-in", on_action_zoomin_activate, NULL, NULL, NULL},
+	{"zoom-out", on_action_zoomout_activate, NULL, NULL, NULL},
+	{"zoom-reset", on_action_zoomreset_activate, NULL, NULL, NULL},
 	{"show-update-monitor", on_menu_show_update_monitor, NULL, NULL, NULL},
 	{"show-preferences", on_prefbtn_clicked, NULL, NULL, NULL},
 	{"search-feeds", on_searchbtn_clicked, NULL, NULL, NULL},
@@ -1159,6 +1167,7 @@ static const gchar * liferea_accels_toggle_item_flag[] = {"<Control>t", NULL};
 static const gchar * liferea_accels_fullscreen[] = {"F11", NULL};
 static const gchar * liferea_accels_zoom_in[] = {"<Control>plus", NULL};
 static const gchar * liferea_accels_zoom_out[] = {"<Control>minus", NULL};
+static const gchar * liferea_accels_zoom_reset[] = {"<Control>0", NULL};
 static const gchar * liferea_accels_search_feeds[] = {"<Control>f", NULL};
 static const gchar * liferea_accels_show_help_contents[] = {"F1", NULL};
 static const gchar * liferea_accels_open_selected_item_enclosure[] = {"<Control>o", NULL};
@@ -1228,6 +1237,7 @@ liferea_shell_create (GtkApplication *app, const gchar *overrideWindowState, gin
 	gtk_application_set_accels_for_action (app, "app.fullscreen", liferea_accels_fullscreen);
 	gtk_application_set_accels_for_action (app, "app.zoom-in", liferea_accels_zoom_in);
 	gtk_application_set_accels_for_action (app, "app.zoom-out", liferea_accels_zoom_out);
+	gtk_application_set_accels_for_action (app, "app.zoom-reset", liferea_accels_zoom_reset);
 	gtk_application_set_accels_for_action (app, "app.search-feeds", liferea_accels_search_feeds);
 	gtk_application_set_accels_for_action (app, "app.show-help-contents", liferea_accels_show_help_contents);
 	gtk_application_set_accels_for_action (app, "app.open-selected-item-enclosure", liferea_accels_open_selected_item_enclosure);


### PR DESCRIPTION
Because of the way zoom works in Liferea it is not possible to go back by zooming out after zooming in, the resulting size is slightly different which this is annoying. In Firefox for example, the zoom works differently, there seems to be a fixed list of zoom levels between 30% and 300%.
Here I just add an action to set the zoom back to 1:1 to the existing zoom in and out.

In the second commit I also remove what I think is obsolete code to make shortcuts for zoom works, but I'm not sure about that part. I added the shortcuts to the actions and it seems to work, and that way they are not completely hardcoded : they can be changed by plugins, etc ... But maybe there was another reason for those shortcuts to be handled in this way ?