### PR TITLE
Add cleanup of metadata rows

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -565,6 +565,10 @@ db_init (void)
 	db_exec ("DELETE FROM subscription_metadata WHERE node_id NOT IN "
           	 "(SELECT node_id FROM node);");
 
+	debug0 (DEBUG_DB, "Removing metadata without item...\n");
+	db_exec ("DELETE FROM metadata WHERE item_id NOT IN "
+		 "(SELECT item_id FROM items);");
+
 	debug0 (DEBUG_DB, "DB cleanup finished. Continuing startup.");
 		
 	/* 4. Creating triggers (after cleanup so it is not slowed down by triggers) */


### PR DESCRIPTION
This adds deleting the metadata rows that don't have a corresponding item in the DB cleanup stage.

This is related to #884 but I'm not sure it fixes it. If the leftover rows are caused by crashes, then is enough to solve it. Anyway, I think it is logical to clean that table too.

Maybe there should be a better debug log to keep track that there *were* anomalous rows that needed to be removed.