### PR TITLE
Improved timeout error handling in feed commands

### DIFF
--- a/man/it/liferea.1
+++ b/man/it/liferea.1
@@ -94,6 +94,13 @@ usato come URI del proxy. Entrambe vengono usate da molti strumenti CLI, quindi
 assicurati di esportarle in una sotto-shell dedicata.
 .RE
 .TP
+.B LIFEREA_FEED_CMD_TIMEOUT
+.RS
+Se definita, sovrascrive il timeout predefinito per i comandi di generazione
+di feeds con il numero di secondi dato in questa variabile. Deve essere un
+valore intero maggiore di zero; valori non validi verranno ignorati.
+.RE
+.TP
 .B LIFEREA_UA_ANONYMOUS
 Se definita, randomizza e anonimizza la stringa User-Agent HTTP/S predefinita.
 .RB

--- a/man/liferea.1
+++ b/man/liferea.1
@@ -92,6 +92,13 @@ URIs. Both are used by many common CLI tools, so make sure to export them in a
 dedicated subshell.
 .RE
 .TP
+.B LIFEREA_FEED_CMD_TIMEOUT
+.RS
+If defined, overrides the default timeout for feed generating commands with
+the number of seconds given in this variable. It must be an integer value
+greater than zero; invalid values will be ignored.
+.RE
+.TP
 .B LIFEREA_UA_ANONYMOUS
 If defined, randomizes and anonymizes the default HTTP/S User-Agent string.
 .RB

--- a/src/net.c
+++ b/src/net.c
@@ -488,6 +488,14 @@ network_strerror (gint status)
 		case SOUP_STATUS_PROXY_UNAUTHORIZED:	tmp = _("Proxy authentication required"); break;
 		case SOUP_STATUS_REQUEST_TIMEOUT:	tmp = _("Request timed out"); break;
 		case SOUP_STATUS_GONE:			tmp = _("The webserver indicates this feed is discontinued. It's no longer available. Liferea won't update it anymore but you can still access the cached headlines."); break;
+
+		/* http 5xx server errors */
+		case SOUP_STATUS_INTERNAL_SERVER_ERROR:	tmp = _("Internal Server Error"); break;
+		case SOUP_STATUS_NOT_IMPLEMENTED:	tmp = _("Not Implemented"); break;
+		case SOUP_STATUS_BAD_GATEWAY:		tmp = _("Bad Gateway"); break;
+		case SOUP_STATUS_SERVICE_UNAVAILABLE:	tmp = _("Service Unavailable"); break;
+		case SOUP_STATUS_GATEWAY_TIMEOUT:	tmp = _("Gateway Timeout"); break;
+		case SOUP_STATUS_HTTP_VERSION_NOT_SUPPORTED: tmp = _("HTTP Version Not Supported"); break;
 	}
 
 	if (!tmp) {

--- a/src/update.c
+++ b/src/update.c
@@ -594,7 +594,7 @@ get_exec_timeout_ms(void)
 			return 1000*i;
 		}
 	}
-	return 30000; /* Default timeout */
+	return 60000; /* Default timeout */
 }
 
 static void

--- a/src/update.c
+++ b/src/update.c
@@ -584,6 +584,18 @@ update_exec_cmd_cb_timeout (gpointer user_data)
 	return FALSE;	/* Remove timeout source */
 }
 
+static int
+get_exec_timeout_ms(void)
+{
+	const gchar	*val;
+	int	i;
+	if ((val = g_getenv("LIFEREA_FEED_CMD_TIMEOUT")) != NULL) {
+		if ((i = atoi(val)) > 0) {
+			return 1000*i;
+		}
+	}
+	return 30000; /* Default timeout */
+}
 
 static void
 update_exec_cmd (updateJobPtr job)
@@ -614,8 +626,7 @@ update_exec_cmd (updateJobPtr job)
 	job->cmd.stdout_ch = g_io_channel_unix_new (job->cmd.fd);
 	job->cmd.io_watch_id = g_io_add_watch (job->cmd.stdout_ch, G_IO_IN | G_IO_HUP, (GIOFunc) update_exec_cmd_cb_out_watch, job);
 
-	/* FIXME: timeout should be configurable */
-	job->cmd.timeout_id = g_timeout_add (30000, (GSourceFunc) update_exec_cmd_cb_timeout, job);
+	job->cmd.timeout_id = g_timeout_add (get_exec_timeout_ms(), (GSourceFunc) update_exec_cmd_cb_timeout, job);
 }
 
 static void


### PR DESCRIPTION
I was facing some timeout issues with feed-generating commands that may be affecting other users too so follows three commits with small  improvements. They are separate changes, but also closely related and mutually dependent, so they all go in a single PR.

First commit allows overriding it via environment variable `LIFEREA_FEED_CMD_TIMEOUT`, in the same way Liferea already uses `LIFEREA_UA` for the user-agent string; second increases the default timeout to 60 s (it seems I was too optimistic with the 30 s timeout when I first added it), and the third commit changes the error reporting so it becomes possible to tell timeouts and other errors apart.

I hope they will be useful!

