### PR TITLE
Fix typo in "There are two option"

### DIFF
--- a/doc/html/enclosures_en.html
+++ b/doc/html/enclosures_en.html
@@ -60,7 +60,7 @@
 	<p>Of course you can also <b>manually download</b> enclosures.
 	To do so open the item with the enclosure and click the 
 	arrow to open the enclosure context menu. There are two
-	option. The first one downloads and launches the file
+	options. The first one downloads and launches the file
 	while the second option save the file into a specified
 	directory.
 	</p>


### PR DESCRIPTION
Should be plural.