### PR TITLE
Export source in node_source_export

### DIFF
--- a/src/fl_sources/node_source.c
+++ b/src/fl_sources/node_source.c
@@ -228,6 +228,8 @@ node_source_export (nodePtr node, xmlNodePtr xml, gboolean trusted)
 
 	subscription_export (node->subscription, xml, trusted);
 
+	NODE_SOURCE_TYPE (node)->source_export (node);
+
 	debug_exit("node_source_export");
 }
 


### PR DESCRIPTION
When exporting subscriptions, ensure that the subscription is exported in addition to the node source. Otherwise, feed preferences won't be saved on change until the next sync, among other things.