### PR TITLE
Fixes #903: Fix autodiscovery endless loop

### DIFF
--- a/src/comments.c
+++ b/src/comments.c
@@ -132,9 +132,8 @@ comments_process_update_result (const struct updateResult * const result, gpoint
 		node_set_subscription (node, ctxt->subscription);
 		ctxt->data = result->data;
 		ctxt->dataLength = result->size;
-		feed_parse (ctxt);
 
-		if (ctxt->failed) {
+		if (!feed_parse (ctxt)) {
 			debug0 (DEBUG_UPDATE, "parsing comment feed failed!");
 		} else {
 			itemSetPtr	comments;

--- a/src/feed.c
+++ b/src/feed.c
@@ -318,17 +318,15 @@ feed_process_update_result (subscriptionPtr subscription, const struct updateRes
 		ctxt->subscription = subscription;
 
 		/* try to parse the feed */
-		feed_parse (ctxt);
-
-		if (ctxt->failed) {
+		if (!feed_parse (ctxt)) {
 			/* No feed found, display an error */
 			node->available = FALSE;
 
 			g_string_prepend (feed->parseErrors, _("<p>Could not detect the type of this feed! Please check if the source really points to a resource provided in one of the supported syndication formats!</p>"
 			                                       "XML Parser Output:<br /><div class='xmlparseroutput'>"));
 			g_string_append (feed->parseErrors, "</div>");
-		} else if (!ctxt->failed && !ctxt->feed->fhp) {
-			/* There's a feed but no Handler. This means autodiscovery
+		} else if (!ctxt->feed->fhp) {
+			/* There's a feed but no handler. This means autodiscovery
 			 * found a feed, but we still need to download it.
 			 * An update should be in progress that will process it */
 		} else {

--- a/src/feed_parser.c
+++ b/src/feed_parser.c
@@ -93,7 +93,7 @@ feed_create_parser_ctxt (void)
 
 void
 feed_free_parser_ctxt (feedParserCtxtPtr ctxt)
-{https://www.groupe-ldlc.com/communiques-de-presse/
+{
 	if (ctxt) {
 		/* Don't free the itemset! */
 		g_hash_table_destroy (ctxt->tmpdata);

--- a/src/feed_parser.c
+++ b/src/feed_parser.c
@@ -178,7 +178,6 @@ feed_parse (feedParserCtxtPtr ctxt)
 	xmlNodePtr	xmlNode = NULL, htmlNode = NULL;
 	xmlDocPtr	xmlDoc, htmlDoc;
 	gboolean	autoDiscovery = FALSE, success = FALSE;
-	gboolean	htmlParsing = FALSE;
 
 	debug_enter ("feed_parse");
 

--- a/src/feed_parser.c
+++ b/src/feed_parser.c
@@ -30,6 +30,8 @@
 #include "parsers/ldjson_feed.h"
 #include "parsers/rss_channel.h"
 
+#define AUTO_DISCOVERY_MAX_REDIRECTS	5
+
 static GSList *feedHandlers = NULL;	/**< list of available parser implementations */
 
 struct feed_type {
@@ -91,7 +93,7 @@ feed_create_parser_ctxt (void)
 
 void
 feed_free_parser_ctxt (feedParserCtxtPtr ctxt)
-{
+{https://www.groupe-ldlc.com/communiques-de-presse/
 	if (ctxt) {
 		/* Don't free the itemset! */
 		g_hash_table_destroy (ctxt->tmpdata);
@@ -106,7 +108,7 @@ feed_free_parser_ctxt (feedParserCtxtPtr ctxt)
  * this source instead into the given feed parsing context. It also
  * replaces the HTTP URI with the found feed source.
  *
- * Mutates ctxt->failed and ctxt->feed->parseErrors
+ * Mutates ctxt->feed->parseErrors
  */
 static gboolean
 feed_parser_auto_discover (feedParserCtxtPtr ctxt)
@@ -119,7 +121,7 @@ feed_parser_auto_discover (feedParserCtxtPtr ctxt)
 	else
 		ctxt->feed->parseErrors = g_string_new(NULL);
 
-	debug1 (DEBUG_UPDATE, "Starting feed auto discovery (%s)", subscription_get_source (ctxt->subscription));
+	debug2 (DEBUG_UPDATE, "Starting feed auto discovery (%s) redirects=%d", subscription_get_source (ctxt->subscription), ctxt->subscription->autoDiscoveryTries);
 
 	links = html_auto_discover_feed (ctxt->data, subscription_get_source (ctxt->subscription));
 	if (links)
@@ -128,7 +130,6 @@ feed_parser_auto_discover (feedParserCtxtPtr ctxt)
 	/* FIXME: we only need the !g_str_equal as a workaround after a 404 */
 	if (source && !g_str_equal (source, subscription_get_source (ctxt->subscription))) {
 		debug1 (DEBUG_UPDATE, "Discovered link: %s", source);
-		ctxt->failed = FALSE;
 		subscription_set_source (ctxt->subscription, source);
 
 		/* The feed that was processed wasn't the correct one, we need to redownload it.
@@ -136,10 +137,13 @@ feed_parser_auto_discover (feedParserCtxtPtr ctxt)
 		subscription_cancel_update (ctxt->subscription);
 		subscription_update (ctxt->subscription, FEED_REQ_RESET_TITLE);
 		g_free (source);
-	} else {
-		debug0 (DEBUG_UPDATE, "No feed link found!");
-		g_string_append (ctxt->feed->parseErrors, _("The URL you want Liferea to subscribe to points to a webpage and the auto discovery found no feeds on this page. Maybe this webpage just does not support feed auto discovery."));
+
+		return TRUE;
 	}
+
+	debug0 (DEBUG_UPDATE, "No feed link found!");
+	g_string_append (ctxt->feed->parseErrors, _("The URL you want Liferea to subscribe to points to a webpage and the auto discovery found no feeds on this page. Maybe this webpage just does not support feed auto discovery."));
+	return FALSE;
 }
 
 static void
@@ -155,7 +159,6 @@ feed_parser_ctxt_cleanup (feedParserCtxtPtr ctxt)
 	metadata_list_free (ctxt->subscription->metadata);
 
 	ctxt->subscription->metadata = NULL;
-	ctxt->failed = FALSE;
 }
 
 /**
@@ -174,14 +177,12 @@ feed_parse (feedParserCtxtPtr ctxt)
 {
 	xmlNodePtr	xmlNode = NULL, htmlNode = NULL;
 	xmlDocPtr	xmlDoc, htmlDoc;
-	gboolean	success = FALSE;
+	gboolean	autoDiscovery = FALSE, success = FALSE;
 	gboolean	htmlParsing = FALSE;
 
 	debug_enter ("feed_parse");
 
 	g_assert (NULL == ctxt->items);
-
-	ctxt->failed = TRUE;	/* reset on success ... */
 
 	if (ctxt->feed->parseErrors)
 		g_string_truncate (ctxt->feed->parseErrors, 0);
@@ -235,15 +236,22 @@ feed_parse (feedParserCtxtPtr ctxt)
 			ctxt->feed->fhp = handler;
 			feed_parser_ctxt_cleanup (ctxt);
 			(*(handler->feedParser)) (ctxt, handler->html?htmlNode:xmlNode);
+			success = TRUE;
 			break;
 		}
 		handlerIter = handlerIter->next;
 	}
 
-	/* 2.) None of the feed formats did work, chance is high that we are
+	/* 3.) None of the feed formats did work, chance is high that we are
 	       working on a HTML documents. Let's look for feed links inside it! */
-	if (ctxt->failed)
-		feed_parser_auto_discover (ctxt);
+	if (!success) {
+		ctxt->subscription->autoDiscoveryTries++;
+		if (ctxt->subscription->autoDiscoveryTries > AUTO_DISCOVERY_MAX_REDIRECTS) {
+			debug2 (DEBUG_UPDATE, "Stopping feed auto discovery (%s) after too many redirects (limit is %d)", subscription_get_source (ctxt->subscription), AUTO_DISCOVERY_MAX_REDIRECTS);
+		} else {
+			autoDiscovery = feed_parser_auto_discover (ctxt);
+		}
+	}
 
 	if (htmlDoc)
 		xmlFreeDoc (htmlDoc);
@@ -251,7 +259,7 @@ feed_parse (feedParserCtxtPtr ctxt)
 		xmlFreeDoc (xmlDoc);
 
 	/* 4.) We give up and inform the user */
-	if (ctxt->failed) {
+	if (!success && !autoDiscovery) {
 		/* test if we have a HTML page */
 		if ((strstr (ctxt->data, "<html>") || strstr (ctxt->data, "<HTML>") ||
 		     strstr (ctxt->data, "<html ") || strstr (ctxt->data, "<HTML "))) {
@@ -262,7 +270,14 @@ feed_parse (feedParserCtxtPtr ctxt)
 			g_string_append (ctxt->feed->parseErrors, _("Could not determine the feed type."));
 		}
 	} else {
-		debug1 (DEBUG_UPDATE, "discovered feed format: %s", feed_type_fhp_to_str (ctxt->feed->fhp));
+		if (ctxt->feed->fhp) {
+			debug1 (DEBUG_UPDATE, "discovered feed format: %s", feed_type_fhp_to_str (ctxt->feed->fhp));
+			ctxt->subscription->autoDiscoveryTries = 0;
+		} else {
+			/* Auto discovery found a link that is being processed
+			   asynchronously, for now we do not know wether it will
+			   succeed. Still our auto-discovery was successful. */
+		}
 		success = TRUE;
 	}
 

--- a/src/feed_parser.h
+++ b/src/feed_parser.h
@@ -27,19 +27,17 @@
 
 /** Holds all information used on feed parsing time */
 typedef struct feedParserCtxt {
-	subscriptionPtr	subscription;	/**< the subscription the feed belongs to (optional) */
-	feedPtr		feed;		/**< the feed structure to fill */
-	GList		*items;		/**< the list of new items */
-	struct item	*item;		/**< the item currently parsed (or NULL) */
+	subscriptionPtr	subscription;		/**< the subscription the feed belongs to (optional) */
+	feedPtr		feed;			/**< the feed structure to fill */
+	GList		*items;			/**< the list of new items */
+	struct item	*item;			/**< the item currently parsed (or NULL) */
 
-	GHashTable	*tmpdata;	/**< tmp data hash used during stateful parsing */
+	GHashTable	*tmpdata;		/**< tmp data hash used during stateful parsing */
 
-	gchar		*title;		/**< resulting feed/channel title */
+	gchar		*title;			/**< resulting feed/channel title */
 
-	gchar		*data;		/**< data buffer to parse */
-	gsize		dataLength;	/**< length of the data buffer */
-
-	gboolean	failed;		/**< TRUE if parsing failed because feed type could not be detected */
+	gchar		*data;			/**< data buffer to parse */
+	gsize		dataLength;		/**< length of the data buffer */
 } *feedParserCtxtPtr;
 
 

--- a/src/subscription.h
+++ b/src/subscription.h
@@ -1,12 +1,12 @@
 /**
  * @file subscription.h  common subscription handling interface
- * 
+ *
  * Copyright (C) 2003-2012 Lars Windolf <lars.windolf@gmx.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version. 
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -19,7 +19,7 @@
  */
 #ifndef _SUBSCRIPTION_H
 #define _SUBSCRIPTION_H
- 
+
 #include <glib.h>
 #include <libxml/parser.h>
 #include "node.h"
@@ -38,27 +38,29 @@ enum feed_request_flags {
 	FEED_REQ_RESET_TITLE		= (1<<0),	/**< Feed's title should be reset to default upon update */
 	FEED_REQ_PRIORITY_HIGH		= (1<<3),	/**< set to signal that this is an important user triggered request */
 };
- 
+
 /** Common structure to hold all information about a single subscription. */
 typedef struct subscription {
 	nodePtr		node;			/**< the feed list node the subscription is attached to */
 	struct subscriptionType *type;		/**< the subscription type */
-	
+
 	gchar		*source;		/**< current source, can be changed by redirects */
 	gchar		*origSource;		/**< the source given when creating the subscription */
 	updateOptionsPtr updateOptions;		/**< update options for the feed source */
 	struct updateJob *updateJob;		/**< update request structure used when downloading the subscribed source */
-	
-	gint		updateInterval;		/**< user defined update interval in minutes */	
+
+	gint		updateInterval;		/**< user defined update interval in minutes */
 	guint		defaultInterval;	/**< optional update interval as specified by the feed in minutes */
-	
+
 	GSList		*metadata;		/**< metadata list assigned to this subscription */
-	
+
 	gchar		*updateError;		/**< textual description of processing errors */
 	gchar		*httpError;		/**< textual description of HTTP protocol errors */
 	gint		httpErrorCode;		/**< last HTTP error code */
 	updateStatePtr	updateState;		/**< update states (etag, last modified, cookies, last polling times...) */
-	
+
+	guint		autoDiscoveryTries;	/**< counter to break auto discovery redirect circles */
+
 	gboolean	activeAuth;		/**< TRUE if authentication in progress */
 
 	gboolean	discontinued;		/**< flag to avoid updating after HTTP 410 */
@@ -106,7 +108,7 @@ void subscription_export (subscriptionPtr subscription, xmlNodePtr xml, gboolean
 void subscription_to_xml (subscriptionPtr subscription, xmlNodePtr xml);
 
 /**
- * Triggers updating a subscription. Will download the 
+ * Triggers updating a subscription. Will download the
  * the document indicated by the source URL of the subscription.
  * Will call the node type specific update callback to process
  * the downloaded data.
@@ -232,7 +234,7 @@ void subscription_set_filter(subscriptionPtr subscription, const gchar * filter)
 
 /**
  * Set authentication information for a given subscription
- * 
+ *
  * @param subscription	the subscription
  * @param username	the user name
  * @param password	the password
@@ -243,7 +245,7 @@ void subscription_set_auth_info (subscriptionPtr subscription, const gchar *user
  * Frees the given subscription structure.
  *
  * @param subscription	the subscription
- */ 
+ */
 void subscription_free(subscriptionPtr subscription);
 
 #endif


### PR DESCRIPTION
- Add audodiscovery redirect counter to subscription
- Stops after 5 redirects
- Drop mutation of ctxt->failed use return codes instead