### PR TITLE
Use closed signal to reset concatenation in libnotify plugin

### DIFF
--- a/plugins/libnotify.py
+++ b/plugins/libnotify.py
@@ -19,7 +19,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import gettext
-import time
 import gi
 gi.require_version('Notify', '0.7')
 from gi.repository import GObject, Liferea, Notify
@@ -42,28 +41,26 @@ class LibnotifyPlugin(GObject.Object, Liferea.ShellActivatable):
     notification_title = _("Feed Updates")
     notification_body = ""
     notification_icon = "net.sourceforge.liferea"
-    timestamp = None
     _handler_id = None
 
     def do_activate(self):
-        self.timestamp = 0
         Notify.init('Liferea')
         self._handler_id = self.shell.props.feed_list.connect("node-updated", self.on_node_updated)
         self.notification = Notify.Notification.new(self.notification_title, self.notification_body, self.notification_icon)
+        self.notification.connect("closed", self.on_closed)
 
     def do_deactivate(self):
         Notify.uninit()
         self.shell.props.feed_list.disconnect(self._handler_id)
 
     def on_node_updated(self, widget, node_title):
-        new_timestamp = time.time()
-
-        # Only make a new notification every 10 seconds
-        if new_timestamp > self.timestamp + 10:
-            self.notification_body = node_title
-            # Update the timestamp
-            self.timestamp = new_timestamp
-        else:
+        # Update the existing notification if it hasn't been closed yet
+        if self.notification_body:
             self.notification_body += "\n" + node_title
+        else:
+            self.notification_body = node_title
         self.notification.update(self.notification_title, self.notification_body, self.notification_icon)
         self.notification.show()
+
+    def on_closed(self, data):
+        self.notification_body = ""


### PR DESCRIPTION
This behaves better than simply timing it, as the user might manually dismiss the notification, in which case previously it'd pop up with the same feed titles, plus the new ones.

Tested in Unity, Cinnamon and AwesomeWM.

In Cinnamon, the closed signal fires when the notification is dismissed manually either from the notification centre or by pressing the X button while it is visible. This is not an issue, as the notification ends up being updated and re-shown when more feeds have updates, without adding an extra entry in the history. Presumably GNOME behaves in a similar way.

I was mostly worried about environments such as Awesome, but it seems like it behaves as expected there as well.

Replaces https://github.com/lwindolf/liferea/pull/1207