### PR TITLE
Browse to requested URI on JS window creation

### DIFF
--- a/src/ui/liferea_browser.c
+++ b/src/ui/liferea_browser.c
@@ -434,7 +434,7 @@ liferea_browser_load_finished (LifereaBrowser *browser, const gchar *location)
 			(gchar *)g_bytes_get_data (b2, NULL),
 			(gchar *)g_bytes_get_data (b3, NULL),
 			(browser->readerMode?"true":"false"),
-			browser->content)
+			browser->content != NULL ? browser->content : "")
 		);
 	}
 }

--- a/src/webkit/liferea_web_view.c
+++ b/src/webkit/liferea_web_view.c
@@ -584,12 +584,16 @@ liferea_web_view_decide_policy (WebKitWebView *view,
 static WebKitWebView*
 liferea_web_view_create_web_view (WebKitWebView *view, WebKitNavigationAction *action, gpointer user_data)
 {
-	LifereaBrowser *htmlview;
-	GtkWidget	*container;
-	GtkWidget	*htmlwidget;
-	GList 		*children;
+	LifereaBrowser 		*htmlview;
+	GtkWidget		*container;
+	GtkWidget		*htmlwidget;
+	GList 			*children;
+	WebKitURIRequest	*request;
+	const gchar 		*uri;
 
-	htmlview = browser_tabs_add_new (NULL, NULL, TRUE);
+	request = webkit_navigation_action_get_request (action);
+	uri = webkit_uri_request_get_uri (request);
+	htmlview = browser_tabs_add_new (g_strcmp0(uri, "") != 0 ? uri : NULL, NULL, TRUE);
 	container = liferea_browser_get_widget (htmlview);
 
 	/* Ugly lookup of the webview. LifereaBrowser uses a GtkBox


### PR DESCRIPTION
Some sites intercept hyperlink clicks in order to inject tracking scripts or similar. They may then open the link in a new window via JavaScript. In Liferea, this results in a new empty tab opening with no content.

Browse to the request URI when one is provided. Opening a new window without a URI in Liferea won't have much effect, but it could happen, so that's handled as well.

Also handle `window.open()` with no URI so it doesn't look like an error to users.

Sample code to show the issue as exists today:
```
<a href="https://google.com/">a link</a>
<script>
  window.addEventListener('load', function () {
      document.querySelector('a').onclick = function() {
          window.open('https://google.com/');
          return false;
        };
    })
</script>
```

This will open a new tab in Liferea and will simply render the string `(null)`.

Unfortunately JS window creation doesn't hook in to `liferea_web_view_decide_policy`; it simply calls `liferea_web_view_create_web_view`. I figured it'd be preferable to respect the user's choice of whether to browse internally or externally, but I couldn't figure out a nice clean way to do that.