### PR TITLE
Check for 304 status before 0 length data #1285

### DIFF
--- a/src/subscription.c
+++ b/src/subscription.c
@@ -189,7 +189,10 @@ subscription_process_update_result (const struct updateResult * const result, gp
   }
 
 	/* consider everything that prevents processing the data we got */
-	if (result->httpstatus >= 400 || !result->data) {
+	if (304 == result->httpstatus) {
+		node->available = TRUE;
+		statusbar = g_strdup_printf (_("\"%s\" has not changed since last update"), node_get_title(node));
+	} else if (result->httpstatus >= 400 || !result->data) {
 		/* Default */
 		subscription->error = FETCH_ERROR_NET;
 		node->available = FALSE;
@@ -203,9 +206,6 @@ subscription_process_update_result (const struct updateResult * const result, gp
 			subscription_set_discontinued (subscription, TRUE);
 			statusbar = g_strdup_printf (_("\"%s\" is discontinued. Liferea won't updated it anymore!"), node_get_title (node));
 		}
-	} else if (304 == result->httpstatus) {
-		node->available = TRUE;
-		statusbar = g_strdup_printf (_("\"%s\" has not changed since last update"), node_get_title(node));
 	} else if (result->filterErrors) {
 		node->available = FALSE;
 		subscription->error = FETCH_ERROR_NET;


### PR DESCRIPTION
When a subscription is requested to update, and it hasn't updated since the last time in the current liferea session,
and the status is 304, liferea was setting the subscription into the error state.

Check for 304 status before checking for no data.