### PR TITLE
Add the option to enable intelligent tracking prevention

### DIFF
--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -1254,6 +1254,115 @@
                     <property name="top_attach">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox" id="itpbox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkCheckButton" id="itpbtn">
+                        <property name="label" translatable="yes">_Intelligent Tracking Prevention. </property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_start">12</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_itpbtn_toggled" swapped="no"/>
+                        <accessibility>
+                          <relation type="labelled-by" target="itpbtn_label"/>
+                        </accessibility>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="itpbtn_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">This enables the WebKit feature described &lt;a href="https://webkit.org/tracking-prevention/"&gt;here&lt;/a&gt;.</property>
+                        <property name="use_markup">True</property>
+                        <property name="wrap">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkInfoBar" id="itpInfoBar">
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin_start">24</property>
+                    <child internal-child="action_area">
+                      <object class="GtkButtonBox">
+                        <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
+                        <property name="layout_style">end</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child internal-child="content_area">
+                      <object class="GtkBox">
+                        <property name="can_focus">False</property>
+                        <property name="spacing">16</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Intelligent tracking prevention is only available with WebKitGtk+ 2.30 or higher.</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="position">6</property>

--- a/net.sf.liferea.gschema.xml.in
+++ b/net.sf.liferea.gschema.xml.in
@@ -187,6 +187,11 @@
       <summary>Enable plugins</summary>
       <description>This options determines if liferea should enable plugins.</description>
     </key>
+    <key name="enable-itp" type="b">
+      <default>true</default>
+      <summary>Enable intelligent tracking protection</summary>
+      <description>This options determines if liferea should enable WebKit's intelligent tracking protection.</description>
+    </key>
     <key name="browser-font" type="s">
       <default>''</default>
       <summary>User defined browser-font</summary>

--- a/src/conf.h
+++ b/src/conf.h
@@ -39,6 +39,7 @@
 #define DISABLE_JAVASCRIPT		"disable-javascript"
 #define SOCIAL_BM_SITE			"social-bm-site"
 #define ENABLE_PLUGINS			"enable-plugins"
+#define ENABLE_ITP			"enable-itp"
 
 /* enclosure handling */
 #define DOWNLOAD_CUSTOM_COMMAND 	"download-custom-command"

--- a/src/ui/preferences_dialog.c
+++ b/src/ui/preferences_dialog.c
@@ -431,6 +431,12 @@ on_donottrackbtn_toggled (GtkToggleButton *button, gpointer user_data)
 	conf_set_bool_value (DO_NOT_TRACK, gtk_toggle_button_get_active (button));
 }
 
+void
+on_itpbtn_toggled (GtkToggleButton *button, gpointer user_data)
+{
+	conf_set_bool_value (ENABLE_ITP, gtk_toggle_button_get_active (button));
+}
+
 static void
 preferences_dialog_destroy_cb (GtkWidget *widget, PreferencesDialog *pd)
 {
@@ -673,6 +679,15 @@ preferences_dialog_init (PreferencesDialog *pd)
 	conf_get_bool_value (DO_NOT_TRACK, &bSetting);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (widget), bSetting);
 
+#if WEBKIT_CHECK_VERSION (2, 30, 0)
+	gtk_widget_destroy (GTK_WIDGET (liferea_dialog_lookup (pd->dialog, "itpInfoBar")));
+	widget = liferea_dialog_lookup (pd->dialog, "itpbtn");
+	conf_get_bool_value (ENABLE_ITP, &bSetting);
+	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (widget), bSetting);
+#else
+	gtk_widget_set_sensitive (GTK_WIDGET (liferea_dialog_lookup (pd->dialog, "itpbtn")), FALSE);
+	gtk_widget_show (GTK_WIDGET (liferea_dialog_lookup (pd->dialog, "itpInfoBar")));
+#endif
 	/* ================= panel 7 "Enclosures" ======================== */
 
 	/* menu for download tool */


### PR DESCRIPTION
Adds the option to enable WebKit's intelligent tracking protection,
enabled by default, to the settings.
Adds a check button in the privacy tab, with a notice if WebKitGtk
version is too low.
Fixes #881 

For some reason the gschema file has dos line endings ... Should that be changed ?

Also, about the preference dialog, I don't see a way to add links or have wrapping text in the GtkCheckButton embedded label. I tried putting no text in that label, and all the text in a GtkLabel to the right, but then I could not have the mnemonic for accessibility work as it should, even after setting this label as labelling the checkbox. And also the text was not aligned with the text of the other GtkCheckButton above ... I wanted to include the link to https://webkit.org/tracking-prevention/ (or another ?) to have a more detailed explanation of the feature. The result is not really pretty ... If the label with the link is under the checkbox, it is also hard to align in a "nice" way ...