### PR TITLE
Add seach rule to find items from a given author

### DIFF
--- a/doc/html/searching_en.html
+++ b/doc/html/searching_en.html
@@ -93,6 +93,18 @@
 	</td></tr>
 	<!-- ----------------------------------------- -->
 	<tr><td style="background:#bfb">
+	<b>Item author does contain</b>
+	</td><td>
+	<b>Adds</b> each item whose item author (or creator, acording to the feed) matches the given case insensitive string to the search folder.
+	</td></tr>
+	<!-- ----------------------------------------- -->
+	<tr><td style="background:#fbb">
+	<b>Item title does not contain</b>
+	</td><td>
+	<b>Removes</b> each item whose item author (or creator, acording to the feed) matches the given case insensitive string from the search folder.
+	</td></tr>
+	<!-- ----------------------------------------- -->
+	<tr><td style="background:#bfb">
 	<b>Item body does contain</b>
 	</td><td>
 	<b>Adds</b> each item whose item content matches the given case insensitive string to the search folder.

--- a/src/rule.c
+++ b/src/rule.c
@@ -30,6 +30,7 @@
 #define ITEM_MATCH_RULE_ID		"exact"
 #define ITEM_TITLE_MATCH_RULE_ID	"exact_title"
 #define ITEM_DESC_MATCH_RULE_ID		"exact_desc"
+#define ITEM_AUTHOR_MATCH_RULE_ID	"exact_author"
 #define FEED_TITLE_MATCH_RULE_ID	"feed_title"
 #define FEED_SOURCE_MATCH_RULE_ID	"feed_source"
 #define PARENT_FOLDER_MATCH_RULE_ID	"parent_folder"
@@ -200,6 +201,30 @@ rule_check_item_category (rulePtr rule, itemPtr item)
 }
 
 static gboolean
+rule_check_item_author (rulePtr rule, itemPtr item)
+{
+	GSList	*iter;
+
+	iter = metadata_list_get_values (item->metadata, "author");
+	while (iter) {
+		if (rule_strcasecmp ((gchar *)iter->data, rule->valueCaseFolded)) {
+			return TRUE;
+		}
+		iter = g_slist_next (iter);
+	}
+
+	iter = metadata_list_get_values (item->metadata, "creator");
+	while (iter) {
+		if (rule_strcasecmp ((gchar *)iter->data, rule->valueCaseFolded)) {
+			return TRUE;
+		}
+		iter = g_slist_next (iter);
+	}
+	return FALSE;
+}
+
+
+static gboolean
 rule_check_feed_title (rulePtr rule, itemPtr item)
 {
 	nodePtr feedNode = node_from_id (item->parentNodeId);
@@ -265,6 +290,7 @@ rule_init (void)
 	rule_info_add (rule_check_item_all,		ITEM_MATCH_RULE_ID,		_("Item"),			_("does contain"),	_("does not contain"),	TRUE);
 	rule_info_add (rule_check_item_title,		ITEM_TITLE_MATCH_RULE_ID,	_("Item title"),		_("does contain"),	_("does not contain"),	TRUE);
 	rule_info_add (rule_check_item_description,	ITEM_DESC_MATCH_RULE_ID,	_("Item body"),			_("does contain"),	_("does not contain"),	TRUE);
+	rule_info_add (rule_check_item_author,		ITEM_AUTHOR_MATCH_RULE_ID,	_("Item author"),		_("does contain"),	_("does not contain"),	TRUE);
 	rule_info_add (rule_check_item_is_unread,	"unread",			_("Read status"),		_("is unread"),		_("is read"),		FALSE);
 	rule_info_add (rule_check_item_is_flagged,	"flagged",			_("Flag status"),		_("is flagged"),	_("is unflagged"),	FALSE);
 	rule_info_add (rule_check_item_has_enc,		"enclosure",			_("Enclosure"),			_("included"),		_("not included"),	FALSE);


### PR DESCRIPTION
Add a new filter rule to filter feed items by author. "Author" is definedin a broad sense, as it would look for the user, and the rule matches both elements "author" (from RSS2 and Atom) and "creator" (from DC namespace).