### PR TITLE
Faster and safer generation of localized filenames

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1,9 +1,10 @@
 /**
  * @file common.c common routines for Liferea
- * 
+ *
  * Copyright (C) 2003-2013  Lars Windolf <lars.windolf@gmx.de>
  * Copyright (C) 2004-2006  Nathan J. Conrad <t98502@users.sourceforge.net>
  * Copyright (C) 2004       Karl Soderstrom <ks@xanadunet.net>
+ * Copyright (C) 2022       Lorenzo L. Ancora <admin@lorenzoancora.info>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -55,7 +56,7 @@ common_parse_long (const gchar *str, long def)
 		return def;
 	if (0 == (sscanf (str,"%ld", &num)))
 		num = def;
-	
+
 	return num;
 }
 
@@ -92,7 +93,7 @@ common_init_paths (void)
 }
 
 gchar *
-common_create_data_filename (const gchar *filename) 
+common_create_data_filename (const gchar *filename)
 {
 	if (!pathsChecked)
 		common_init_paths ();
@@ -101,7 +102,7 @@ common_create_data_filename (const gchar *filename)
 }
 
 gchar *
-common_create_config_filename (const gchar *filename) 
+common_create_config_filename (const gchar *filename)
 {
 	if (!pathsChecked)
 		common_init_paths ();
@@ -135,13 +136,13 @@ common_uri_escape (const xmlChar *url)
 	xmlChar	*result, *tmp;
 
 	g_assert (NULL != url);
-		
-	/* xmlURIEscape returns NULL if spaces are in the URL, 
+
+	/* xmlURIEscape returns NULL if spaces are in the URL,
 	   so we need to replace them first (see SF #2965158) */
 	tmp = (xmlChar *)common_strreplace (g_strdup ((gchar *)url), " ", "%20");
 	result = xmlURIEscape (tmp);
 	g_free (tmp);
-	
+
 	/* workaround if escaping somehow fails... */
 	if (!result)
 		result = (xmlChar *)g_strdup ((gchar *)url);
@@ -159,7 +160,7 @@ xmlChar *
 common_uri_sanitize (const xmlChar *uri)
 {
 	xmlChar *tmp, *result;
-	
+
 	/* We must escape all dangerous characters (e.g. & and spaces)
 	   in the URL. As we do not know if the URL is already escaped we
 	   simply unescape and reescape it. */
@@ -185,7 +186,7 @@ common_build_url (const gchar *url, const gchar *baseURL)
 			xmlFree (escapedURL);
 		else
 			absURL = escapedURL;
-		
+
 		xmlFree (escapedBaseURL);
 	} else {
 		absURL = escapedURL;
@@ -240,7 +241,7 @@ const gchar *
 common_get_text_direction (const gchar *text)
 {
 	PangoDirection pango_direction = PANGO_DIRECTION_NEUTRAL;
-	
+
 	if (text)
 		pango_direction = common_find_base_dir (text, -1);
 
@@ -351,17 +352,17 @@ common_strcasestr (const char *phaystack, const char *pneedle)
 			if (c == '\0')
 				goto ret0;
 		} while (tolower(c) != (int) b);
-		
+
 		c = tolower(*++needle);
 		if (c == '\0')
 			goto foundneedle;
 		++needle;
 		goto jin;
-		
+
 		for (;;) {
 			register chartype a;
 			register const unsigned char *rhaystack, *rneedle;
-			
+
 			do {
 				a = *++haystack;
 				if (a == '\0')
@@ -375,18 +376,18 @@ common_strcasestr (const char *phaystack, const char *pneedle)
 				;
 			}
 			while (tolower(a) != (int) b);
-			
+
 		jin:      a = *++haystack;
 			if (a == '\0')
 				goto ret0;
-			
+
 			if (tolower(a) != (int) c)
 				goto shloop;
-			
+
 			rhaystack = haystack-- + 1;
 			rneedle = needle;
 			a = tolower(*rneedle);
-			
+
 			if (tolower(*rhaystack) == (int) a)
 				do {
 					if (a == '\0')
@@ -400,9 +401,9 @@ common_strcasestr (const char *phaystack, const char *pneedle)
 					++rhaystack;
 					a = tolower(*++needle);
 				} while (tolower (*rhaystack) == (int) a);
-			
+
 			needle = rneedle;             /* took the register-poor approach */
-			
+
 			if (a == '\0')
 				break;
 		}
@@ -446,22 +447,39 @@ common_get_mod_time (const gchar *file)
 }
 
 gchar *
-common_get_localized_filename (const gchar *str)
+common_get_localized_filename (const gchar *format)
 {
-	const gchar *const *languages = g_get_language_names();
+	const gchar *const *locales = g_get_language_names();
 	int i = 0;
 
-	while (languages[i] != NULL) {
-		gchar *filename = g_strdup_printf (str, strcmp (languages[i], "C") ? languages[i] : "en");
+	while (locales[i] != NULL) {
+		GString *filename = NULL;
+		GString *locale = NULL;
+		gboolean default_locale = FALSE;
 
-		if (g_file_test (filename, G_FILE_TEST_IS_REGULAR))
-			return filename;
+		/* Enforce ISO 639-1 2-char ids as used in filename postfixes */
+		if (strlen(locales[i]) > 2) locale = g_string_new_len (locales[i], 2);
+		else locale = g_string_new (locales[i]);
+		locale = g_string_ascii_down(locale); // Support case-sensitive filesystems
 
-		g_free (filename);
-		i++;
+		filename = g_string_new(NULL);
+		default_locale = g_str_equal (locale->str, "c"); // C is the system fallback
+		g_string_printf (filename, format, default_locale ? "en" : locale->str);
+		debug3(DEBUG_VERBOSE, "%s: %s -> %s.", locales[i], format, filename->str);
+
+		if (g_file_test (filename->str, G_FILE_TEST_IS_REGULAR)) {
+			debug1(DEBUG_VERBOSE, "Chosen file: \"%s\".", filename->str);
+			g_string_free (locale, TRUE);
+			return filename->str;
+		} else {
+			debug1(DEBUG_VERBOSE, "Discarded: \"%s\" , not a file.", filename->str);
+			g_string_free (locale, TRUE);
+			g_string_free (filename, TRUE);
+			i++;
+		}
 	}
 
-	g_warning ("No file found for %s", str);
+	g_warning ("No file found for %s", format);
 
 	return NULL;
 }


### PR DESCRIPTION
This PR:
- fixes a bug where `ISO 639-1` + `ISO 3166-1 alpha-2` + `encoding` identifiers (and variations) were accepted in place of pure `ISO 639-1` identifiers;
- adds the automatic conversion of upper case and mixed case language names into lower case language names, to allow for compatibility with case-sensitive filesystems when system locale names are misconfigured and/or partially configured;
- adds debugging to show which filenames are opened, selected or discarded;
- replaces code shorthands and semantically ambiguous names with documented and self-documented alternatives.

The consequence of this quick fix is a reduction in disk I/O and an overall stability improvement.