### PR TITLE
Fix incorrect item_id when downloading AMP URLs

### DIFF
--- a/src/feed.c
+++ b/src/feed.c
@@ -263,7 +263,7 @@ feed_enrich_item_cb (const struct updateResult * const result, gpointer userdata
 				NULL 	// Explicitely do not the feed's proxy/auth options to 3rd parties like Google (AMP)!
 			);
 
-			update_execute_request (NULL, request, feed_enrich_item_cb, item, FEED_REQ_NO_FEED);
+			update_execute_request (NULL, request, feed_enrich_item_cb, GUINT_TO_POINTER (item->id), FEED_REQ_NO_FEED);
 
 			g_free (ampurl);
 		}


### PR DESCRIPTION
Code passed an incorrect element when enriching an entry from a AMP URL, resulting in a pointer to the item becoming the id. This commit fixes the issue.