### PR TITLE
Fix notification icon in libnotify plugin

### DIFF
--- a/plugins/libnotify.py
+++ b/plugins/libnotify.py
@@ -41,7 +41,7 @@ class LibnotifyPlugin(GObject.Object, Liferea.ShellActivatable):
     notification = None
     notification_title = _("Feed Updates")
     notification_body = ""
-    notification_icon = "liferea"
+    notification_icon = "net.sourceforge.liferea"
     timestamp = None
     _handler_id = None
 


### PR DESCRIPTION
Commit 0dea39b79802 changed the filename of the liferea icon but the plugin was not updated to reflect that.