### PR TITLE
Export items to feed file

### DIFF
--- a/src/date.c
+++ b/src/date.c
@@ -472,3 +472,26 @@ parsing_failed:
 	g_free (ascii_date);
 	return t;
 }
+
+
+static const gchar * rfc822_weekdays[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+
+gchar *
+date_format_rfc822_en_gmt (gint64 datetime)
+{
+	struct tm dt;
+	gmtime_r (&datetime, &dt);
+
+	if (dt.tm_wday < 0 || dt.tm_wday > 6) {
+		return NULL;	/* Invalid date from gmtime_r. Should *never* happen. */
+	}
+
+	if (dt.tm_mon < 0 || dt.tm_mon > 11) {
+		return NULL;	/* Invalid date from gmtime_r. Should *never* happen. */
+	}
+
+	return g_strdup_printf ("%s, %02d %s %d %02d:%02d:%02d GMT",
+		rfc822_weekdays[dt.tm_wday],
+		dt.tm_mday, rfc822_months[dt.tm_mon], dt.tm_year + 1900,
+		dt.tm_hour, dt.tm_min, dt.tm_sec);
+}

--- a/src/date.h
+++ b/src/date.h
@@ -57,4 +57,17 @@ gint64 date_parse_ISO8601 (const gchar *date);
 gint64 date_parse_RFC822 (const gchar *date);
 
 
+/**
+ * Formats an Unix timestamp to a RFC822 date/time with English locale,
+ * independently of the current system locale configuration, and timezone
+ * set for GMT/UTC, as defined for element "pubDate" in RSS 2.0 spec.
+ * Caller is responsible for g_free()'ing the returned string.
+ *
+ * @param datetime		the date string to format
+ *
+ * @returns (transfer full) (nullable): a newly allocated string or NULL for internal errors.
+ */
+
+gchar * date_format_rfc822_en_gmt (gint64 datetime);
+
 #endif

--- a/src/feed.c
+++ b/src/feed.c
@@ -461,7 +461,8 @@ feed_get_node_type (void)
 		NODE_CAPABILITY_SHOW_UNREAD_COUNT |
 		NODE_CAPABILITY_UPDATE |
 		NODE_CAPABILITY_UPDATE_FAVICON |
-		NODE_CAPABILITY_EXPORT,
+		NODE_CAPABILITY_EXPORT |
+		NODE_CAPABILITY_EXPORT_ITEMS,
 		"feed",		/* not used, feed format ids are used instead */
 		NULL,
 		feed_import,

--- a/src/itemlist.c
+++ b/src/itemlist.c
@@ -232,6 +232,12 @@ itemlist_merge_item (itemPtr item)
 	itemview_add_item (item);
 }
 
+static void
+itemlist_merge_item_callback (itemPtr item, gpointer _unused)
+{
+	itemlist_merge_item (item);
+}
+
 /* Helper method checking if the passed item set is relevant
    for the currently item list content. */
 static gboolean
@@ -266,7 +272,7 @@ itemlist_merge_itemset (itemSetPtr itemSet)
 
 	if (itemlist_itemset_is_valid (itemSet)) {
 		debug_start_measurement (DEBUG_GUI);
-		itemset_foreach (itemSet, itemlist_merge_item);
+		itemset_foreach (itemSet, itemlist_merge_item_callback, NULL);
 		itemview_update ();
 		debug_end_measurement (DEBUG_GUI, "itemlist merge");
 	}

--- a/src/itemset.c
+++ b/src/itemset.c
@@ -36,14 +36,14 @@
 #include "fl_sources/node_source.h"
 
 void
-itemset_foreach (itemSetPtr itemSet, itemActionFunc callback)
+itemset_foreach (itemSetPtr itemSet, itemActionFunc callback, gpointer userdata)
 {
 	GList	*iter = itemSet->ids;
 
 	while(iter) {
 		itemPtr item = item_load (GPOINTER_TO_UINT (iter->data));
 		if (item) {
-			(*callback) (item);
+			(*callback) (item, userdata);
 			item_unload (item);
 		}
 		iter = g_list_next (iter);

--- a/src/itemset.h
+++ b/src/itemset.h
@@ -41,16 +41,17 @@ typedef struct itemSet {
 
 /* item set iterating interface */
 
-typedef void 	(*itemActionFunc)	(itemPtr item);
+typedef void 	(*itemActionFunc)	(itemPtr item, gpointer userdata);
 
 /**
  * itemset_foreach: (skip)
  * @itemSet:	the item set
  * @callback:	the callback
+ * @userdata:	(nullable): an optional user-defined pointer to be passed to the callback
  *
  * Calls the given callback for each of the items in the item set.
  */
-void itemset_foreach (itemSetPtr itemSet, itemActionFunc callback);
+void itemset_foreach (itemSetPtr itemSet, itemActionFunc callback, gpointer userdata);
 
 /**
  * itemset_merge_items: (skip)

--- a/src/newsbin.c
+++ b/src/newsbin.c
@@ -214,7 +214,8 @@ newsbin_get_node_type (void)
 		nodeType = g_new0 (struct nodeType, 1);
 		nodeType->capabilities		= NODE_CAPABILITY_RECEIVE_ITEMS |
 		                                  NODE_CAPABILITY_SHOW_UNREAD_COUNT |
-		                                  NODE_CAPABILITY_SHOW_ITEM_COUNT;
+		                                  NODE_CAPABILITY_SHOW_ITEM_COUNT |
+		                                  NODE_CAPABILITY_EXPORT_ITEMS;
 		nodeType->id			= "newsbin";
 		nodeType->icon			= icon_get (ICON_NEWSBIN);
 		nodeType->load			= feed_get_node_type()->load;

--- a/src/node.c
+++ b/src/node.c
@@ -616,7 +616,9 @@ save_item_to_file_callback (itemPtr item, gpointer userdata)
 	}
 
 	if (item->description) {
-		xmlTextWriterWriteElement (writer, BAD_CAST "description", item->description);
+		xmlTextWriterStartElement (writer, BAD_CAST "description");
+		xmlTextWriterWriteCDATA (writer, item->description);
+		xmlTextWriterEndElement (writer);	/* </description> */
 	}
 
 	xmlTextWriterEndElement (writer);	/* </item> */

--- a/src/node.h
+++ b/src/node.h
@@ -431,6 +431,17 @@ gboolean node_can_add_child_feed (nodePtr node);
  */
 gboolean node_can_add_child_folder (nodePtr node);
 
+/**
+ * node_save_items_to_file: (skip)
+ * @node:	the node
+ * @filename:	the destination file name
+ * @error:	(nullable): a GError that will receive error information on failure
+ *
+ * Exports all items in this node as a RSS2 feed.
+ */
+void node_save_items_to_file(nodePtr node, const gchar *filename, GError **error);
+
+
 /* child nodes iterating interface */
 
 typedef void 	(*nodeActionFunc)	(nodePtr node);

--- a/src/node_type.h
+++ b/src/node_type.h
@@ -40,7 +40,8 @@ enum {
 	NODE_CAPABILITY_UPDATE			= (1<<10),	/**< node type always has a subscription and can be updated */
 	NODE_CAPABILITY_UPDATE_CHILDS		= (1<<11),	/**< childs of this node type can be updated */
 	NODE_CAPABILITY_UPDATE_FAVICON		= (1<<12),	/**< this node allows downloading a favicon */
-	NODE_CAPABILITY_EXPORT			= (1<<13)	/**< nodes of this type can be exported safely to OPML */
+	NODE_CAPABILITY_EXPORT			= (1<<13),	/**< nodes of this type can be exported safely to OPML */
+	NODE_CAPABILITY_EXPORT_ITEMS		= (1<<14)	/**< contents of this node can be exported as a RSS2 */
 };
 
 /**

--- a/src/vfolder.c
+++ b/src/vfolder.c
@@ -294,7 +294,8 @@ vfolder_get_node_type (void)
 {
 	static struct nodeType nti = {
 		NODE_CAPABILITY_SHOW_ITEM_FAVICONS |
-		NODE_CAPABILITY_SHOW_UNREAD_COUNT,
+		NODE_CAPABILITY_SHOW_UNREAD_COUNT |
+		NODE_CAPABILITY_EXPORT_ITEMS,
 		"vfolder",
 		NULL,
 		vfolder_import,


### PR DESCRIPTION
Add feature to save contents for a feed or vfolder to a file

This new feature allows saving/exporting the items from feeds, search
folders and news bins to a RSS 2.0 file. Typical use cases are an user
wanting to process feeds with an external tool or publish a static
feed after using Liferea to download, sort, or select the data.

Code and behavior are the same for all supported node types, allowing
users to, e.g., select the items manually (copying them to a news bin)
or automatically (using a search folder). It is also possible to export
cached items from standard feed subscriptions.

The only output format currently supported is RSS 2.0 but new ones
can be added if necessary.

I am still not sure that putting most of the code in node.c was the best
idea; it seems out of place there because it is intended to implement a
very specific feature, OTOH putting it somewhere more related to a
specific node type does *also* look out ot place, as it is intended to
be generic for all nodes with the given capability.  Some feedback is
welcome here!

