### PR TITLE
Fix two license claims

### DIFF
--- a/plugins/add-bookmark-site.py
+++ b/plugins/add-bookmark-site.py
@@ -1,25 +1,24 @@
 #!/usr/bin/python3
 # vim:fileencoding=utf-8:sw=4:et
-#
-# Add social bookmark site
-#
-# Copyright (C) 2022  Lars Windolf <lars.windolf@gmx.de>
-#
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Library General Public
-# License as published by the Free Software Foundation; either
-# version 3 of the License, or (at your option) any later version.
-#
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Library General Public License for more details.
-#
-# You should have received a copy of the GNU Library General Public License
-# along with this library; see the file COPYING.LIB.  If not, write to
-# the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
-#
+
+"""
+Add social bookmark site
+
+Copyright (C) 2022 Lars Windolf <lars.windolf@gmx.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
 
 import os
 from pathlib import Path

--- a/src/tests/ui-test.py
+++ b/src/tests/ui-test.py
@@ -6,20 +6,19 @@
 # Copyright (c) 2021 Johannes Schauer Marin Rodrigues <josch@mister-muffin.de>
 # Copyright (c) 2023 Paul Gevers <elbrus@debian.org>
 
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Library General Public
-# License as published by the Free Software Foundation; either
+# This program is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation, either
 # version 2 of the License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# Library General Public License for more details.
+# General Public License for more details.
 #
-# You should have received a copy of the GNU Library General Public License
-# along with this library; see the file COPYING.LIB.  If not, write to
-# the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 02111-1307, USA.
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 import atexit


### PR DESCRIPTION
While trying to package 1.15.1 for Debian I noticed 

1) The license claim of plugins/add-bookmark-site.py had similar problems as #950, I propose to bring it in line with the other plugins
2) The header of src/tests/ui-test.py didn't reflect what josch and I intended, as can be seen in the comments of #1227, the license is supposed to be GPL2+, not LGPL2+.