### PR TITLE
Gitignore: Ignore flatpak build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ src/tests/social
 xslt/*.xml
 org.gnome.liferea.gschema.valid
 stamp-h1
+.flatpak-builder


### PR DESCRIPTION
After opening liferea with GNOME builder, a folder `.flatpak-builder` is being created. It contains the following folders:
```
build
cache
ccache
checksums
downloads
rofiles
```
All of that looks like it is not useful to be kept or even checked in.