### PR TITLE
Load custom user stylesheet for all URLs

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -302,8 +302,7 @@ render_get_theme_color (const gchar *name)
 {
 	GSList	*iter;
 
-	if (!themeColors)
-		return NULL;
+	g_return_val_if_fail (themeColors != NULL, NULL);
 
 	iter = themeColors;
 	while (iter) {
@@ -324,8 +323,7 @@ render_get_default_css (void)
 		gchar	*userStyleSheetFile;
 		gchar	*tmp;
 
-		if (!themeColors)
-			return NULL;
+		g_return_val_if_fail (themeColors != NULL, NULL);
 
 		css = g_string_new(NULL);
 
@@ -353,8 +351,7 @@ render_get_user_css (void)
 		gchar	*userStyleSheetFile;
 		gchar	*tmp;
 
-		if (!themeColors)
-			return NULL;
+		g_return_val_if_fail (themeColors != NULL, NULL);
 
 		userCss = g_string_new(NULL);
 

--- a/src/render.c
+++ b/src/render.c
@@ -154,6 +154,7 @@ render_load_stylesheet (const gchar *xsltName)
 
 /** cached CSS definitions */
 static GString	*css = NULL;
+static GString	*userCss = NULL;
 
 /** widget background theme colors as 8bit HTML RGB code */
 typedef struct themeColor {
@@ -222,6 +223,10 @@ render_init_theme_colors (GtkWidget *widget)
 	if (css) {
 		g_string_free (css, FALSE);
 		css = NULL;
+	}
+	if (userCss) {
+		g_string_free (userCss, FALSE);
+		userCss = NULL;
 	}
 	if (themeColors) {
 		g_slist_free_full (themeColors, (GDestroyNotify)render_theme_color_free);
@@ -312,7 +317,7 @@ render_get_theme_color (const gchar *name)
 }
 
 gchar *
-render_get_css (void)
+render_get_default_css (void)
 {
 	if (!css) {
 		gchar	*defaultStyleSheetFile;
@@ -335,19 +340,36 @@ render_get_css (void)
 		}
 
 		g_free(defaultStyleSheetFile);
+	}
+
+	return css->str;
+}
+
+gchar *
+render_get_user_css (void)
+{
+	if (!userCss) {
+		gchar	*defaultStyleSheetFile;
+		gchar	*userStyleSheetFile;
+		gchar	*tmp;
+
+		if (!themeColors)
+			return NULL;
+
+		userCss = g_string_new(NULL);
 
 		userStyleSheetFile = common_create_config_filename ("liferea.css");
 
 		if (g_file_get_contents(userStyleSheetFile, &tmp, NULL, NULL)) {
 			tmp = render_set_theme_colors(tmp);
-			g_string_append(css, tmp);
+			g_string_append(userCss, tmp);
 			g_free(tmp);
 		}
 
 		g_free(userStyleSheetFile);
 	}
 
-	return css->str;
+	return userCss->str;
 }
 
 gchar *

--- a/src/render.h
+++ b/src/render.h
@@ -56,9 +56,14 @@ renderParamPtr render_parameter_new (void);
 void render_parameter_add (renderParamPtr paramSet, const gchar *fmt, ...);
 
 /**
- * Returns CSS definitions for inclusion in XHTML output.
+ * Returns default CSS definitions for inclusion in XHTML output.
  */
-gchar * render_get_css (void);
+gchar * render_get_default_css (void);
+
+/**
+ * Returns user CSS definitions for inclusion in XHTML output.
+ */
+gchar * render_get_user_css (void);
 
 /**
  * Returns the CSS value of a given GTK theme color name e.g. "GTK-COLOR-MID".

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -1370,8 +1370,9 @@ liferea_shell_create (GtkApplication *app, const gchar *overrideWindowState, gin
 
 	gtk_widget_set_sensitive (GTK_WIDGET (shell->feedlistViewWidget), TRUE);
 
-	/* 10.) After main window is realized get theme colors and set up feed
-		list and load WebView stylesheet */
+	/* 10.) After main window is realized get theme colors and set up feed list */
+	// FIXME: this should not be necessary, but style-updated does not
+	// always fire before we get here
 	render_init_theme_colors (GTK_WIDGET (shell->window));
 
 	shell->feedlist = feedlist_create (feedListView);
@@ -1383,8 +1384,6 @@ liferea_shell_create (GtkApplication *app, const gchar *overrideWindowState, gin
 	                  G_CALLBACK (liferea_shell_update_node_actions), NULL);
 	g_signal_connect (feedListView, "selection-changed",
 	                  G_CALLBACK (liferea_shell_update_node_actions), NULL);
-
-	itemview_style_update ();
 
 	/* 11.) Restore latest selection */
 


### PR DESCRIPTION
Only load the default stylesheet, used for theming, when loading Liferea-generated HTML.

Fixes #1163.