### PR TITLE
Add pango_find_base_dir replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ help you asap.
 ###### _Mandatory Dependencies_
 
    libxml2-dev libxslt1-dev libsqlite3-dev libwebkit2gtk-4.0-dev libjson-glib-dev libgirepository1.0-dev
-   libpeas-dev gsettings-desktop-schemas-dev python3 libtool intltool
+   libpeas-dev gsettings-desktop-schemas-dev python3 libtool intltool fribidi-dev
 
    
 ###### _Compiling from Tarball_

--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,8 @@ pkg_modules="	gtk+-3.0 >= 3.22.0
 		gobject-introspection-1.0
 		gsettings-desktop-schemas
 		libpeas-1.0 >= 1.0.0
-		libpeas-gtk-1.0 >= 1.0.0"
+		libpeas-gtk-1.0 >= 1.0.0
+		fribidi >= 0.19.7"
 
 ################################################################################
 

--- a/src/common.h
+++ b/src/common.h
@@ -28,6 +28,7 @@
 #include <libxml/parser.h>
 #include <glib.h>
 #include <string.h>
+#include <pango/pango-direction.h>
 
 /*
  * Standard gettext macros
@@ -132,6 +133,22 @@ xmlChar * common_uri_sanitize(const xmlChar *uri);
  * @returns new string with resulting absolute URL
  */
 xmlChar * common_build_url(const gchar *url, const gchar *baseURL);
+
+/**
+ * Replacement for deprecated pango_find_base_dir
+ * Searches a string the first character that has a strong direction,
+ * according to the Unicode bidirectional algorithm.
+ *
+ * @param text		The text to process. Must be valid UTF-8
+ *
+ * @param length	Length of text in bytes 
+ * 					(may be -1 if text is nul-terminated)
+ *
+ * @returns 		The direction corresponding to the first strong character.
+ * 					If no such character is found, then 
+ * 					PANGO_DIRECTION_NEUTRAL is returned.
+ */
+PangoDirection common_find_base_dir (const gchar *text, gint length);
 
 /**
  * Analyzes the string, returns a direction setting immediately

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -453,7 +453,7 @@ item_list_title_alignment (gchar *title)
 
 	/* debug5 (DEBUG_HTML, "title ***%s*** first bytes %02hhx%02hhx%02hhx pango %d",
 		title, title[0], title[1], title[2], pango_find_base_dir (title, -1)); */
-	int txt_direction = pango_find_base_dir (title, -1);
+	int txt_direction = common_find_base_dir (title, -1);
   	int app_direction = gtk_widget_get_default_direction ();
 	if ((txt_direction == PANGO_DIRECTION_LTR &&
 	     app_direction == GTK_TEXT_DIR_LTR) ||


### PR DESCRIPTION
Because pango_find_base_dir replacement is deprecated I wrote a replacement for this function.
The code is based on the original function and is a combination of two functions pango_find_base_dir and pango_unichar_direction.
New function is named common_find_base_dir
fribidi library is now required to build and use.