### PR TITLE
Fix Next Unread Item crash when no feed selected

### DIFF
--- a/src/feedlist.c
+++ b/src/feedlist.c
@@ -496,7 +496,7 @@ feedlist_collect_unread (nodePtr node, gpointer user_data)
 	}
 	if (!node->subscription)
 		return;
-	if (!node->unreadCount && !g_str_equal (node->id, SELECTED->id))
+	if (!node->unreadCount && SELECTED && !g_str_equal (node->id, SELECTED->id))
 		return;
 
 	*list = g_slist_append (*list, g_strdup (node->id));

--- a/src/ui/feed_list_view.c
+++ b/src/ui/feed_list_view.c
@@ -385,13 +385,14 @@ feed_list_view_select (nodePtr node)
 	GtkTreeModel *model = gtk_tree_view_get_model (flv->treeview);
 
 	if (model && node && node != feedlist_get_root ()) {
-		GtkTreePath *path;
+		GtkTreePath *path = NULL;
 
 		/* in filtered mode we need to convert the iterator */
 		if (flv->feedlist_reduced_unread) {
 			GtkTreeIter iter;
-			gtk_tree_model_filter_convert_child_iter_to_iter (GTK_TREE_MODEL_FILTER (flv->filter), &iter, feed_list_view_to_iter (node->id));
-			path = gtk_tree_model_get_path (model, &iter);
+			gboolean valid = gtk_tree_model_filter_convert_child_iter_to_iter (GTK_TREE_MODEL_FILTER (flv->filter), &iter, feed_list_view_to_iter (node->id));
+			if (valid)
+				path = gtk_tree_model_get_path (model, &iter);
 		} else {
 			path = gtk_tree_model_get_path (model, feed_list_view_to_iter (node->id));
 		}


### PR DESCRIPTION
When no feed is selected (e.g. when using the Reduced Feed List), selecting the next unread item will cause a crash.

Fixes #1091