### PR TITLE
src/node_type.h: add `#include <libxml/tree.h>` for `xmlNodePtr` type

### DIFF
--- a/src/node_type.h
+++ b/src/node_type.h
@@ -23,6 +23,7 @@
 
 #include "node.h"
 
+#include <libxml/tree.h>
 #include <libxml/xmlmemory.h>
 #include <gtk/gtk.h>
 


### PR DESCRIPTION
Without the change build fails on `libxml2-2.12.3` as:

    ../../src/node_type.h:62:64: error: unknown type name 'xmlNodePtr'; did you mean 'nodePtr'?
       62 |         void            (*export)               (nodePtr node, xmlNodePtr cur, gboolean trusted);
          |                                                                ^~~~~~~~~~
          |                                                                nodePtr