### PR TITLE
Register liferea custom scheme, fixes #973

### DIFF
--- a/src/webkit/webkit.c
+++ b/src/webkit/webkit.c
@@ -392,12 +392,29 @@ liferea_webkit_impl_download_started (WebKitWebContext	*context,
 }
 
 static void
+liferea_webkit_handle_liferea_scheme (WebKitURISchemeRequest *request, gpointer user_data)
+{
+	const gchar *uri = webkit_uri_scheme_request_get_uri (request);
+	GInputStream *stream;
+	gssize length;
+	gchar *contents;
+
+	contents = g_strdup_printf ("Placeholder handler for liferea scheme. URI requested : %s", uri);
+	length = (gssize) strlen (contents);
+	stream = g_memory_input_stream_new_from_data (contents, length, g_free);
+	webkit_uri_scheme_request_finish (request, stream, length, "text/plain");
+	g_object_unref (stream);
+}
+
+static void
 liferea_webkit_impl_init (LifereaWebKitImpl *self)
 {
 	gboolean	disable_javascript, enable_plugins, enable_itp;
 	WebKitSecurityManager *security_manager;
 	WebKitWebsiteDataManager *website_data_manager;
 	self->dbus_connections = NULL;
+	webkit_web_context_register_uri_scheme (webkit_web_context_get_default(), "liferea",
+		(WebKitURISchemeRequestCallback) liferea_webkit_handle_liferea_scheme,NULL,NULL);
 
 	security_manager = webkit_web_context_get_security_manager (webkit_web_context_get_default ());
 	website_data_manager = webkit_web_context_get_website_data_manager (webkit_web_context_get_default ());


### PR DESCRIPTION
It used to be enough to declare the liferea custom scheme as local to
access resources with file scheme, but for WebKit2Gtk >= 2.32 it looks
like it is necessary to register the custom scheme with a handler.
This fixes #973

The handler doesn't do anything interesting for now as we just pass the
content with webkit_web_view_load_bytes and use the file scheme to
access resources, but it could be used to load Liferea resources in the
future ...
