### PR TITLE
Fix TypeError on add-bookmark-site preferences

### DIFF
--- a/plugins/add-bookmark-site.py
+++ b/plugins/add-bookmark-site.py
@@ -56,8 +56,8 @@ def load_config():
             url = fields[1]
     except Exception as e:
         print(e)
-        name = None
-        url = None        
+        name = ''
+        url = ''
 
     return (name, url)
 


### PR DESCRIPTION
When opening the add-bookmark-site preferences, if there was no configuration file or if any other error occurs when loading the configuration, the preferences window never appears and the following error occurs:

```
Traceback (most recent call last):
  File "/usr/lib/liferea/plugins/add-bookmark-site.py", line 103, in do_create_configure_widget
    self._urlEntry.set_text(url)
TypeError: Argument 1 does not allow None as a value
```

To reproduce, make sure `~/.config/liferea/plugins/add-bookmark-site/add-bookmark-site.ini` does not exist, then try opening the preferences of the plugin.

This fixes the issue by using empty strings as the default values instead of `None`. Since both are considered to be false, the plugin assumes no URL was set yet and does not try to register *nothing*.