### PR TITLE
Use UTF-8 encoding for feedlist.opml

### DIFF
--- a/src/export.c
+++ b/src/export.c
@@ -172,7 +172,7 @@ export_OPML_feedlist (const gchar *filename, nodePtr node, gboolean trusted)
 
 		xmlSetDocCompressMode (doc, 0);
 
-		if (-1 == xmlSaveFormatFile (backupFilename, doc, TRUE)) {
+		if (-1 == xmlSaveFormatFileEnc (backupFilename, doc, "utf-8", TRUE)) {
 			g_warning ("Could not export to OPML file!");
 			error = TRUE;
 		}


### PR DESCRIPTION
Use UTF-8 instead of ASCII for feedlist.opml, so minimizing the amount of XML entities there for users who have lots of non-ASCII characters in their feeds, which is specially useful if they also edit the feed list manually with a standard text editor.

Liferea will load this file file with any encoding supported by libxml2, so this change is both backward and forward compatible.