### PR TITLE
Don't crash when loading badly encoded enclosures from DB

### DIFF
--- a/src/itemset.c
+++ b/src/itemset.c
@@ -258,10 +258,12 @@ itemset_merge_item (itemSetPtr itemSet, GList *items, itemPtr item, gint maxChec
 			GSList *iter = metadata_list_get_values (item->metadata, "enclosure");
 			while (iter) {
 				enclosurePtr enc = enclosure_from_string (iter->data);
-				debug1 (DEBUG_UPDATE, "download enclosure (%s)", (gchar *)iter->data);
-				enclosure_download (NULL, enc->url, FALSE /* non interactive */);
+				if (enc) {
+					debug1 (DEBUG_UPDATE, "download enclosure (%s)", (gchar *)iter->data);
+					enclosure_download (NULL, enc->url, FALSE /* non interactive */);
+					enclosure_free (enc);
+				}
 				iter = g_slist_next (iter);
-				enclosure_free (enc);
 			}
 		}
 	} else {

--- a/src/rule.c
+++ b/src/rule.c
@@ -161,10 +161,12 @@ rule_check_item_has_podcast_metadata_cb ( const gchar *key, const gchar *value,
 		return;
 	}
 	enclosurePtr encl = enclosure_from_string (value);
-	if (encl->mime && g_str_has_prefix (encl->mime, "audio/")) {
-		*found = TRUE;
+	if (encl != NULL) {
+		if (encl->mime && g_str_has_prefix (encl->mime, "audio/")) {
+			*found = TRUE;
+		}
+		enclosure_free (encl);
 	}
-	enclosure_free (encl);
 }
 
 static gboolean


### PR DESCRIPTION
Function enclosure_from_string can return NULL if the enclosure saved in DB is incorrectly encoded (possibly due to a corrupted database or user changing things manually there). Check for these returns before dereferencing the pointer so the program does not crash.

I introduced one of these issues myself in commit c829a05e875f92ba34d92138a5108eae243de876 (where I used the function to check for podcast enclosures) and the other was already present in the code. I only noticed the NULL return when trying to extend feature "Export items to file" to also include the enclosures, and will sen the code for this in the next PR.