### PR TITLE
Reset reader mode when writing directly to browser

### DIFF
--- a/src/ui/liferea_browser.c
+++ b/src/ui/liferea_browser.c
@@ -326,6 +326,9 @@ liferea_browser_write (LifereaBrowser *browser, const gchar *string, const gchar
 	if (!browser)
 		return;
 
+	/* Reset any intermediate reader mode change via browser context menu */
+	conf_get_bool_value (ENABLE_READER_MODE, &(browser->readerMode));
+
 	browser->internal = TRUE;	/* enables special links */
 
 	if (baseURL == NULL)


### PR DESCRIPTION
We reset the reader mode when launching a URL, but should also reset when writing content directly to the browser (e.g. loading feed item content.)