### PR TITLE
Free previous stylesheet and only reload on change

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -322,7 +322,7 @@ render_is_dark_theme (void)
 	return darkTheme;
 }
 
-const gchar *
+gchar *
 render_get_css (void)
 {
 	if (!css || styleUpdated) {
@@ -334,6 +334,9 @@ render_get_css (void)
 			return NULL;
 
 		styleUpdated = FALSE;
+
+		if (css)
+			g_string_free(css, FALSE);
 
 		css = g_string_new(NULL);
 

--- a/src/render.h
+++ b/src/render.h
@@ -58,7 +58,7 @@ void render_parameter_add (renderParamPtr paramSet, const gchar *fmt, ...);
 /**
  * Returns CSS definitions for inclusion in XHTML output.
  */
-const gchar * render_get_css (void);
+gchar * render_get_css (void);
 
 /**
  * Returns the CSS value of a given GTK theme color name e.g. "GTK-COLOR-MID".

--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -509,5 +509,5 @@ itemview_do_zoom (gint zoom)
 void
 itemview_style_update (void)
 {
-	liferea_browser_update_style_element (itemview->htmlview);
+	liferea_browser_update_stylesheet (itemview->htmlview);
 }

--- a/src/ui/liferea_browser.c
+++ b/src/ui/liferea_browser.c
@@ -612,7 +612,7 @@ liferea_browser_update (LifereaBrowser *browser, guint mode)
 }
 
 void
-liferea_browser_update_style_element (LifereaBrowser *browser)
+liferea_browser_update_stylesheet (LifereaBrowser *browser)
 {
 	liferea_webkit_reload_style (browser->renderWidget);
 }

--- a/src/ui/liferea_browser.h
+++ b/src/ui/liferea_browser.h
@@ -200,12 +200,12 @@ void liferea_browser_do_zoom (LifereaBrowser *browser, gint zoom);
 void liferea_browser_update (LifereaBrowser *browser, guint mode);
 
 /**
- * liferea_browser_update_style_element:
+ * liferea_browser_update_stylesheet:
  * @browser:	the html view
  *
  * Update the user stylesheet of the WebView
  */
-void liferea_browser_update_style_element (LifereaBrowser *browser);
+void liferea_browser_update_stylesheet (LifereaBrowser *browser);
 
 G_END_DECLS
 

--- a/src/webkit/webkit.c
+++ b/src/webkit/webkit.c
@@ -665,20 +665,27 @@ liferea_webkit_set_proxy (ProxyDetectMode mode, const gchar *host, guint port, c
 #endif
 }
 
+static gchar *lastCss = NULL;
+
 /**
  * Load liferea.css via user style sheet
  */
 void
 liferea_webkit_reload_style (GtkWidget *webview)
 {
-	if (render_get_css () == NULL)
+	gchar *css = render_get_css ();
+
+	if (css == NULL || g_strcmp0 (css, lastCss) == 0)
 		return;
+
+	g_free (lastCss);
+	lastCss = css;
 
 	WebKitUserContentManager *manager = webkit_web_view_get_user_content_manager (WEBKIT_WEB_VIEW (webview));
 
 	webkit_user_content_manager_remove_all_style_sheets (manager);
 
-	WebKitUserStyleSheet *stylesheet = webkit_user_style_sheet_new (render_get_css(),
+	WebKitUserStyleSheet *stylesheet = webkit_user_style_sheet_new (css,
 		WEBKIT_USER_CONTENT_INJECT_ALL_FRAMES,
 		WEBKIT_USER_STYLE_LEVEL_USER,
 		NULL,


### PR DESCRIPTION
There was a memory leak in the previous implementation any time render_get_css was called (which as it turns out can be often.)

Also, there's no need to reload the stylesheet if it hasn't changed. Unfortunately there's no way to get the stylesheet back from WebKit, so we keep a copy of it.

Also fix a method name that regressed with a previous refactor.