### PR TITLE
Set the urlentry progress bar, fixes #841

### DIFF
--- a/src/ui/liferea_htmlview.c
+++ b/src/ui/liferea_htmlview.c
@@ -395,6 +395,13 @@ liferea_htmlview_title_changed (LifereaHtmlView *htmlview, const gchar *title)
 }
 
 void
+liferea_htmlview_progress_changed (LifereaHtmlView *htmlview, gdouble progress)
+{
+	double bar_progress = (progress == 1.0)?0.0:progress;
+	gtk_entry_set_progress_fraction (GTK_ENTRY (htmlview->urlentry), bar_progress);
+}
+
+void
 liferea_htmlview_location_changed (LifereaHtmlView *htmlview, const gchar *location)
 {
 	if (!g_str_has_prefix (location, "liferea")) {

--- a/src/ui/liferea_htmlview.h
+++ b/src/ui/liferea_htmlview.h
@@ -90,6 +90,8 @@ void liferea_htmlview_on_url (LifereaHtmlView *htmlview, const gchar *url);
 
 void liferea_htmlview_title_changed (LifereaHtmlView *htmlview, const gchar *title);
 
+void liferea_htmlview_progress_changed (LifereaHtmlView *htmlview, gdouble progress);
+
 void liferea_htmlview_location_changed (LifereaHtmlView *htmlview, const gchar *location);
 
 /**

--- a/src/webkit/liferea_web_view.c
+++ b/src/webkit/liferea_web_view.c
@@ -607,6 +607,14 @@ liferea_webkit_load_status_changed (WebKitWebView *view, WebKitLoadEvent event, 
 }
 
 static void
+liferea_web_view_progress_changed (GObject *webview, GParamSpec *pspec, gpointer user_data)
+{
+	LifereaHtmlView *htmlview = g_object_get_data (G_OBJECT (webview), "htmlview");
+
+	liferea_htmlview_progress_changed (htmlview, webkit_web_view_get_estimated_load_progress (WEBKIT_WEB_VIEW (webview)));
+}
+
+static void
 liferea_web_view_init(LifereaWebView *self)
 {
 	self->dbus_connection = NULL;
@@ -628,6 +636,12 @@ liferea_web_view_init(LifereaWebView *self)
 		self,
 		"notify::title",
 		G_CALLBACK (liferea_web_view_title_changed),
+		NULL
+	);
+	g_signal_connect (
+		self,
+		"notify::estimated-load-progress",
+		G_CALLBACK (liferea_web_view_progress_changed),
 		NULL
 	);
 	g_signal_connect (


### PR DESCRIPTION
Pass the WebKitWebView estimated progress value to the GtkEntry built-in progress bar.
And reset the bar to 0 when progress reaches 1, so the bar is only shown when loading.
This fixes #841.