### PR TITLE
Improvements for podcast search rule

### DIFF
--- a/doc/html/searching_en.html
+++ b/doc/html/searching_en.html
@@ -143,11 +143,23 @@
 	<tr><td style="background:#bfb">
 	<b>Podcast included</b>
 	</td><td>
-	<b>Adds</b> all items that contain an enclosure to the search folder.
+	<b>Adds</b> all items that contain a podcast to the search folder. For this rule, podcast is assumed to be any enclosure for an audio file.
 	</td></tr>
 	<!-- ----------------------------------------- -->
 	<tr><td style="background:#fbb">
 	<b>Podcast not included</b>
+	</td><td>
+	<b>Removes</b> all items that do not contain a podcast (i.e. an enclosure for an audio file) from the search folder.
+	</td></tr>
+	<!-- ----------------------------------------- -->
+	<tr><td style="background:#bfb">
+	<b>Enclosure included</b>
+	</td><td>
+	<b>Adds</b> all items that contain an enclosure (for any file type) to the search folder.
+	</td></tr>
+	<!-- ----------------------------------------- -->
+	<tr><td style="background:#fbb">
+	<b>Enclosure not included</b>
 	</td><td>
 	<b>Removes</b> all items that do not contain an enclosure from the search folder.
 	</td></tr>


### PR DESCRIPTION
Two small improvements for the podcast search rule that I only noticed when writing the new author search rule for PR #1148 : make code shorter (by using `metadata_list_get_values` instead of callbacks) and add the documentation to the help files.
