### PR TITLE
Add new flat view mode and title filter

### DIFF
--- a/glade/liferea_menu.ui
+++ b/glade/liferea_menu.ui
@@ -153,8 +153,19 @@
        </section>
       <section>
         <item>
-          <attribute name="action">app.reduced-feed-list</attribute>
-          <attribute name="label" translatable="yes">_Reduced Feed List</attribute>
+          <attribute name="action">app.feedlist-view-mode</attribute>
+          <attribute name="label" translatable="yes">N_ormal feed list</attribute>
+          <attribute name="target">normal</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.feedlist-view-mode</attribute>
+          <attribute name="label" translatable="yes">_Reduced feed list</attribute>
+          <attribute name="target">reduced</attribute>
+        </item>
+        <item>
+          <attribute name="action">app.feedlist-view-mode</attribute>
+          <attribute name="label" translatable="yes">F_lat feed list</attribute>
+          <attribute name="target">flat</attribute>
         </item>
       </section>
     </submenu>

--- a/glade/mainwindow.ui
+++ b/glade/mainwindow.ui
@@ -29,23 +29,50 @@
             <property name="vexpand">True</property>
             <property name="position">170</property>
             <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow3">
+              <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="hscrollbar-policy">never</property>
-                <property name="shadow-type">in</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkTreeView" id="feedlist">
+                  <object class="GtkSearchEntry" id="titleFilter">
+                    <property name="visible">False</property>
+                    <property name="can-focus">True</property>
+                    <property name="primary-icon-name">edit-find-symbolic</property>
+                    <property name="primary-icon-activatable">False</property>
+                    <property name="primary-icon-sensitive">False</property>
+                    <property name="placeholder-text" translatable="yes">Filter (Alt+g)</property>
+                    <accelerator key="g" signal="grab-focus" modifiers="GDK_MOD1_MASK"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow3">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
-                    <property name="headers-visible">False</property>
-                    <property name="reorderable">True</property>
-                    <signal name="button-press-event" handler="on_mainfeedlist_button_press_event" swapped="no"/>
-                    <signal name="popup-menu" handler="on_mainfeedlist_popup_menu" swapped="no"/>
-                    <child internal-child="selection">
-                      <object class="GtkTreeSelection"/>
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTreeView" id="feedlist">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <property name="reorderable">True</property>
+                        <signal name="button-press-event" handler="on_mainfeedlist_button_press_event" swapped="no"/>
+                        <signal name="popup-menu" handler="on_mainfeedlist_popup_menu" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
+                      </object>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>

--- a/net.sf.liferea.gschema.xml.in
+++ b/net.sf.liferea.gschema.xml.in
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
 <schemalist gettext-domain="liferea">
+  <enum id="net.sf.liferea.FeedlistViewMode">
+    <value value="0" nick="normal"/>
+    <value value="1" nick="reduced"/>
+    <value value="2" nick="flat"/>
+  </enum>
   <schema gettext-domain="@GETTEXT_PACKAGE@" id="net.sf.liferea" path="/org/gnome/liferea/">
     <child name="plugins" schema="net.sf.liferea.plugins"/>
     <key name="browse-inside-application" type="b">
@@ -131,6 +136,11 @@
       <default>false</default>
       <summary>Filter feeds without unread items from feed list.</summary>
       <description>If this option is enabled the feed list will contain only feeds that have unread items.</description>
+    </key>
+    <key name="feedlist-view-mode" enum="net.sf.liferea.FeedlistViewMode">
+      <default>'normal'</default>
+      <summary>How the feed list is presented</summary>
+      <description>How the feed list is presented to the user. Possible values are "normal", "reduced", and "flat".</description>
     </key>
     <key name="download-custom-command" type="s">
       <default>''</default>

--- a/src/conf.c
+++ b/src/conf.c
@@ -215,6 +215,13 @@ conf_set_int_value (const gchar *key, gint value)
 	g_settings_set_int (settings, key, value);
 }
 
+void
+conf_set_enum_value (const gchar *key, gint value)
+{
+	g_assert (key != NULL);
+	g_settings_set_enum (settings, key, value);
+}
+
 gchar *
 conf_get_toolbar_style(void)
 {
@@ -294,6 +301,19 @@ conf_get_int_value_from_schema (GSettings *gsettings, const gchar *key, gint *va
 	*value = g_settings_get_int (gsettings,key);
 	return (NULL != value);
 }
+
+gboolean
+conf_get_enum_value_from_schema (GSettings *gsettings, const gchar *key, gint *value)
+{
+	g_assert (key != NULL);
+	g_assert (value != NULL);
+
+	if (gsettings == NULL)
+		gsettings = settings;
+	*value = g_settings_get_enum (gsettings,key);
+	return (NULL != value);
+}
+
 
 gboolean
 conf_get_default_font (gchar **value)

--- a/src/conf.h
+++ b/src/conf.h
@@ -95,6 +95,7 @@ void	conf_deinit (void);
 #define conf_get_str_value(key, value) conf_get_str_value_from_schema (NULL, key, value)
 #define conf_get_strv_value(key, value) conf_get_strv_value_from_schema (NULL, key, value)
 #define conf_get_int_value(key, value) conf_get_int_value_from_schema (NULL, key, value)
+#define conf_get_enum_value(key, value) conf_get_enum_value_from_schema (NULL, key, value)
 
 
 /**
@@ -154,6 +155,17 @@ gboolean conf_get_strv_value_from_schema (GSettings *gsettings,const gchar *key,
 gboolean conf_get_int_value_from_schema (GSettings *gsettings, const gchar *key, gint *value);
 
 /**
+ * Retrieves the value of the given enum configuration key.
+ *
+ * @param gsettings	gsettings schema to use
+ * @param key	the configuration key
+ * @param value the value, if the function returned FALSE it's always 0
+ *
+ * @returns TRUE if the configuration key was found
+ */
+gboolean conf_get_enum_value_from_schema (GSettings *gsettings, const gchar *key, gint *value);
+
+/**
  * Sets the value of the given boolean configuration key.
  *
  * @param key	the configuration key
@@ -186,6 +198,15 @@ void conf_set_strv_value (const gchar *key, const gchar **value);
  * @param value	the new integer value
  */
 void conf_set_int_value (const gchar *key, gint value);
+
+/**
+ * Sets the value of the given enum configuration key
+ *
+ * @param key	the configuration key
+ * @param value	the new enum (as integer) value
+ */
+void conf_set_enum_value (const gchar *key, gint value);
+
 
 /**
  * Returns the current toolbar configuration.

--- a/src/conf.h
+++ b/src/conf.h
@@ -56,7 +56,7 @@
 /* folder handling settings */
 #define FOLDER_DISPLAY_MODE		"folder-display-mode"
 #define FOLDER_DISPLAY_HIDE_READ	"folder-display-hide-read"
-#define REDUCED_FEEDLIST		"reduced-feedlist"
+#define FEEDLIST_VIEW_MODE		"feedlist-view-mode"
 
 /* GUI settings and persistency values */
 #define CONFIRM_MARK_ALL_READ 		"confirm-mark-all-read"

--- a/src/ui/feed_list_view.c
+++ b/src/ui/feed_list_view.c
@@ -51,7 +51,7 @@ struct _FeedListView {
 
 	GHashTable		*flIterHash;				/**< hash table used for fast node id <-> tree iter lookup */
 
-	gboolean		feedlist_reduced_unread;	/**< TRUE when feed list is in reduced mode (no folders, only unread feeds) */
+	enum feedlistViewMode	view_mode;
 };
 
 enum {
@@ -94,6 +94,42 @@ static void
 feed_list_view_init (FeedListView *f)
 {
 }
+
+
+enum feedlistViewMode
+feed_list_view_mode_string_to_value (const gchar *str_mode)
+{
+	/* TODO: Load these values from Gsettings Schema. */
+	if (!g_strcmp0 ("normal", str_mode)) {
+		return FEEDLIST_VIEW_MODE_NORMAL;
+	}
+	if (!g_strcmp0 ("reduced", str_mode)) {
+		return FEEDLIST_VIEW_MODE_REDUCED;
+	}
+	if (!g_strcmp0 ("flat", str_mode)) {
+		return FEEDLIST_VIEW_MODE_FLAT;
+	}
+
+	/* Unknown or invalid mode, assume normal. */
+	return FEEDLIST_VIEW_MODE_NORMAL;
+}
+
+const gchar *
+feed_list_view_mode_value_to_string (enum feedlistViewMode mode)
+{
+	/* TODO: Load these values from Gsettings Schema. */
+	switch (mode) {
+	case FEEDLIST_VIEW_MODE_NORMAL:
+		return "normal";
+	case FEEDLIST_VIEW_MODE_REDUCED:
+		return "reduced";
+	case FEEDLIST_VIEW_MODE_FLAT:
+		return "flat";
+	}
+	/* Unknown or invalid mode, assume normal. */
+	return "normal";
+}
+
 
 static void
 feed_list_view_row_changed_cb (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter)
@@ -185,18 +221,24 @@ feed_list_view_filter_visible_function (GtkTreeModel *model, GtkTreeIter *iter, 
 	gint			count;
 	nodePtr			node;
 
-	if (!flv->feedlist_reduced_unread)
+	if (flv->view_mode == FEEDLIST_VIEW_MODE_NORMAL) {
 		return TRUE;
+	}
+
+	/* From here, assume mode is REDUCED or FLAT */
 
 	gtk_tree_model_get (model, iter, FS_PTR, &node, FS_UNREAD, &count, -1);
-	if (!node)
+	if (!node) {
 		return FALSE;
+	}
 
-	if (IS_NEWSBIN(node) && node->data && ((feedPtr)node->data)->alwaysShowInReduced)
+	if (IS_NEWSBIN(node) && node->data && ((feedPtr)node->data)->alwaysShowInReduced) {
 		return TRUE;
+	}
 
-	if (IS_FOLDER (node) || IS_NODE_SOURCE (node))
+	if (IS_FOLDER (node) || IS_NODE_SOURCE (node)) {
 		return FALSE;
+	}
 
 	if (IS_VFOLDER (node))
 		return TRUE;
@@ -207,10 +249,11 @@ feed_list_view_filter_visible_function (GtkTreeModel *model, GtkTreeIter *iter, 
 	if (feedlist_get_selected () == node)
 		return TRUE;
 
-	if (count > 0)
-		return TRUE;
+	if (flv->view_mode == FEEDLIST_VIEW_MODE_REDUCED && count == 0) {
+		return FALSE;
+	}
 
-	return FALSE;
+	return TRUE;
 }
 
 static void
@@ -232,9 +275,9 @@ feed_list_view_restore_folder_expansion (nodePtr node)
 }
 
 static void
-feed_list_view_reduce_mode_changed (void)
+feed_list_view_mode_changed (void)
 {
-	if (flv->feedlist_reduced_unread) {
+	if (flv->view_mode != FEEDLIST_VIEW_MODE_NORMAL) {
 		gtk_tree_view_set_reorderable (flv->treeview, FALSE);
 		gtk_tree_view_set_model (flv->treeview, GTK_TREE_MODEL (flv->filter));
 		gtk_tree_model_filter_refilter (GTK_TREE_MODEL_FILTER (flv->filter));
@@ -248,11 +291,11 @@ feed_list_view_reduce_mode_changed (void)
 }
 
 static void
-feed_list_view_set_reduce_mode (gboolean newReduceMode)
+feed_list_view_set_view_mode (enum feedlistViewMode mode)
 {
-	flv->feedlist_reduced_unread = newReduceMode;
-	conf_set_bool_value (REDUCED_FEEDLIST, flv->feedlist_reduced_unread);
-	feed_list_view_reduce_mode_changed ();
+	flv->view_mode = mode;
+	conf_set_enum_value (FEEDLIST_VIEW_MODE, flv->view_mode);
+	feed_list_view_mode_changed ();
 	feed_list_view_reload_feedlist ();
 }
 
@@ -285,7 +328,7 @@ feed_list_view_sort_folder (nodePtr folder)
 	feed_list_view_reload_feedlist ();
 	/* Reduce mode didn't actually change but we need to set the
 	 * correct model according to the setting in the same way : */
-	feed_list_view_reduce_mode_changed ();
+	feed_list_view_mode_changed ();
 	feedlist_foreach (feed_list_view_restore_folder_expansion);
 	feedlist_schedule_save ();
 }
@@ -359,9 +402,9 @@ feed_list_view_create (GtkTreeView *treeview)
 	                  G_CALLBACK (feed_list_view_selection_changed_cb),
                 	  flv);
 
-	conf_get_bool_value (REDUCED_FEEDLIST, &flv->feedlist_reduced_unread);
-	if (flv->feedlist_reduced_unread)
-		feed_list_view_reduce_mode_changed ();	/* before menu setup for reduced mode check box to be correct */
+	conf_get_enum_value (FEEDLIST_VIEW_MODE, (gint *) &flv->view_mode);
+	if (flv->view_mode != FEEDLIST_VIEW_MODE_NORMAL)
+		feed_list_view_mode_changed ();	/* before menu setup for reduced mode check box to be correct */
 
 	ui_dnd_setup_feedlist (flv->feedstore);
 
@@ -378,7 +421,7 @@ feed_list_view_select (nodePtr node)
 		GtkTreePath *path = NULL;
 
 		/* in filtered mode we need to convert the iterator */
-		if (flv->feedlist_reduced_unread) {
+		if (flv->view_mode != FEEDLIST_VIEW_MODE_NORMAL) {
 			GtkTreeIter iter;
 			gboolean valid = gtk_tree_model_filter_convert_child_iter_to_iter (GTK_TREE_MODEL_FILTER (flv->filter), &iter, feed_list_view_to_iter (node->id));
 			if (valid)
@@ -519,13 +562,20 @@ on_new_vfolder_activate (GSimpleAction *menuitem, GVariant *parameter, gpointer 
 }
 
 void
-on_feedlist_reduced_activate (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+on_feedlist_view_mode_activate (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
-	GVariant *state = g_action_get_state (G_ACTION (action));
-	gboolean val = !g_variant_get_boolean (state);
-	feed_list_view_set_reduce_mode (val);
-	g_simple_action_set_state (action, g_variant_new_boolean (val));
-	g_object_unref (state);
+	const gchar *str_new_mode = g_variant_get_string (parameter, NULL);
+	enum feedlistViewMode new_mode = feed_list_view_mode_string_to_value (str_new_mode);
+
+	GVariant *tmp = g_action_get_state (G_ACTION(action));
+	const gchar *str_cur_mode = g_variant_get_string (tmp, NULL);
+	enum feedlistViewMode cur_mode = feed_list_view_mode_string_to_value (str_cur_mode);
+	g_variant_unref (tmp);
+
+	if (new_mode != cur_mode) {
+		feed_list_view_set_view_mode (new_mode);
+		g_simple_action_set_state (action, g_variant_new_string (str_new_mode));
+	}
 }
 
 // Handling feed list nodes
@@ -569,7 +619,7 @@ feed_list_view_is_expanded (const gchar *nodeId)
 	GtkTreeIter	*iter;
 	gboolean 	expanded = FALSE;
 
-	if (flv->feedlist_reduced_unread)
+	if (flv->view_mode != FEEDLIST_VIEW_MODE_NORMAL)
 		return FALSE;
 
 	iter = feed_list_view_to_iter (nodeId);
@@ -588,7 +638,7 @@ feed_list_view_set_expansion (nodePtr folder, gboolean expanded)
 	GtkTreeIter		*iter;
 	GtkTreePath		*path;
 
-	if (flv->feedlist_reduced_unread)
+	if (flv->view_mode != FEEDLIST_VIEW_MODE_NORMAL)
 		return;
 
 	iter = feed_list_view_to_iter (folder->id);
@@ -691,14 +741,14 @@ feed_list_view_add_node (nodePtr node)
 	iter = g_new0 (GtkTreeIter, 1);
 
 	/* if reduced feedlist, show flat treeview */
-	if (flv->feedlist_reduced_unread)
+	if (flv->view_mode != FEEDLIST_VIEW_MODE_NORMAL)
 		parentIter = NULL;
 	else if (node->parent != feedlist_get_root ())
 		parentIter = feed_list_view_to_iter (node->parent->id);
 
 	position = g_slist_index (node->parent->children, node);
 
-	if (flv->feedlist_reduced_unread || position < 0)
+	if ((flv->view_mode != FEEDLIST_VIEW_MODE_NORMAL) || position < 0)
 		gtk_tree_store_append (flv->feedstore, iter, parentIter);
 	else
 		gtk_tree_store_insert (flv->feedstore, iter, parentIter, position);

--- a/src/ui/feed_list_view.h
+++ b/src/ui/feed_list_view.h
@@ -40,6 +40,14 @@ enum {
 	FS_LEN
 };
 
+
+enum feedlistViewMode {
+	FEEDLIST_VIEW_MODE_NORMAL	= 0,
+	FEEDLIST_VIEW_MODE_REDUCED	= 1,
+	FEEDLIST_VIEW_MODE_FLAT		= 2,
+};
+
+
 /**
  * feed_list_view_select:
  *
@@ -84,7 +92,7 @@ void on_new_plugin_activate (GSimpleAction *menuitem, GVariant *parameter, gpoin
 void on_new_newsbin_activate (GSimpleAction *menuitem, GVariant *parameter, gpointer user_data);
 void on_new_vfolder_activate (GSimpleAction *menuitem, GVariant *parameter, gpointer user_data);
 
-void on_feedlist_reduced_activate (GSimpleAction *action, GVariant *parameter, gpointer user_data);
+void on_feedlist_view_mode_activate (GSimpleAction *action, GVariant *parameter, gpointer user_data);
 
 /**
  * Determines the tree iter of a given node.
@@ -183,5 +191,23 @@ void feed_list_view_remove (nodePtr node);
  * @param exNode			the existing node
  */
 void feed_list_view_add_duplicate_url_subscription (subscriptionPtr tempSubscription, nodePtr exNode);
+
+/**
+ * Return the integer value associated to the string representing the view mode.
+ * If the view mode is invalid or unrecognized, returns FEEDLIST_VIEW_MODE_NORMAL.
+ *
+ * @param str_mode A string representing a view mode.
+ * @return A integer relative to this mode.
+ */
+enum feedlistViewMode feed_list_view_mode_string_to_value (const gchar *str_mode);
+
+/**
+ * Return a read-only string representing the given view mode.
+ * The returned string must not be changed in any way.
+ *
+ * @param mode a FEEDLIST_VIEW_MODE_* integer.
+ * @return an internally allocated const string.
+ */
+const gchar * feed_list_view_mode_value_to_string (enum feedlistViewMode mode);
 
 #endif

--- a/src/ui/feed_list_view.h
+++ b/src/ui/feed_list_view.h
@@ -93,6 +93,8 @@ void on_new_newsbin_activate (GSimpleAction *menuitem, GVariant *parameter, gpoi
 void on_new_vfolder_activate (GSimpleAction *menuitem, GVariant *parameter, gpointer user_data);
 
 void on_feedlist_view_mode_activate (GSimpleAction *action, GVariant *parameter, gpointer user_data);
+void on_titlefilter_entry_changed (GtkEditable *self, gpointer user_data);
+
 
 /**
  * Determines the tree iter of a given node.

--- a/src/ui/liferea_shell.c
+++ b/src/ui/liferea_shell.c
@@ -977,7 +977,7 @@ static const GActionEntry liferea_shell_gaction_entries[] = {
 
 	/* Parameter type must be NULL for toggle. */
 	{"fullscreen", NULL, NULL, "@b false", on_menu_fullscreen_activate},
-	{"reduced-feed-list", NULL, NULL, "@b false", on_feedlist_reduced_activate},
+	{"feedlist-view-mode", NULL, "s", "@s 'normal'", on_feedlist_view_mode_activate},
 
 	{"toggle-item-read-status", on_toggle_unread_status, "t", NULL, NULL},
 	{"toggle-item-flag", on_toggle_item_flag, "t", NULL, NULL},
@@ -1280,8 +1280,11 @@ liferea_shell_create (GtkApplication *app, const gchar *overrideWindowState, gin
 	shell->itemlist = itemlist_create ();
 
 	/* Prepare some toggle button states */
-	conf_get_bool_value (REDUCED_FEEDLIST, &toggle);
-	g_simple_action_set_state ( G_SIMPLE_ACTION (g_action_map_lookup_action (G_ACTION_MAP (app), "reduced-feed-list")), g_variant_new_boolean (toggle));
+
+	conf_get_enum_value (FEEDLIST_VIEW_MODE, &mode);
+	g_simple_action_set_state (
+		G_SIMPLE_ACTION (g_action_map_lookup_action (G_ACTION_MAP (app), "feedlist-view-mode")),
+		g_variant_new_string (feed_list_view_mode_value_to_string (mode)));
 
 	/* Menu creation */
 	gtk_builder_add_from_file (shell->xml, PACKAGE_DATA_DIR G_DIR_SEPARATOR_S PACKAGE G_DIR_SEPARATOR_S "liferea_menu.ui", NULL);


### PR DESCRIPTION
I originally sent this as a discussion issue ( #1203 ), but it was more than four months ago and the feature already proved itself valuable for me and I didn't find any bug. So, it's time for me to bite the bullet with a PR =)

This PR introduces a new view mode for Liferea that shows all feeds in a single level, similar to the reduced view mode but also showing the feeds with no unread items, and a text box to filter feeds by their titles. The filter is also shown in the new reduced view, as it seems useful there too, specially for folks with lots of subscriptions (I subscribe to ~520 feeds ATM and already miss this kind of filter).

The "Reduced view" checkbox in the view menu is replaced by a "Normal/Reduced/Flat view" radio buttons (but feedback is welcome for these names!) :

![New view mode menu](https://github.com/lwindolf/liferea/assets/110642/c3919fc9-8967-489d-8fdf-b3af26284604)


And the new filter box :

![Filter box with no text, showing all entries](https://github.com/lwindolf/liferea/assets/110642/941f3c92-6c81-417d-bdfc-f34de909c56f)

![Filter box listing only BBC subscriptions](https://github.com/lwindolf/liferea/assets/110642/aa3eee3c-38b7-46fc-8380-ac56c5038d78)


I chose to call this box as "Filter" so it is not confused with the usual search feature, but I would also like some feedback on this.

