### PR TITLE
Fix strsep implicit declaration warning

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -27,6 +27,9 @@
 #include <libxml/xmlmemory.h>
 #include <libxml/parser.h>
 #include <glib.h>
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
 #include <string.h>
 #include <pango/pango-bidi-type.h>
 


### PR DESCRIPTION
When compile in Fedora there is a warning about implicit declaration
```
liferea_shell.c: In function 'liferea_shell_URL_received':
liferea_shell.c:851:32: warning: implicit declaration of function 'strsep'; did you mean 'strlen'? [-Wimplicit-function-declaration]
  851 |                 while ((tmp2 = strsep (&tmp1, "\n\r"))) {
      |                                ^~~~~~
      |                                strlen
liferea_shell.c:851:30: warning: assignment to 'gchar *' {aka 'char *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
  851 |                 while ((tmp2 = strsep (&tmp1, "\n\r"))) {
      |                              ^
```
Source https://kojipkgs.fedoraproject.org//packages/liferea/1.13.7/1.fc35/data/logs/x86_64/build.log

According to the strsep manual in addition to including string.h, _DEFAULT_SOURCE feature test macro must also be defined.

