### PR TITLE
Fix color scheme support across desktop environments

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -81,20 +81,24 @@ conf_get_dark_theme (void)
 	if (fdo_settings) {
 		gint scheme;
 
-		conf_get_int_value_from_schema (fdo_settings, "color-scheme", &scheme);
-		debug1 (DEBUG_CONF, "FDO reports color-schema code '%d'", scheme);
-		if (1 == scheme)
-			dark = FALSE;
-		if (0 == scheme || 2 == scheme)
-			dark = TRUE;
+		if (conf_schema_has_key (fdo_settings, "color-scheme")) {
+			conf_get_int_value_from_schema (fdo_settings, "color-scheme", &scheme);
+			debug1 (DEBUG_CONF, "FDO reports color-schema code '%d'", scheme);
+			if (1 == scheme)
+				dark = FALSE;
+			if (0 == scheme || 2 == scheme)
+				dark = TRUE;
+		}
 	} else {
 		gchar *scheme = NULL;
 
-		conf_get_str_value_from_schema (desktop_settings, "color-scheme", &scheme);
-		if (scheme) {
-			debug1 (DEBUG_CONF, "GNOME reports color-schema '%s'", scheme);
-			dark = g_str_equal (scheme, "prefer-dark");
-			g_free (scheme);
+		if (conf_schema_has_key (desktop_settings, "color-scheme")) {
+			conf_get_str_value_from_schema (desktop_settings, "color-scheme", &scheme);
+			if (scheme) {
+				debug1 (DEBUG_CONF, "GNOME reports color-schema '%s'", scheme);
+				dark = g_str_equal (scheme, "prefer-dark");
+				g_free (scheme);
+			}
 		}
 	}
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -227,6 +227,23 @@ conf_get_toolbar_style(void)
 }
 
 gboolean
+conf_schema_has_key (GSettings *gsettings, const gchar *key)
+{
+	g_assert (gsettings != NULL);
+	g_assert (key != NULL);
+
+	GSettingsSchema *schema = NULL;
+	gboolean has_key = FALSE;
+
+	g_object_get (gsettings, "settings-schema", &schema, NULL);
+	if (schema) {
+		has_key = g_settings_schema_has_key (schema, key);
+		g_settings_schema_unref (schema);
+	}
+	return has_key;
+}
+
+gboolean
 conf_get_bool_value_from_schema (GSettings *gsettings, const gchar *key, gboolean *value)
 {
 	g_assert (key != NULL);

--- a/src/conf.c
+++ b/src/conf.c
@@ -94,6 +94,7 @@ conf_get_dark_theme (void)
 		if (scheme) {
 			debug1 (DEBUG_CONF, "GNOME reports color-schema '%s'", scheme);
 			dark = g_str_equal (scheme, "prefer-dark");
+			g_free (scheme);
 		}
 	}
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -85,7 +85,7 @@ conf_get_dark_theme (void)
 		debug1 (DEBUG_CONF, "FDO reports color-schema code '%d'", scheme);
 		if (1 == scheme)
 			dark = FALSE;
-		if (0 == scheme && 2 == scheme)
+		if (0 == scheme || 2 == scheme)
 			dark = TRUE;
 	} else {
 		gchar *scheme = NULL;

--- a/src/conf.h
+++ b/src/conf.h
@@ -95,6 +95,17 @@ void	conf_deinit (void);
 #define conf_get_strv_value(key, value) conf_get_strv_value_from_schema (NULL, key, value)
 #define conf_get_int_value(key, value) conf_get_int_value_from_schema (NULL, key, value)
 
+
+/**
+ * Returns true if the key is defined in the schema for the given gsettings.
+ *
+ * @param gsettings	gsettings schema to use
+ * @param key	the configuration key
+ *
+ * @returns TRUE if the configuration key is defined
+ */
+gboolean conf_schema_has_key (GSettings *gsettings, const gchar *key);
+
 /**
  * Retrieves the value of the given boolean configuration key.
  *


### PR DESCRIPTION
A sequence of commits that fix a few issues with the color scheme support for different desktop environments: a memory leak after reading org.gnome.desktop.interface.color-scheme, an always-false comparison for org.freedesktop.appearance.color-scheme and a crash if the DE has no support for dark themes at all (which also happens with any Gnome < 42). 

In commit 078d32ddd006a89b5fe9701f66ee3dc225fb84ae I assumed that the ideas was for Liferea to get the dark theme by default if user sets no preference (from both the typo being || → && and from the preference stated in commit 72e9567bbc05f84f79822b164f5f6a40a3d99eb3 ... please point if I was wrong here).

I hope I haven't missed anything as I haven't tested in many DEs.
