### PR TITLE
Add option to always show news bins in the reduced feed list

### DIFF
--- a/glade/new_newsbin.ui
+++ b/glade/new_newsbin.ui
@@ -9,7 +9,6 @@
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <property name="type_hint">dialog</property>
-    <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
     <child>
       <placeholder/>
     </child>
@@ -32,7 +31,7 @@
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="new_newsbin" swapped="yes"/>
+                <signal name="clicked" handler="gtk_widget_destroy" object="new_newsbin" swapped="yes"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -49,8 +48,6 @@
                 <property name="has_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="gtk_widget_hide" object="new_newsbin" after="yes" swapped="yes"/>
-                <signal name="clicked" handler="on_newnewsbinbtn_clicked" object="new_newsbin" swapped="yes"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -95,6 +92,21 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="newsbinalwaysshowinreduced">
+                <property name="label" translatable="yes">_Always show in Reduced Feed List</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+                <property name="width">2</property>
               </packing>
             </child>
           </object>

--- a/src/feed.h
+++ b/src/feed.h
@@ -60,6 +60,7 @@ typedef struct feed {
 	gboolean	ignoreComments;		/**< if TRUE ignore comment feeds for this feed */
 	gboolean	markAsRead;		/**< if TRUE downloaded items are automatically marked as read */
 	gboolean	html5Extract;		/**< if TRUE try to fetch extra content via HTML5 / Google AMP */
+	gboolean	alwaysShowInReduced;	/**< for newsbins only, if TRUE always show when using reduced feed list */
 } *feedPtr;
 
 /**

--- a/src/newsbin.c
+++ b/src/newsbin.c
@@ -33,7 +33,6 @@
 #include "ui/feed_list_view.h"
 #include "ui/liferea_dialog.h"
 
-static GtkWidget *newnewsbindialog = NULL;
 static GSList * newsbin_list = NULL;
 
 GSList *
@@ -45,16 +44,35 @@ newsbin_get_list (void)
 static void
 newsbin_import (nodePtr node, nodePtr parent, xmlNodePtr cur, gboolean trusted)
 {
+	xmlChar		*tmp;
 	feed_get_node_type ()->import (node, parent, cur, trusted);
 
 	/* but we don't need a subscription (created by feed_import()) */
 	g_free (node->subscription);
 	node->subscription = NULL;
 
+	tmp = xmlGetProp (cur, BAD_CAST"alwaysShowInReducedMode");
+	if (tmp && !xmlStrcmp (tmp, BAD_CAST"true"))
+		((feedPtr)node->data)->alwaysShowInReduced = TRUE;
+	xmlFree (tmp);
+
 	((feedPtr)node->data)->cacheLimit = CACHE_UNLIMITED;
 
 	newsbin_list = g_slist_append(newsbin_list, node);
 }
+
+
+static void
+newsbin_export (nodePtr node, xmlNodePtr xml, gboolean trusted)
+{
+	feedPtr feed = (feedPtr) node->data;
+
+	if (trusted) {
+		if (feed->alwaysShowInReduced)
+			xmlNewProp (xml, BAD_CAST"alwaysShowInReducedMode", BAD_CAST"true");
+	}
+}
+
 
 static void
 newsbin_remove (nodePtr node)
@@ -76,35 +94,76 @@ newsbin_render (nodePtr node)
 	return output;
 }
 
-static gboolean
-ui_newsbin_add (void)
+
+static void
+on_newsbin_common_btn_clicked (GtkButton *button, gpointer user_data)
 {
-	GtkWidget	*nameentry;
+	GtkWidget	*dialog = gtk_widget_get_toplevel (GTK_WIDGET (button));
+	GtkWidget	*nameentry = liferea_dialog_lookup (dialog, "newsbinnameentry");
+	GtkWidget	*showinreduced = liferea_dialog_lookup (dialog, "newsbinalwaysshowinreduced");
+	nodePtr		newsbin = (nodePtr) user_data;
+	gboolean	newly_created = FALSE;
 
-	if (!newnewsbindialog || !G_IS_OBJECT (newnewsbindialog))
-		newnewsbindialog = liferea_dialog_new ("new_newsbin");
+	if (newsbin == NULL) {
+		newsbin = node_new (newsbin_get_node_type ());
+		node_set_data (newsbin, (gpointer)feed_new ());
+		newsbin_list = g_slist_append(newsbin_list, newsbin);
+		newly_created = TRUE;
+	}
 
-	nameentry = liferea_dialog_lookup (newnewsbindialog, "newsbinnameentry");
-	gtk_entry_set_text (GTK_ENTRY (nameentry), "");
+	node_set_title (newsbin, (gchar *)gtk_entry_get_text (GTK_ENTRY (nameentry)));
+	if (newsbin->data) {
+		((feedPtr)newsbin->data)->alwaysShowInReduced = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (showinreduced));
+	}
+	if (newly_created) {
+		feedlist_node_added (newsbin);
+	}
 
-	gtk_window_present (GTK_WINDOW (newnewsbindialog));
+	feedlist_schedule_save ();
+	gtk_widget_destroy (dialog);
+}
+
+
+static gboolean
+ui_newsbin_common (nodePtr node)
+{
+	GtkWidget	*dialog = liferea_dialog_new ("new_newsbin");
+	GtkWidget	*nameentry = liferea_dialog_lookup (dialog, "newsbinnameentry");
+	GtkWidget	*showinreduced = liferea_dialog_lookup (dialog, "newsbinalwaysshowinreduced");
+	GtkWidget	*okbutton = liferea_dialog_lookup (dialog, "newnewsbinbtn");
+
+	if (node) {
+		gtk_window_set_title (GTK_WINDOW (dialog), _("News Bin Properties"));
+		gtk_entry_set_text (GTK_ENTRY (nameentry), node_get_title (node));
+		gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (showinreduced), ((feedPtr)node->data)->alwaysShowInReduced);
+	} else {
+		gtk_window_set_title (GTK_WINDOW (dialog), _("Create News Bin"));
+		gtk_entry_set_text (GTK_ENTRY (nameentry), "");
+		gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (showinreduced), FALSE);
+	}
+
+	g_signal_connect (G_OBJECT (okbutton), "clicked",
+	                  G_CALLBACK (on_newsbin_common_btn_clicked), node);
+
+	gtk_window_present (GTK_WINDOW (dialog));
 
 	return TRUE;
 }
 
-void
-on_newnewsbinbtn_clicked (GtkButton *button, gpointer user_data)
+
+static gboolean
+ui_newsbin_add (void)
 {
-	nodePtr		newsbin;
-
-	newsbin = node_new (newsbin_get_node_type ());
-	node_set_title (newsbin, (gchar *)gtk_entry_get_text (GTK_ENTRY (liferea_dialog_lookup (newnewsbindialog, "newsbinnameentry"))));
-	node_set_data (newsbin, (gpointer)feed_new ());
-
-	newsbin_list = g_slist_append(newsbin_list, newsbin);
-
-	feedlist_node_added (newsbin);
+	return ui_newsbin_common(NULL);
 }
+
+
+static void
+ui_newsbin_properties (nodePtr node)
+{
+	ui_newsbin_common(node);
+}
+
 
 void
 on_action_copy_to_newsbin (GSimpleAction *action, GVariant *parameter, gpointer user_data)
@@ -160,13 +219,13 @@ newsbin_get_node_type (void)
 		nodeType->icon			= icon_get (ICON_NEWSBIN);
 		nodeType->load			= feed_get_node_type()->load;
 		nodeType->import		= newsbin_import;
-		nodeType->export		= feed_get_node_type()->export;
+		nodeType->export		= newsbin_export;
 		nodeType->save			= feed_get_node_type()->save;
 		nodeType->update_counters	= feed_get_node_type()->update_counters;
 		nodeType->remove		= newsbin_remove;
 		nodeType->render		= newsbin_render;
 		nodeType->request_add		= ui_newsbin_add;
-		nodeType->request_properties	= feed_list_view_rename_node;
+		nodeType->request_properties	= ui_newsbin_properties;
 		nodeType->free			= feed_get_node_type()->free;
 	}
 

--- a/src/newsbin.h
+++ b/src/newsbin.h
@@ -21,17 +21,12 @@
 #ifndef _NEWSBIN_H
 #define _NEWSBIN_H
 
-#include <gtk/gtk.h>
 #include "node_type.h"
 
 /**
  * Returns a list of the names of all news bins
  */
 GSList * newsbin_get_list(void);
-
-/* UI callbacks */
-
-void on_newnewsbinbtn_clicked(GtkButton *button, gpointer user_data);
 
 /**
  * on_action_copy_to_newsbin: (skip)

--- a/src/ui/feed_list_view.c
+++ b/src/ui/feed_list_view.c
@@ -198,6 +198,9 @@ feed_list_view_filter_visible_function (GtkTreeModel *model, GtkTreeIter *iter, 
 	if (!node)
 		return FALSE;
 
+	if (IS_NEWSBIN(node) && node->data && ((feedPtr)node->data)->alwaysShowInReduced)
+		return TRUE;
+
 	if (IS_FOLDER (node) || IS_NODE_SOURCE (node))
 		return FALSE;
 


### PR DESCRIPTION
Add a new option "Always show in Reduced Feed List" to the news bin
properties so an user can make it appear there even when there are no
unread items. This enables some new and very practical workflows for
users wanting to use news bins to sort items or prepare reading lists
directly from the reduced view.

A new option always has a complexity cost for the user, but this one
seems worth it: the alternative of always showing news bins in the
reduced view, as happens with the search folders, can make the list
less useful for people who do not want all of them to be always there.

The setting is persisted in feedlist.opml, requires no changes to the
database schema and is forward and backwards compatible except, of
course, for the value being lost when loaded in a previews version.
Editing the option requires changes to the dialogs used to create news
bins and do not allow reusing the "rename node" dialog as a properties
dialog for this node type anymore. To prevent code duplication, the new
dialog is used both as a creating and a properties dialog.