### PR TITLE
Write content to output.html with --debug-html

### DIFF
--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -305,12 +305,6 @@ itemview_update (void)
 		liferea_shell_update_allitems_actions (0 != itemview->node->itemCount, (0 != itemview->node->unreadCount) || IS_VFOLDER (itemview->node));
 }
 
-void
-itemview_display_info (const gchar *html)
-{
-	liferea_browser_write (itemview->htmlview, html, NULL);
-}
-
 /* next unread selection logic */
 
 itemPtr

--- a/src/ui/liferea_browser.c
+++ b/src/ui/liferea_browser.c
@@ -334,12 +334,6 @@ liferea_browser_write (LifereaBrowser *browser, const gchar *string, const gchar
 	if (baseURL == NULL)
 		baseURL = "file:///";
 
-	if (debug_level & DEBUG_HTML) {
-		gchar *filename = common_create_cache_filename (NULL, "output", "html");
-		g_file_set_contents (filename, string, -1, NULL);
-		g_free (filename);
-	}
-
 	if (!g_utf8_validate (string, -1, NULL)) {
 		/* It is really a bug if we get invalid encoded UTF-8 here!!! */
 		liferea_webkit_write_html (browser->renderWidget, errMsg, strlen (errMsg), baseURL, "text/plain");
@@ -591,6 +585,12 @@ liferea_browser_update (LifereaBrowser *browser, guint mode)
 		default:
 			g_warning ("HTML view: invalid viewing mode!!!");
 			break;
+	}
+
+	if (debug_level & DEBUG_HTML) {
+		gchar *filename = common_create_cache_filename (NULL, "output", "html");
+		g_file_set_contents (filename, content, -1, NULL);
+		g_free (filename);
 	}
 
 	g_free (browser->content);


### PR DESCRIPTION
With the changes for reader mode, output.html no longer contains the content of the item view. Write content to output.html in liferea_browser_update to fix.

Note that this will not show changes made via JavaScript (e.g. Reader Mode). The inspector can be used to view the page source in such cases.

Fixes #1092