### PR TITLE
use g_memdup2 only when it is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,10 +48,13 @@ pkg_modules="	gtk+-3.0 >= 3.22.0
 
 ################################################################################
 
+
 PKG_CHECK_MODULES(PACKAGE, [$pkg_modules])
 
+AC_CHECK_LIB(glib-2.0, g_memdup2, [PACKAGE_CFLAGS="$PACKAGE_CFLAGS -DHAVE_G_MEMDUP2"])
 AC_SUBST(PACKAGE_CFLAGS)
 AC_SUBST(PACKAGE_LIBS)
+
 
 PKG_CHECK_MODULES([WEB_EXTENSION], [
                   webkit2gtk-web-extension-4.0

--- a/src/net.c
+++ b/src/net.c
@@ -86,7 +86,12 @@ network_process_callback (SoupSession *session, SoupMessage *msg, gpointer user_
 	debug1 (DEBUG_NET, "download status code: %d", msg->status_code);
 	debug1 (DEBUG_NET, "source after download: >>>%s<<<", job->result->source);
 
+#ifdef HAVE_G_MEMDUP2
 	job->result->data = g_memdup2 (msg->response_body->data, msg->response_body->length+1);
+#else
+	job->result->data = g_memdup (msg->response_body->data, msg->response_body->length+1);
+#endif
+
 	job->result->size = (size_t)msg->response_body->length;
 	debug1 (DEBUG_NET, "%d bytes downloaded", job->result->size);
 

--- a/src/ui/liferea_shell.h
+++ b/src/ui/liferea_shell.h
@@ -22,7 +22,6 @@
 #ifndef _LIFEREA_SHELL_H
 #define _LIFEREA_SHELL_H
 
-#define _DEFAULT_SOURCE
 #include <string.h>
 #include <glib-object.h>
 #include <glib.h>


### PR DESCRIPTION
g_memdep2 is available since glib 2.68 but liferea requires min. 2.50
Now it causes problems with the building on the older systems like Ubuntu 18.04 which is used by CodeQL.