### PR TITLE
net: Do not add a second content decoder to the libsoup session

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -338,13 +338,11 @@ network_init (void)
 						 SOUP_SESSION_TIMEOUT, 120,
 						 SOUP_SESSION_IDLE_TIMEOUT, 30,
 						 SOUP_SESSION_ADD_FEATURE, cookies,
-	                                         SOUP_SESSION_ADD_FEATURE_BY_TYPE, SOUP_TYPE_CONTENT_DECODER,
 						 NULL);
 	session2 = soup_session_new_with_options (SOUP_SESSION_USER_AGENT, useragent,
 						  SOUP_SESSION_TIMEOUT, 120,
 						  SOUP_SESSION_IDLE_TIMEOUT, 30,
 						  SOUP_SESSION_ADD_FEATURE, cookies,
-	                                          SOUP_SESSION_ADD_FEATURE_BY_TYPE, SOUP_TYPE_CONTENT_DECODER,
 						  SOUP_SESSION_PROXY_URI, NULL,
 						  SOUP_SESSION_PROXY_RESOLVER, NULL,
 						  NULL);


### PR DESCRIPTION
The default soup session constructor already adds a content decoder.
This was harmless so far as long as there was only the deflate/gzip decoder,
which didn't mind being passed plain text content that was already
ungzipped, but becomes more problematic now that libsoup also supports
brotli compression.

See https://gitlab.gnome.org/GNOME/libsoup/-/issues/146 for some context