### PR TITLE
 Save enclosures when exporting items to a file 

### DIFF
--- a/src/itemset.c
+++ b/src/itemset.c
@@ -258,10 +258,12 @@ itemset_merge_item (itemSetPtr itemSet, GList *items, itemPtr item, gint maxChec
 			GSList *iter = metadata_list_get_values (item->metadata, "enclosure");
 			while (iter) {
 				enclosurePtr enc = enclosure_from_string (iter->data);
-				debug1 (DEBUG_UPDATE, "download enclosure (%s)", (gchar *)iter->data);
-				enclosure_download (NULL, enc->url, FALSE /* non interactive */);
+				if (enc) {
+					debug1 (DEBUG_UPDATE, "download enclosure (%s)", (gchar *)iter->data);
+					enclosure_download (NULL, enc->url, FALSE /* non interactive */);
+					enclosure_free (enc);
+				}
 				iter = g_slist_next (iter);
-				enclosure_free (enc);
 			}
 		}
 	} else {

--- a/src/node.c
+++ b/src/node.c
@@ -33,6 +33,7 @@
 #include "itemset.h"
 #include "item_state.h"
 #include "metadata.h"
+#include "enclosure.h"
 #include "node.h"
 #include "node_view.h"
 #include "render.h"
@@ -572,6 +573,29 @@ save_item_to_file_metadata_callback (const gchar *key, const gchar *value, guint
 	}
 	else if (g_strcmp0(key, "category") == 0) {
 		xmlTextWriterWriteElement (writer, BAD_CAST "category", BAD_CAST value);
+	}
+	else if (g_strcmp0(key, "enclosure") == 0) {
+		enclosurePtr encl = enclosure_from_string (value);
+		if (encl != NULL) {
+			/* There is no reason to save an enclosure with no URL. */
+			if (encl->url) {
+				xmlTextWriterStartElement(writer, BAD_CAST "enclosure");
+				xmlTextWriterWriteAttribute(writer, BAD_CAST "url", BAD_CAST encl->url);
+
+				/* Spec says both size and type are required but not all feeds respect this. */
+				if (encl->mime) {
+					xmlTextWriterWriteAttribute(writer, BAD_CAST "type", BAD_CAST encl->mime);
+				}
+				if (encl->size > 0) {
+					gchar buf[32];
+					g_snprintf(buf, sizeof(buf), "%ld", encl->size);
+					buf[sizeof(buf)-1] = '\0';
+					xmlTextWriterWriteAttribute(writer, BAD_CAST "length", BAD_CAST buf);
+				}
+				xmlTextWriterEndElement (writer);
+			}
+			enclosure_free (encl);
+		}
 	}
 }
 

--- a/src/rule.c
+++ b/src/rule.c
@@ -161,10 +161,12 @@ rule_check_item_has_podcast_metadata_cb ( const gchar *key, const gchar *value,
 		return;
 	}
 	enclosurePtr encl = enclosure_from_string (value);
-	if (encl->mime && g_str_has_prefix (encl->mime, "audio/")) {
-		*found = TRUE;
+	if (encl != NULL) {
+		if (encl->mime && g_str_has_prefix (encl->mime, "audio/")) {
+			*found = TRUE;
+		}
+		enclosure_free (encl);
 	}
-	enclosure_free (encl);
 }
 
 static gboolean


### PR DESCRIPTION
Also export the enclosure elements when exporting items to a feed file. This is mostly useful for podcasts.

Please notice that this PR already includes the commit to fix the invalid memory access to function enclosure_from_string() that I sent a few minutes ago in PR #1138. To make things easier, you can merge this one and close both issues.

