### PR TITLE
Preserve search rule argument when changing rule types

### DIFF
--- a/src/ui/rule_editor.c
+++ b/src/ui/rule_editor.c
@@ -139,18 +139,18 @@ static void
 do_ruletype_changed (struct changeRequest	*changeRequest)
 {
 	ruleInfoPtr		ruleInfo;
-	rulePtr			rule;
+	rulePtr			curRule, newRule;
 
-	rule = g_object_get_data (G_OBJECT (changeRequest->paramHBox), "rule");
-	if (rule) {
-		changeRequest->editor->newRules = g_slist_remove (changeRequest->editor->newRules, rule);
-		rule_free (rule);
-	}
+	curRule = g_object_get_data (G_OBJECT (changeRequest->paramHBox), "rule");
 	ruleInfo = g_slist_nth_data (rule_get_available_rules (), changeRequest->rule);
-	rule = rule_new (ruleInfo->ruleId, "", TRUE);
-	changeRequest->editor->newRules = g_slist_append (changeRequest->editor->newRules, rule);
+	newRule = rule_new (ruleInfo->ruleId, curRule && curRule->value ? curRule->value : "", TRUE);
+	if (curRule) {
+		changeRequest->editor->newRules = g_slist_remove (changeRequest->editor->newRules, curRule);
+		rule_free (curRule);
+	}
+	changeRequest->editor->newRules = g_slist_append (changeRequest->editor->newRules, newRule);
 
-	rule_editor_setup_widgets (changeRequest, rule);
+	rule_editor_setup_widgets (changeRequest, newRule);
 }
 
 /* callback for rule type option menu */


### PR DESCRIPTION
Do not erase the rule argument when user changes a rule type in the editor used for the search folders and advanced search. This is a purely usability change, no effect on persistent data.

Current behavior:


https://github.com/lwindolf/liferea/assets/110642/e267cf56-b499-4c5d-96a2-eca553b4e8a1


New behavior:


https://github.com/lwindolf/liferea/assets/110642/da0bd06d-7222-4eab-9ccf-2cbdbcbe1ec4


