### PR TITLE
Fixed the `aria2` download selection not using the proper command

### DIFF
--- a/src/ui/preferences_dialog.c
+++ b/src/ui/preferences_dialog.c
@@ -71,7 +71,7 @@ static const gchar * enclosure_download_commands[] = {
 	"kget %s",
 	"uget-gtk %s",
 	"transmission-gtk %s",
-	"aria2 %s"
+	"aria2c %s"
 };
 
 /** order must match enclosure_download_commands[] */


### PR DESCRIPTION
The correct aria2 download command is `aria2c`.