### PR TITLE
changes for #788 - introduce defer delete mode for Search folders

### DIFF
--- a/doc/html/preferences_en.html
+++ b/doc/html/preferences_en.html
@@ -92,6 +92,12 @@
 	<b>Default View Mode</b> Select your favourite viewing mode here.
 	</li>
 
+        <li>
+        <b>Defer removing read items from Search Folder</b>  When reading items from a Search Folder, like
+            'Unread', defer removing the items from the UI until you leave the folder.  This allows
+            re-reading read items or marking them unread.  Read items appear in light-weight font.
+        </li>
+
 	<li>
 	<b>Web Integration:</b> Here you can configure your favourite
 	social bookmarking website. This setting is used when you invoke

--- a/glade/prefs.ui
+++ b/glade/prefs.ui
@@ -546,6 +546,23 @@
                         <property name="top_attach">2</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkCheckButton" id="deferdeletebtn">
+                        <property name="label" translatable="yes">_Defer removing read items from Search Folder.</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_start">12</property>
+                        <property name="use_underline">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_deferdeletemode_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
                     <accessibility>
                       <relation type="labelled-by" target="readingHeadlinesLabel"/>
                     </accessibility>

--- a/net.sf.liferea.gschema.xml.in
+++ b/net.sf.liferea.gschema.xml.in
@@ -32,6 +32,11 @@
       <summary>The default view mode for feed list nodes.</summary>
       <description>The default view mode for displaying feed list nodes. Possible values: 0=email like 3-pane, 1=wide view 3-pane</description>
     </key>
+    <key name="defer-delete-mode" type="b">
+      <default>false</default>
+      <summary>Defer deleting items from the Search Folder.</summary>
+      <description>If this option is enabled, defer deleting read items from UI until the folder is switched.</description>
+    </key>
     <key name="default-update-interval" type="i">
       <default>0</default>
       <summary>Default interval for fetching feeds.</summary>

--- a/src/conf.h
+++ b/src/conf.h
@@ -33,6 +33,7 @@
 #define BROWSER_COMMAND			"browser"
 
 #define DEFAULT_VIEW_MODE		"default-view-mode"
+#define DEFER_DELETE_MODE               "defer-delete-mode"
 
 #define DEFAULT_FONT			"document-font-name"
 #define USER_FONT			"browser-font"

--- a/src/item.h
+++ b/src/item.h
@@ -49,6 +49,7 @@ typedef struct item {
 	gboolean	updateStatus;		/*<< TRUE if the item content was updated */
 	gboolean 	flagStatus;		/*<< TRUE if the item has been flagged */
 	gboolean	hasEnclosure;		/*<< TRUE if this item has at least one enclosure */
+        gboolean        isHidden;               /**< TRUE if this item has been 'hidden' in search folder */
 	gchar		*title;			/*<< Title */
 	gchar		*source;		/*<< URL to the post online */
 	gchar		*sourceId;		/*<< "Unique" syndication item identifier, for example <guid> in RSS */

--- a/src/itemlist.c
+++ b/src/itemlist.c
@@ -176,15 +176,22 @@ itemlist_check_for_deferred_action (void)
 {
 	gulong	id = itemlist->priv->selectedId;
 	itemPtr	item;
+	gboolean  defer_remove;
 
 	if (id) {
 		itemlist_set_selected (NULL);
+                conf_get_bool_value (DEFER_DELETE_MODE, &defer_remove);
 
 		/* check for removals caused by itemlist filter rule */
 		if (itemlist->priv->deferredFilter) {
 			itemlist->priv->deferredFilter = FALSE;
 			item = item_load (id);
-			itemview_remove_item (item);
+                        item->isHidden = TRUE;
+                        if (defer_remove) {
+                                itemview_update_item (item);
+                        } else {
+                                itemview_remove_item (item);
+                        }
 			feed_list_view_update_node (item->nodeId);
 		}
 
@@ -440,6 +447,7 @@ static void
 itemlist_unhide_item (itemPtr item)
 {
 	itemlist->priv->deferredFilter = FALSE;
+        item->isHidden = FALSE;
 }
 
 /* functions to remove items on remove requests */

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -471,6 +471,7 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, GtkTreeIte
 	gchar		*title, *time_str;
 	const GIcon	*state_icon;
 	gint		state = 0;
+        int fontWeight = PANGO_WEIGHT_BOLD;
 
 	if (item->flagStatus)
 		state += 2;
@@ -503,6 +504,9 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, GtkTreeIte
 	             !item->readStatus ? icon_get (ICON_UNREAD) :
 		     NULL;
 
+        if (item->readStatus)
+                fontWeight = item->isHidden ? PANGO_WEIGHT_ULTRALIGHT : PANGO_WEIGHT_NORMAL;
+
 	if (ilv->batch_mode)
 		itemstore = ilv->batch_itemstore;
 	else
@@ -519,7 +523,7 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, GtkTreeIte
                             IS_ENCICON, item->hasEnclosure?icon_get (ICON_ENCLOSURE):NULL,
                             IS_ENCLOSURE, item->hasEnclosure,
 		            IS_STATE, state,
-	                    ITEMSTORE_WEIGHT, item->readStatus ? PANGO_WEIGHT_NORMAL : PANGO_WEIGHT_BOLD,
+	                    ITEMSTORE_WEIGHT, fontWeight,
 			    -1);
         } else {
                 gtk_tree_store_set (itemstore, iter,
@@ -534,7 +538,7 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, GtkTreeIte
                             IS_ENCLOSURE, item->hasEnclosure,
                             IS_SOURCE, node,
                             IS_STATE, state,
-	                    ITEMSTORE_WEIGHT, item->readStatus ? PANGO_WEIGHT_NORMAL : PANGO_WEIGHT_BOLD,
+	                    ITEMSTORE_WEIGHT, fontWeight,
                             -1);
         }
 

--- a/src/ui/preferences_dialog.c
+++ b/src/ui/preferences_dialog.c
@@ -364,6 +364,15 @@ on_default_view_mode_changed (gpointer user_data)
 }
 
 void
+on_deferdeletemode_toggled (GtkToggleButton *togglebutton, gpointer user_data)
+{
+	gboolean	enabled;
+
+	enabled = gtk_toggle_button_get_active (togglebutton);
+	conf_set_bool_value (DEFER_DELETE_MODE, enabled);
+}
+
+void
 on_enclosure_download_predefined_toggled (GtkToggleButton *button, gpointer user_data)
 {
 	gboolean is_active = gtk_toggle_button_get_active (button);
@@ -540,6 +549,9 @@ preferences_dialog_init (PreferencesDialog *pd)
 	                            default_view_mode_options,
 	                            G_CALLBACK (on_default_view_mode_changed),
 	                            iSetting);
+
+	conf_get_bool_value (DEFER_DELETE_MODE, &bSetting);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON (liferea_dialog_lookup (pd->dialog, "deferdeletebtn")), bSetting?TRUE:FALSE);
 
 	/* Setup social bookmarking list */
 	i = 0;

--- a/src/ui/preferences_dialog.h
+++ b/src/ui/preferences_dialog.h
@@ -45,6 +45,7 @@ void preferences_dialog_open (void);
 /* functions used in glade/prefs.ui */
 void on_folderdisplaybtn_toggled (GtkToggleButton *togglebutton, gpointer user_data);
 void on_folderhidereadbtn_toggled (GtkToggleButton *togglebutton, gpointer user_data);
+void on_deferdeletemode_toggled (GtkToggleButton *togglebutton, gpointer user_data);
 void on_popupwindowsoptionbtn_clicked (GtkButton *button, gpointer user_data);
 void on_startupactionbtn_toggled (GtkButton *button, gpointer user_data);
 void on_browsercmd_changed (GtkEditable *editable, gpointer user_data);


### PR DESCRIPTION
Add UI preference 'Defer removing read items from Search Folder'.
Don't delete items from folder, like 'Unread', until leaving the folder.