### PR TITLE
Allow building with libpango < 1.43.0

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -28,7 +28,7 @@
 #include <libxml/parser.h>
 #include <glib.h>
 #include <string.h>
-#include <pango/pango-direction.h>
+#include <pango/pango-bidi-type.h>
 
 /*
  * Standard gettext macros


### PR DESCRIPTION
I'm not that sure this commit is worth of merging as 1.43.0 is two years old
now, but Ubuntu 18.04 uses pango 1.40.x so perhaps keeping compatibility
has its value.

The workaround for the deprecation of text direction features in pango,
added by commit ab849555164bc3a6a287bd6a88ad5f83633efe8f , broke
compilation in older versions of libpango. As enums PANGO_DIRECTION_*
were moved to pango-direction.h in version 1.43.0 (commit
9fc788a6a6bde68cfeef7dbc4d55969638d82a4a in pango repo) and
pango-bidi-type.h was made to include it, we can include pango-bidi-type.h
and make the code work with all versions.

This causes no forward compatibility issues unless, of course, the API
is changed again.

