### PR TITLE
Don't update HTML view when browsing internally

### DIFF
--- a/src/feedlist.c
+++ b/src/feedlist.c
@@ -342,7 +342,6 @@ feedlist_mark_all_read (nodePtr node)
 		node_foreach_child (ROOTNODE, node_mark_all_read);
 
 	feedlist_foreach (feedlist_update_node_counters);
-	itemview_select_item (NULL);
 	itemview_update_all_items ();
 	itemview_update ();
 }

--- a/src/itemlist.c
+++ b/src/itemlist.c
@@ -535,11 +535,6 @@ itemlist_update_item (itemPtr item)
 		itemlist_unhide_item (item);
 	}
 
-	/* FIXME: this is tricky. It's possible that the item is
-	 * selected, but the itemview contains a webpage. In
-	 * that case, we don't want to reload the item.
-	 * So how to know whether the itemview contains the item?
-	 */
 	itemview_update_item (item);
 }
 

--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -482,19 +482,15 @@ itemview_create (GtkWidget *window)
 void
 itemview_launch_URL (const gchar *url, gboolean forceInternal)
 {
-	gboolean internal;
-
 	if (forceInternal) {
-		itemview->browsing = TRUE;
 		liferea_browser_launch_URL_internal (itemview->htmlview, url);
+	} else if (liferea_browser_handle_URL (itemview->htmlview, url)) {
+		/* URL was launched externally. */
 		return;
 	}
 
-	/* Otherwise let the HTML view figure out if we want to browse internally. */
-	internal = liferea_browser_handle_URL (itemview->htmlview, url);
-
-	if (!internal)
-		liferea_browser_launch_URL_internal (itemview->htmlview, url);
+	itemview->needsHTMLViewUpdate = FALSE;
+	itemview->browsing = TRUE;
 }
 
 void

--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -258,6 +258,10 @@ itemview_update_all_items (void)
 	if (itemview->itemListView)
 		item_list_view_update_all_items (itemview->itemListView);
 
+	/* Bail if we do internal browsing, and no item is shown */
+	if (itemview->browsing)
+		return;
+
 	itemview->needsHTMLViewUpdate = TRUE;
 }
 

--- a/src/ui/liferea_browser.c
+++ b/src/ui/liferea_browser.c
@@ -456,6 +456,7 @@ liferea_browser_handle_URL (LifereaBrowser *browser, const gchar *url)
 
 	if(browser->forceInternalBrowsing || browse_inside_application) {
 		liferea_browser_launch_URL_internal (browser, url);
+		return FALSE;
 	} else {
 		(void)browser_launch_URL_external (url);
 	}

--- a/src/webkit/liferea_web_view.c
+++ b/src/webkit/liferea_web_view.c
@@ -504,12 +504,11 @@ liferea_web_view_link_clicked ( WebKitWebView 		*view,
 		return TRUE;
 	}
 
-	url_handled = liferea_browser_handle_URL (g_object_get_data (G_OBJECT (view), "htmlview"), uri);
+	(void)liferea_browser_handle_URL (g_object_get_data (G_OBJECT (view), "htmlview"), uri);
 
-	if (url_handled)
-		webkit_policy_decision_ignore (policy_decision);
+	webkit_policy_decision_ignore (policy_decision);
 
-	return url_handled;
+	return TRUE;
 }
 
 /**
@@ -532,13 +531,8 @@ liferea_web_view_new_window_requested (	WebKitWebView *view,
 	if (webkit_navigation_action_get_mouse_button (navigation_action) == 2) {
 		/* middle-click, let's open the link in a new tab */
 		browser_tabs_add_new (uri, uri, FALSE);
-	} else if (liferea_browser_handle_URL (g_object_get_data (G_OBJECT (view), "htmlview"), uri)) {
-		/* The link is to be opened externally, let's do nothing here */
 	} else {
-		/* If the link is not to be opened in a new tab, nor externally,
-		 * it was likely a normal click on a target="_blank" link.
-		 * Let's open it in the current view to not disturb users */
-		webkit_web_view_load_uri (view, uri);
+		(void)liferea_browser_handle_URL (g_object_get_data (G_OBJECT (view), "htmlview"), uri);
 	}
 
 	/* We handled the request ourselves */


### PR DESCRIPTION
Fixes issues with the internal browser content being replaced with rendered feed items under various conditions.

Reproduction steps in https://github.com/lwindolf/liferea/issues/289#issuecomment-1004395375. To reproduce the mark as read issue, simply mark feed as read instead of updating.

Fixes #289.