### PR TITLE
[WIP] Load raw content in Readability.js instead of DOM loading

### DIFF
--- a/js/htmlview.js
+++ b/js/htmlview.js
@@ -32,19 +32,39 @@ function loadContent(readerEnabled, content) {
 	}
 	if (true == readerEnabled) {
 		try {
-			console.log('[liferea] enabling reader mode...');
+			console.log('[liferea] reader mode is on');
+			var contentDiv = document.getElementById('content');
 			var documentClone = document.cloneNode(true);
 
+			console.log("content="+decodeURIComponent(content).substring(0,100));
+			console.log("contentDiv="+contentDiv);
+			console.log("href=>>>"+document.location.href+"<<<");
+			
 			// When we are internally browsing than we need basic
 			// structure to insert Reader mode content
-			if(document.location.href !== 'liferea://') {
-				content = document.documentElement.innerHTML;
+			if(contentDiv !== null) {
+				console.log('[liferea] adding <div id="content"> for website content');
 				document.body.innerHTML = '<div id=\"content\"></div>';
-			} else {
+			}
+			
+			// Decide where we get the content from
+			if(document.location.href === 'liferea://') {
 				// Add all content in shadow DOM and split decoration from content
 				// only pass the content to Readability.js
+				console.log('[liferea] load content passed by variable');
 				content = decodeURIComponent(content);
-				documentClone.body.innerHTML = content;
+			} else {
+				console.log('[liferea] using content from original document');
+				content = document.documentElement.innerHTML;
+			}
+
+			// Add content to clone doc as input for Readability.js
+			documentClone.body.innerHTML = content;
+			
+			// When we run with internal URI schema we get layout AND content
+			// from variable and split it, apply layout to document
+			// and copy content to documentClone 
+			if(document.location.href === 'liferea://' && documentClone.getElementById('content') != null) {
 				documentClone.getElementById('content').innerHTML = '';
 				document.body.innerHTML = documentClone.body.innerHTML;
 				documentClone.body.innerHTML = content;
@@ -52,6 +72,9 @@ function loadContent(readerEnabled, content) {
 			}
 
 			if (!isProbablyReaderable(documentClone)) {
+				console.log('[liferea] reader mode not possible! fallback to unfiltered content');
+				// FIXME: distinguish for reader mode on headlines and reader mode on websites
+				// for latter bring up error and link to full website
 				document.documentElement.innerHTML = content;
 				return;
 			}

--- a/js/htmlview.js
+++ b/js/htmlview.js
@@ -20,6 +20,13 @@
 
 /**
  * loadContent() will be run on each internal / Readability.js rendering
+ *
+ * This method can be called multiple times for a single rendering, so it
+ * needs to be idempotent on what is done. Primary use case for this is
+ * when in internal browser + reader mode we first render layout with parameter
+ * content being empty, while asynchronously downloading content. Once the
+ * download finishes loadContent() is called again with the actual content
+ * which is then inserted in the layout.
  */
 function loadContent(readerEnabled, content) {
 	if (false == readerEnabled) {

--- a/js/htmlview.js
+++ b/js/htmlview.js
@@ -47,7 +47,7 @@ function loadContent(readerEnabled, content) {
 			// structure to insert Reader mode content
 			if(contentDiv !== null) {
 				console.log('[liferea] adding <div id="content"> for website content');
-				document.body.innerHTML = '<div id=\"content\"></div>';
+				document.body.innerHTML += '<div id=\"content\"></div>';
 			}
 			
 			// Decide where we get the content from
@@ -97,8 +97,6 @@ function loadContent(readerEnabled, content) {
 				for (var s of styles) {
 					s.parentNode.removeChild(s);
 				}
-
-				// FIXME: Add our header
 			}
 		} catch(e) {
 			console.log('[liferea] reader mode failed: '+e);

--- a/js/htmlview.js
+++ b/js/htmlview.js
@@ -36,10 +36,6 @@ function loadContent(readerEnabled, content) {
 			var contentDiv = document.getElementById('content');
 			var documentClone = document.cloneNode(true);
 
-			console.log("content="+decodeURIComponent(content).substring(0,100));
-			console.log("contentDiv="+contentDiv);
-			console.log("href=>>>"+document.location.href+"<<<");
-			
 			// When we are internally browsing than we need basic
 			// structure to insert Reader mode content
 			if(contentDiv !== null) {

--- a/src/html.c
+++ b/src/html.c
@@ -328,7 +328,7 @@ html_get_article (const gchar *data, const gchar *baseUri) {
 
 	doc = xhtml_parse ((gchar *)data, (size_t)strlen (data));
 	if (!doc) {
-		debug1 (DEBUG_PARSING, "XHTML parsing error during HTML5 fetch of '%s'\n", baseUri);
+		debug1 (DEBUG_PARSING, "XHTML parsing error on '%s'\n", baseUri);
 		return NULL;
 	}
 
@@ -349,6 +349,30 @@ html_get_article (const gchar *data, const gchar *baseUri) {
 		xmlFreeDoc (doc);
 	}
 
+	return result;
+}
+
+gchar *
+html_get_body (const gchar *data, const gchar *baseUri) {
+	xmlDocPtr	doc;
+	xmlNodePtr	root;
+	gchar		*result = NULL;
+
+	doc = xhtml_parse ((gchar *)data, (size_t)strlen (data));
+	if (!doc) {
+		debug1 (DEBUG_PARSING, "XHTML parsing error on '%s'\n", baseUri);
+		return NULL;
+	}
+	g_print("html_get_body\n");
+	root = xmlDocGetRootElement (doc);
+	if (root) {
+		xmlDocPtr body = xhtml_extract_doc (root, 1, baseUri);
+		if (body) {
+			result = render_xml (body, "html-extract", NULL);
+			xmlFreeDoc (body);
+		}
+		xmlFreeDoc (doc);
+	}
 	return result;
 }
 

--- a/src/html.c
+++ b/src/html.c
@@ -363,7 +363,7 @@ html_get_body (const gchar *data, const gchar *baseUri) {
 		debug1 (DEBUG_PARSING, "XHTML parsing error on '%s'\n", baseUri);
 		return NULL;
 	}
-	g_print("html_get_body\n");
+
 	root = xmlDocGetRootElement (doc);
 	if (root) {
 		xmlDocPtr body = xhtml_extract_doc (root, 1, baseUri);

--- a/src/html.h
+++ b/src/html.h
@@ -2,7 +2,7 @@
  * @file html.h HTML parsing
  *
  * Copyright (C) 2004 ahmed el-helw <ahmedre@cc.gatech.edu>
- * Copyright (C) 2017-2020 Lars Windolf <lars.windolf@gmx.de>
+ * Copyright (C) 2017-2021 Lars Windolf <lars.windolf@gmx.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,14 +52,26 @@ GSList * html_discover_favicon(const gchar* data, const gchar *baseUri);
 /**
  * html_get_article:
  *
- * Parse HTML as XML to check wether it contains an HTML5 article.
+ * Parse HTML as XHTML to extract containing HTML5 article.
  *
  * @data:	the HTML to check
  * @baseUri:	URI of the downloaded HTML used to resolve relative URIs
  *
- * Returns: XHTML fragment representing the article or NULL
+ * Returns: XHTML fragment representing the <article> or NULL
  */
 gchar * html_get_article(const gchar *data, const gchar *baseUri);
+
+/**
+* html_get_body:
+*
+* Parse HTML as XHTML to extract containing HTML body.
+*
+* @data:	the HTML to check
+* @baseUri:	URI of the downloaded HTML used to resolve relative URIs
+*
+* Returns: XHTML fragment representing the <body> or NULL
+*/
+gchar * html_get_body(const gchar *data, const gchar *baseUri);
 
 /**
  * html_get_amp_url:

--- a/src/ui/itemview.c
+++ b/src/ui/itemview.c
@@ -301,12 +301,6 @@ itemview_update (void)
 		liferea_shell_update_allitems_actions (0 != itemview->node->itemCount, (0 != itemview->node->unreadCount) || IS_VFOLDER (itemview->node));
 }
 
-void
-itemview_display_info (const gchar *html)
-{
-	liferea_browser_write (itemview->htmlview, html, NULL);
-}
-
 /* next unread selection logic */
 
 itemPtr

--- a/src/ui/liferea_browser.c
+++ b/src/ui/liferea_browser.c
@@ -609,7 +609,7 @@ liferea_browser_start_output (GString *buffer,
 		g_free (escBase);
 	}
 
-	g_string_append (buffer, "</head><body>Loading...</body></html>");
+	g_string_append (buffer, "</head><body></body></html>");
 }
 
 /* renders headlines & node info */

--- a/src/ui/liferea_browser.c
+++ b/src/ui/liferea_browser.c
@@ -1,7 +1,7 @@
 /*
  * @file liferea_browser.c  Liferea embedded browser
  *
- * Copyright (C) 2003-2021 Lars Windolf <lars.windolf@gmx.de>
+ * Copyright (C) 2003-2022 Lars Windolf <lars.windolf@gmx.de>
  * Copyright (C) 2005-2006 Nathan J. Conrad <t98502@users.sourceforge.net>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -52,11 +52,21 @@
    switches on a toolbar for history and URL navigation when browsing
    external content.
 
-   When serving internal content it reacts to different internal link schemata
-   to trigger functionality inside Liferea. To avoid websites hijacking this we
-   keep a flag to support the link schema only on liferea_browser_write()
-   
-   Also offers support for Reader mode (Readability.js)
+   The widget also manages "reader mode" be it on by default or ad-hoc 
+   requested by the user. To do so it ad-hoc injects Readability.js into the
+   rendering. For increased performance and security external content is pre-fetched
+   and passed directly to Readability.js (thus eliminating all 3rd party 
+   script execution).
+
+   This causes quite some complexity outlined in below table
+
+   Use Case           Intern Rendering    Reader Mode    Pre-Download       URL bar
+   --------------------------------------------------------------------------------
+   item/node view     yes                 yes            yes (feed-cache)   off
+   item/node view     yes                 no             yes (feed-cache)   off
+   local help files   no                  no             no                 on
+   internet URL       no                  no             no                 on
+   internet URL       yes                 yes            yes                on
  */
 
 struct _LifereaBrowser {
@@ -71,10 +81,10 @@ struct _LifereaBrowser {
 	GtkWidget	*urlentry;		/*<< The URL entry widget */
 	browserHistory	*history;		/*<< The browser history */
 
-	gboolean	internal;		/*<< TRUE if internal view presenting generated HTML with special links */
 	gboolean	forceInternalBrowsing;	/*<< TRUE if clicked links should be force loaded in a new tab (regardless of global preference) */
 	gboolean	readerMode;		/*<< TRUE if Readability.js is to be used */
 
+	gchar		*url;			/*<< the URL of the content rendered right now */
 	gchar 		*content;		/*<< current HTML content (excluding decorations, content passed to Readability.js) */
 };
 
@@ -230,7 +240,7 @@ liferea_browser_init (LifereaBrowser *browser)
 	GtkWidget *widget, *image;
 
 	browser->content = NULL;
-	browser->internal = FALSE;
+	browser->url = NULL;
 	browser->readerMode = FALSE;
 	browser->renderWidget = liferea_webkit_new (browser);
 	browser->container = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
@@ -331,8 +341,6 @@ liferea_browser_write (LifereaBrowser *browser, const gchar *string, const gchar
 	/* Reset any intermediate reader mode change via browser context menu */
 	conf_get_bool_value (ENABLE_READER_MODE, &(browser->readerMode));
 
-	browser->internal = TRUE;	/* enables special links */
-
 	if (baseURL == NULL)
 		baseURL = "file:///";
 
@@ -386,17 +394,13 @@ liferea_browser_progress_changed (LifereaBrowser *browser, gdouble progress)
 void
 liferea_browser_location_changed (LifereaBrowser *browser, const gchar *location)
 {
-	if (!g_str_has_prefix (location, "liferea")) {
-		/* A URI different from the locally generated html base url is being loaded. */
-		browser->internal = FALSE;
-	}
-	if (!browser->internal) {
-		browser_history_add_location (browser->history, location);
+	if (browser->url && !g_str_has_prefix (browser->url, "liferea://")) {
+		browser_history_add_location (browser->history, browser->url);
 
 		gtk_widget_set_sensitive (browser->forward, browser_history_can_go_forward (browser->history));
 		gtk_widget_set_sensitive (browser->back,    browser_history_can_go_back (browser->history));
 
-		gtk_entry_set_text (GTK_ENTRY (browser->urlentry), location);
+		gtk_entry_set_text (GTK_ENTRY (browser->urlentry), browser->url);
 
 		/* We show the toolbar as it should be visible when loading external content */
 		gtk_widget_show_all (browser->toolbar);
@@ -426,7 +430,7 @@ liferea_browser_load_finished (LifereaBrowser *browser, const gchar *location)
 		g_assert(b3 != NULL);
 
 		// FIXME: pass actual content here too, instead of on render_item()!
-		// this safe us from the trouble to have JS enabled earlier!
+		// this saves us from the trouble to have JS enabled earlier!
 
 		debug1 (DEBUG_GUI, "Enabling reader mode for '%s'", location);
 		liferea_webkit_run_js (
@@ -516,10 +520,15 @@ liferea_browser_handle_URL (LifereaBrowser *browser, const gchar *url)
 
 	conf_get_bool_value (BROWSE_INSIDE_APPLICATION, &browse_inside_application);
 
-	debug3 (DEBUG_GUI, "handle URL: %s %s %s",
+	debug2 (DEBUG_GUI, "handle URL: %s %s %s",
 	        browse_inside_application?"true":"false",
-	        browser->forceInternalBrowsing?"true":"false",
-		browser->internal?"true":"false");
+	        browser->forceInternalBrowsing?"true":"false");
+
+	/* Save URL here as the Webkit location does not always reflect the URL.
+	   For reader mode it is just liferea:// which doesn't help us to set 
+	   the URL bar */
+	g_free (browser->url);
+	browser->url = g_strdup (url);
 
 	if(browser->forceInternalBrowsing || browse_inside_application) {
 		liferea_browser_launch_URL_internal (browser, url);

--- a/src/webkit/liferea_web_view.c
+++ b/src/webkit/liferea_web_view.c
@@ -589,32 +589,32 @@ liferea_web_view_create_web_view (WebKitWebView *view, WebKitNavigationAction *a
 static void
 liferea_web_view_load_status_changed (WebKitWebView *view, WebKitLoadEvent event, gpointer user_data)
 {
-	LifereaBrowser	*htmlview;
-	gboolean isFullscreen;
+	LifereaBrowser	*htmlview = g_object_get_data (G_OBJECT (view), "htmlview");;
+	gboolean	isFullscreen;
 
 	switch (event) {
 		case WEBKIT_LOAD_STARTED:
-			// Hack to force webview exit from fullscreen mode on new page
-			isFullscreen = GPOINTER_TO_INT(g_object_steal_data(
-						G_OBJECT(view), "fullscreen_on"));
-			if (isFullscreen == TRUE) {
-				webkit_web_view_run_javascript (view, "document.webkitExitFullscreen();", NULL, NULL, NULL);
+			{
+				// Once load starts we can update the reader toggle
+				GActionGroup *action_group;
+				action_group = LIFEREA_WEB_VIEW (view)->menu_action_group;
+				GSimpleAction *reader_action;
+				reader_action = G_SIMPLE_ACTION (g_action_map_lookup_action (G_ACTION_MAP (action_group), "toggle-reader-mode"));
+				gboolean reader = liferea_browser_get_reader_mode (htmlview);
+				g_simple_action_set_state (reader_action, g_variant_new_boolean (reader));
+
+				// Hack to force webview exit from fullscreen mode on new page
+				isFullscreen = GPOINTER_TO_INT(g_object_steal_data(
+							G_OBJECT(view), "fullscreen_on"));
+				if (isFullscreen == TRUE) {
+					webkit_web_view_run_javascript (view, "document.webkitExitFullscreen();", NULL, NULL, NULL);
+				}
+				break;
 			}
-			break;
 		case WEBKIT_LOAD_COMMITTED:
-			htmlview = g_object_get_data (G_OBJECT (view), "htmlview");
 			liferea_browser_location_changed (htmlview, webkit_web_view_get_uri (view));
 			break;
 		case WEBKIT_LOAD_FINISHED:
-			htmlview = g_object_get_data (G_OBJECT (view), "htmlview");
-
-			GActionGroup 	*action_group;
-			action_group = LIFEREA_WEB_VIEW (view)->menu_action_group;
-			GSimpleAction *reader_action;
-			reader_action = G_SIMPLE_ACTION (g_action_map_lookup_action (G_ACTION_MAP (action_group), "toggle-reader-mode"));
-			gboolean reader = liferea_browser_get_reader_mode (htmlview);
-			g_simple_action_set_state (reader_action, g_variant_new_boolean (reader));
-
 			liferea_browser_load_finished (htmlview, webkit_web_view_get_uri (view));
 			break;
 		default:

--- a/src/webkit/liferea_web_view.c
+++ b/src/webkit/liferea_web_view.c
@@ -276,7 +276,7 @@ on_popup_webinspector_activate (GSimpleAction *action, GVariant *parameter, gpoi
 }
 
 static void
-on_popup_toggle_reader_mode_activate (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+on_popup_toggle_reader_mode_change_state (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
 	WebKitWebView *webview = WEBKIT_WEB_VIEW (user_data);
 	gboolean reader = g_variant_get_boolean (parameter);
@@ -292,7 +292,7 @@ static const GActionEntry liferea_web_view_gaction_entries[] = {
 	{"zoom-in", on_popup_zoomin_activate, NULL, NULL, NULL},
 	{"zoom-out", on_popup_zoomout_activate, NULL, NULL, NULL},
 	{"web-inspector", on_popup_webinspector_activate, NULL, NULL, NULL},
-	{"toggle-reader-mode", NULL, NULL, "true", on_popup_toggle_reader_mode_activate}
+	{"toggle-reader-mode", NULL, NULL, "true", on_popup_toggle_reader_mode_change_state}
 };
 
 static void

--- a/src/webkit/liferea_web_view.c
+++ b/src/webkit/liferea_web_view.c
@@ -2,7 +2,7 @@
  * @file liferea_web_view.c  Webkit2 widget for Liferea
  *
  * Copyright (C) 2016 Leiaz <leiaz@mailbox.org>
- * Copyright (C) 2021 Lars Windolf <lars.windolf@gmx.de>
+ * Copyright (C) 2021-2022 Lars Windolf <lars.windolf@gmx.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -99,20 +99,6 @@ liferea_web_view_update_actions_sensitivity (LifereaWebView *self)
                 NULL);
 }
 
-/*
- * Copied from liferea_browser.c Perhaps could go in common.h ?
- */
-static gboolean
-liferea_web_view_is_special_url (const gchar *url)
-{
-	/* match against all special protocols, simple
-	   convention: all have to start with "liferea-" */
-	if (url == strstr (url, "liferea-"))
-		return TRUE;
-
-	return FALSE;
-}
-
 static void
 menu_add_item (GMenu *menu, const gchar *label, const gchar *action, const gchar *parameter)
 {
@@ -162,7 +148,7 @@ liferea_web_view_on_menu (WebKitWebView 	*view,
 	image = (image_uri != NULL);
 
 	/* do not expose internal links */
-	if (link_uri && liferea_web_view_is_special_url (link_uri) && !g_str_has_prefix (link_uri, "javascript:") && !g_str_has_prefix (link_uri, "data:"))
+	if (link_uri && !g_str_has_prefix (link_uri, "javascript:") && !g_str_has_prefix (link_uri, "data:"))
 		link = FALSE;
 
 	liferea_web_view_update_actions_sensitivity (LIFEREA_WEB_VIEW (view));
@@ -295,7 +281,6 @@ on_popup_toggle_reader_mode_activate (GSimpleAction *action, GVariant *parameter
 	WebKitWebView *webview = WEBKIT_WEB_VIEW (user_data);
 	gboolean reader = g_variant_get_boolean (parameter);
 
-g_warning("Change reader mode");
 	liferea_browser_set_reader_mode (g_object_get_data (G_OBJECT (webview), "htmlview"), reader);
 	g_simple_action_set_state (action, g_variant_new_boolean (reader));
 }
@@ -659,7 +644,7 @@ liferea_web_view_init(LifereaWebView *self)
 
 	/* Context menu actions */
 	self->menu_action_group = G_ACTION_GROUP (g_simple_action_group_new ());
-	g_action_map_add_action_entries (G_ACTION_MAP(self->menu_action_group), liferea_web_view_gaction_entries, G_N_ELEMENTS (liferea_web_view_gaction_entries), self);
+	g_action_map_add_action_entries (G_ACTION_MAP (self->menu_action_group), liferea_web_view_gaction_entries, G_N_ELEMENTS (liferea_web_view_gaction_entries), self);
 	gtk_widget_insert_action_group (GTK_WIDGET (self), "liferea_web_view", self->menu_action_group);
 
 	g_signal_connect (

--- a/xslt/Makefile.am
+++ b/xslt/Makefile.am
@@ -1,11 +1,13 @@
 
 xslt_in_files = item.xml.in \
                 feed.xml.in \
-                html5-extract.xml.in \
-                source.xml.in \
                 folder.xml.in \
-		newsbin.xml.in \
-		vfolder.xml.in 
+                html-extract.xml.in \
+                html5-extract.xml.in \
+                reader.xml.in \
+                source.xml.in \
+                newsbin.xml.in \
+                vfolder.xml.in
 
 xslt_files = $(xslt_in_files:.xml.in=.xml) i18n-filter.xslt
 xsltdir = $(pkgdatadir)/xslt

--- a/xslt/html-extract.xml.in
+++ b/xslt/html-extract.xml.in
@@ -2,7 +2,7 @@
 
 <!--
 /**
- * HTML5 extraction stylesheet for Liferea
+ * HTML extraction stylesheet for Liferea
  *
  * Copyright (C) 2020-2021 Lars Windolf <lars.windolf@gmx.de>
  *
@@ -39,14 +39,8 @@
 
 <xsl:template name='copy'>
 	<xsl:choose>
-		<!-- identity copy nodes only for the following extraction locations:
-
-			1.) "//article" for HTML5
-			2.) "//div[@property='articleBody']" for microformats
-			3.) "//div[@id='content']" for just guessing CMS main div
-
-		-->
-		<xsl:when test="ancestor::article | ancestor::div[@property='articleBody'] | ancestor::div[@id='content']">
+		<!-- extract HTML <body> contents as XHTML that can be used for HTML5 --> 
+		<xsl:when test="ancestor::body">
 			<xsl:copy>
 				<xsl:apply-templates select="node()|@*"/>
 				<!-- Fill empty tags with a space to ensure we can


### PR DESCRIPTION
- More secure, because no DOM evaluation happens
- Opens up the possibility to use DOMPurify.js for further stripping
- Avoids loading any JS, cookie walls, ... upon document.load
- But will break Reader mode for all pages that dynamically insert content

Goal here is to be resource efficient, fast and secure with the
trade-off of not loading all pages perfectly.

Closes #1101