### PR TITLE
Fix fuzzy strings for pt-BR translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1306,9 +1306,8 @@ msgid "Program"
 msgstr "Programa"
 
 #: ../src/ui/rule_editor.c:257
-#, fuzzy
 msgid "Remove"
-msgstr "_Remover"
+msgstr "Remover"
 
 #: ../src/ui/search_dialog.c:106
 msgid "Saved Search"
@@ -1862,9 +1861,8 @@ msgid "_Defer removing read items from folders and search folders."
 msgstr "A_diar a remoção de itens lidos de pastas e pastas de pesquisa."
 
 #: ../glade/prefs.ui.h:22
-#, fuzzy
 msgid "Ask for confirmation when marking all items as read."
-msgstr "Pedir confirmação ao marcar todos os itens como lidos"
+msgstr "Pedir confirmação ao marcar todos os itens como lidos."
 
 #: ../glade/prefs.ui.h:23
 msgid "Web Integration"


### PR DESCRIPTION
Replace two instance of fuzzy-matched strings by their correct versions. I somehow missed these in 81b87963d43f437e01de2671432fa3c83c7b60d7.
