### PR TITLE
Various improvements to appdata

### DIFF
--- a/net.sourceforge.liferea.appdata.xml.in
+++ b/net.sourceforge.liferea.appdata.xml.in
@@ -1,42 +1,80 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Lars Windolf  -->
 <component type="desktop-application">
-  <id>net.sourceforge.liferea.desktop</id>
-  <metadata_license>CC0</metadata_license>
+  <id>net.sourceforge.liferea</id>
+  <provides>
+    <id>net.sourceforge.liferea.desktop</id>
+  </provides>
+  <launchable type="desktop-id">net.sourceforge.liferea.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>Liferea</name>
-  <_summary>RSS feed reader</_summary>
+  <developer_name>Lars Windolf</developer_name>
+  <update_contact>lars.windolf_at_gmx.de</update_contact>
+  <summary>RSS feed reader</summary>
   <description>
-    <_p>Liferea is an abbreviation for Linux Feed Reader. It is a news aggregator for
-	online news feeds. It supports a number of different feed formats including 
-	RSS/RDF, CDF and Atom. There are many other news readers available, but these 
-	others are not available for Linux or require many extra libraries to be 
-	installed. Liferea tries to fill this gap by creating a fast, easy to use, 
-	easy to install news aggregator for GTK/GNOME.
-    </_p>
-    <_p>Distinguishing features:</_p>
+    <p>Liferea is an abbreviation for Linux Feed Reader. It is a news aggregator for
+  online news feeds. It supports a number of different feed formats including
+  RSS/RDF, CDF and Atom. There are many other news readers available, but these
+  others are not available for Linux or require many extra libraries to be
+  installed. Liferea tries to fill this gap by creating a fast, easy to use,
+  easy to install news aggregator for GTK/GNOME.
+    </p>
+    <p>Distinguishing features:</p>
     <ul>
-     <_li>Read articles when offline</_li>
-     <_li>Synchronizes with TheOldReader</_li>
-     <_li>Synchronizes with TinyTinyRSS</_li>
-     <_li>Synchronizes with InoReader</_li>
-     <_li>Synchronizes with Reedah</_li>
-     <_li>Permanently save headlines in news bins</_li>
-     <_li>Match items using search folders</_li>
-     <_li>Play Podcasts</_li>
+      <li>Read articles when offline</li>
+      <li>Force fetch full article text using HTML5 extraction</li>
+      <li>Subscribe to HTML5 websites that do not even have a feed!</li>
+      <li>Synchronizes with Google Reader API (TheOldReader, FreshRSS, FeedHQ, Miniflux, ...)</li>
+      <li>Synchronizes with Reedah</li>
+      <li>Synchronizes with TinyTinyRSS</li>
+      <li>Permanently save headlines in news bins</li>
+      <li>Match items using search folders</li>
+      <li>Play Podcasts</li>
     </ul>
   </description>
   <screenshots>
-    <screenshot type="default"><image width="833" height="656">https://lzone.de/liferea/screenshots/screenshot2.png</image></screenshot>
-    <screenshot type="default"><image width="837" height="657">https://lzone.de/liferea/screenshots/screenshot3.png</image></screenshot>
-    <screenshot type="default"><image width="837" height="657">https://lzone.de/liferea/screenshots/screenshot4.png</image></screenshot>
-    <screenshot type="default"><image width="837" height="657">https://lzone.de/liferea/screenshots/screenshot5.png</image></screenshot>
-    <screenshot type="default"><image width="837" height="657">https://lzone.de/liferea/screenshots/screenshot6.png</image></screenshot>
-    <screenshot type="default"><image width="642" height="438">https://lzone.de/liferea/screenshots/screenshot7.png</image></screenshot>
-    <screenshot type="default"><image width="834" height="657">https://lzone.de/liferea/screenshots/screenshot8.png</image></screenshot>
-    <screenshot type="default"><image width="837" height="657">https://lzone.de/liferea/screenshots/screenshot9.png</image></screenshot>
+    <screenshot type="default">
+      <caption>Reading newsfeeds in an email client interface</caption>
+      <image>https://lzone.de/liferea/screenshots/screenshot1.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Hide read feeds from the subscription list</caption>
+      <image>https://lzone.de/liferea/screenshots/screenshot2.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Three pane view mode for wide screens</caption>
+      <image>https://lzone.de/liferea/screenshots/screenshot3.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Play SoundCloud music in Liferea</caption>
+      <image>https://lzone.de/liferea/screenshots/screenshot4.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Play music enclosures with the internal player</caption>
+      <image>https://lzone.de/liferea/screenshots/screenshot5.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Read your favourite comics!</caption>
+      <image>https://lzone.de/liferea/screenshots/screenshot6.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Customize Liferea in the preferences dialog</caption>
+      <image>https://lzone.de/liferea/screenshots/screenshot7.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Easily subscribe to new feeds</caption>
+      <image>https://lzone.de/liferea/screenshots/screenshot8.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Browse the web with tabs inside Liferea</caption>
+      <image>https://lzone.de/liferea/screenshots/screenshot9.png</image>
+    </screenshot>
   </screenshots>
+  <url type="bugtracker">https://github.com/lwindolf/liferea/issues/new</url>
   <url type="homepage">https://lzone.de/liferea/</url>
-  <update_contact>liferea-devel@lists.sf.net</update_contact>
+  <url type="donation">https://paypal.me/32799746569265</url>
+  <translation type="gettext">liferea</translation>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">none</content_attribute>
     <content_attribute id="violence-fantasy">none</content_attribute>
@@ -67,11 +105,60 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
-    <release version="1.13.7"  date="2021-12-07" />
-    <release version="1.13.6"  date="2021-05-07" />
-    <release version="1.13.5"  date="2021-01-10" />
-    <release version="1.13.4"  date="2020-12-24" />
-    <release version="1.13.3"  date="2020-10-09" />
-    <release version="1.13.2"  date="2020-08-28" />
+    <release date="2022-07-26" version="1.13.9">
+      <description>
+        <p>This will be the last unstable release before the first 1.14 release candidate. It contains
+         bugfixes and a generalization of the Google Reader API implementation we already had
+         for TheOldReader. This implementation was improved, fixing some bugs and can now
+         be used with arbitrary Google Reader services.
+        </p>
+        <p>New features: Google Reader API support
+
+           If you are a FeedHQ, FreshRSS, Basquz user or a a user of any other Google Reader
+           compatible service, you can now subscribe to those services.
+
+           Note: it currently doesn't work with Miniflux due to this miniflux/v2#1498
+           which is probably a bug in Miniflux. Once it is solved Miniflux also can be used.
+
+           If you experience any issues please open a ticket for support!
+        </p>
+        <p>GUI simplification: less cluttered item list
+
+           The item list has seen some rework. The quite large left padding (cause by reserved space
+           for expansion header) is now gone. Also the enclosures icon column was dropped. When
+           using Liferea in wide mode this really gives back a lot of vertical space, so Liferea in wide mode
+           becomes more useful half-maximized or in split screen situations.
+
+           Please give feedback how you like the change, especially the rather small padding left of the
+           favicon column (when in wide mode)!
+        </p>
+        <p>Changes</p>
+        <ul>
+          <li>Update to Readability.js 0.41 (better image and table handling) (Lars Windolf)</li>
+          <li>Changes to UserAgent handling: same UA is now used for both feed fetching
+                and internal browsing. User agent now indicates Android+Mobile per default
+                instead of suggesting a Linux desktop to better adapt to the smaller
+                (in comparison to browsers) rendering pane. Additionally special env
+                vars LIFEREA_UA and LIFEREA_UA_ANONYMOUS now also affect the internal
+                browsing.</li>
+          <li>Improve HTML5 extraction: extract main if it exists and no article was found</li>
+          <li>#1117: Hide unused expander space in item list. This saves horizontal space. (Sefler Zhou)</li>
+          <li>Drop enclosure icon from item list. This saves horizontal space. (Lars Windolf)</li>
+          <li>#515, #962, #1113 adds generic Google Reader API support (this enables access to FeedHQ, FreshRSS, Miniflux...)</li>
+          <li>#1108, #113: Improve performance by different check order in itemset merging (suggested by mozbugbox)</li>
+          <li>Fixes #1033: Subscribing defaulted to HTML5 feeds even when real feeds do exist. (reported by Hanno Braun)</li>
+          <li>Fixes #1111: wrong base URI in reader mode (Lars Windolf)</li>
+          <li>Fixes #1112: Image duplication caused by feeds providing an image link which is also in the item description as additional metadata. (Lars Windolf)</li>
+          <li>Update of Dutch translation (Gert-dev)</li>
+        </ul>
+      </description>
+    </release>
+    <release date="2022-04-05" version="1.13.8"/>
+    <release date="2021-12-07" version="1.13.7"/>
+    <release date="2021-05-07" version="1.13.6"/>
+    <release date="2021-01-10" version="1.13.5"/>
+    <release date="2020-12-24" version="1.13.4"/>
+    <release date="2020-10-09" version="1.13.3"/>
+    <release date="2020-08-28" version="1.13.2"/>
   </releases>
 </component>


### PR DESCRIPTION
This improves the display of Liferea on Software Stores and Software Centers.

Some of it is done automatically by `appstream-util upgrade` https://github.com/flathub/flathub/wiki/AppData-Guidelines#upgrading like the metadata license, the rest is done manually.

This can be validated with `appstream-util validate-strict net.sourceforge.liferea.appdata.xml`

Changes:

- Adds a copyright header https://github.com/flathub/flathub/wiki/AppData-Guidelines#header
- Uses the new id tag system https://github.com/flathub/flathub/wiki/AppData-Guidelines#id, provides and launchable
- Added a developer_name tag: 
![developer_name](https://user-images.githubusercontent.com/62639087/181170146-caeff440-3b15-4066-930f-8faa4a352d9e.png)
- Added update_contact, please let me know if you don't want the email displayed there. The mailing list was removed since it is no longer available.
- Updated the feature list section with https://lzone.de/liferea/ :
 
![app_description](https://user-images.githubusercontent.com/62639087/181170853-e2bb9145-10ff-46a7-a668-6a4d1e9b6590.png)

- Added all screenshots from https://lzone.de/liferea/screenshots.htm and added the captions. The width/height property was removed since it is not necessary. The first image is marked as default (All of them doesn't need to be the default image). 
- Added bugtracker and donation links:
 
![links](https://user-images.githubusercontent.com/62639087/181170799-3fdb31a6-1fa7-4735-a306-e80891bba301.png)

- Added translations as per https://github.com/flathub/flathub/wiki/AppData-Guidelines#translations

- Added changelog from https://github.com/lwindolf/liferea/releases/tag/v1.13.9: 

![changelog](https://user-images.githubusercontent.com/62639087/181173038-5f759cd1-8107-4c35-bfd4-5f150102ddd0.png)

Unfortunately formatting like bold is not supported so it looks a bit verbose.

This is the only section that needs updating whenever a new release is made, before the release, so that it is in the release tarball. The release version/date is mandatory and the changelog is optional (but nice to have). It'd be nice if @lwindolf can do it in the release workflow.