### PR TITLE
Use liferea_shell_show_window when reactivating

### DIFF
--- a/src/dbus.c
+++ b/src/dbus.c
@@ -72,7 +72,7 @@ liferea_dbus_set_online (LifereaDBus *self, gboolean online, GError **err)
 static gboolean
 liferea_dbus_subscribe (LifereaDBus *self, const gchar *url, GError **err)
 {
-	liferea_shell_present ();
+	liferea_shell_show_window ();
 	feedlist_add_subscription (url, NULL, NULL, 0);
 	return TRUE;
 }

--- a/src/liferea_application.c
+++ b/src/liferea_application.c
@@ -114,8 +114,7 @@ on_app_activate (GtkApplication *gtk_app, gpointer user_data)
 	list = gtk_application_get_windows (gtk_app);
 
 	if (list) {
-		gtk_window_deiconify (GTK_WINDOW (list->data));
-		gtk_window_present (GTK_WINDOW (list->data));
+		liferea_shell_show_window ();
 	} else {
 		liferea_shell_create (gtk_app, app->initialStateOption, app->pluginsDisabled);
 	}

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -1356,17 +1356,6 @@ liferea_shell_destroy (void)
 	g_object_unref (shell);
 }
 
-void
-liferea_shell_present (void)
-{
-	GtkWidget *mainwindow = GTK_WIDGET (shell->window);
-
-	if ((gdk_window_get_state (gtk_widget_get_window (mainwindow)) & GDK_WINDOW_STATE_ICONIFIED) || !gtk_widget_get_visible (mainwindow))
-		liferea_shell_restore_position ();
-
-	gtk_window_present (shell->window);
-}
-
 static gboolean
 liferea_shell_window_is_on_other_desktop(GdkWindow *gdkwindow)
 {

--- a/src/ui/liferea_shell.h
+++ b/src/ui/liferea_shell.h
@@ -79,13 +79,6 @@ void liferea_shell_create (GtkApplication *app, const gchar *overrideWindowState
 void liferea_shell_destroy (void);
 
 /**
- * liferea_shell_present:
- *
- * Presents the main window if it is hidden.
- */
-void liferea_shell_present (void);
-
-/**
  * liferea_shell_show_window:
  *
  * Show the main window.


### PR DESCRIPTION
Instead of calling gtk_window_deiconify and gtk_window_present directly, use the wrapper liferea_shell_show_window which also moves the window to the current desktop and restores the position if the window is hidden.

Note that we no longer restore position if iconified. I am not sure why this was ever the case but it seems unnecessary these days. Restoring position from iconification also triggers a bug on Cinnamon, whereas letting the window manager handle this seems to work fine.

Fixes an issue where position is not restored when Liferea is running in the background and is then launched from the launcher (instead of the tray icon.)