### PR TITLE
Use monotonic clock in libnotify plugin

### DIFF
--- a/plugins/libnotify.py
+++ b/plugins/libnotify.py
@@ -56,7 +56,7 @@ class LibnotifyPlugin(GObject.Object, Liferea.ShellActivatable):
         self.shell.props.feed_list.disconnect(self._handler_id)
 
     def on_node_updated(self, widget, node_title):
-        new_timestamp = time.time()
+        new_timestamp = time.monotonic()
 
         # Only make a new notification every 10 seconds
         if new_timestamp > self.timestamp + 10:


### PR DESCRIPTION
It is a good idea to use a monotonic clock as a way to check how much time has passed, as it will not be affected by the system clock changing (DST for example).

However, I am not sure what the minimum targeted Python 3 version is.

From the [docs](https://docs.python.org/3/library/time.html#time.monotonic) for `time.monotonic()`:
```
New in version 3.3.

Changed in version 3.5: The function is now always available and always system-wide.

Changed in version 3.10: On macOS, the function is now system-wide.
```

If the minimum Python version is < 3.5, then a check needs to be added to use `time.monotonic()` if it's available.