### PR TITLE
Upgrade CI runner to Ubuntu 20.04

### DIFF
--- a/.github/workflows/cb.yml
+++ b/.github/workflows/cb.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Needed to get compiling against libfribidi-dev to work