### PR TITLE
ci: Validate using appstreamcli

### DIFF
--- a/.github/workflows/cb.yml
+++ b/.github/workflows/cb.yml
@@ -26,7 +26,7 @@ jobs:
 
     - run: |
        apt-get update -qq
-       apt-get install -y -qq libxml2-dev libxslt1-dev libsqlite3-dev libwebkit2gtk-4.1-dev libjson-glib-dev libgirepository1.0-dev libpeas-dev gsettings-desktop-schemas-dev python3 libtool intltool valgrind libfribidi-dev gla11y appstream-util desktop-file-utils
+       apt-get install -y -qq libxml2-dev libxslt1-dev libsqlite3-dev libwebkit2gtk-4.1-dev libjson-glib-dev libgirepository1.0-dev libpeas-dev gsettings-desktop-schemas-dev python3 libtool intltool valgrind libfribidi-dev gla11y appstream desktop-file-utils
        mkdir inst
 
     - run: |
@@ -40,4 +40,4 @@ jobs:
     - run: ls -l /usr/share/glib-2.0/schemas
     - run: cd src/tests && make test
     - run: desktop-file-validate net.sourceforge.liferea.desktop
-    - run: appstream-util validate net.sourceforge.liferea.appdata.xml
+    - run: appstreamcli validate net.sourceforge.liferea.appdata.xml

--- a/net.sourceforge.liferea.appdata.xml.in
+++ b/net.sourceforge.liferea.appdata.xml.in
@@ -76,6 +76,10 @@
   <url type="translate">https://github.com/lwindolf/liferea?tab=readme-ov-file#new-translations</url>
   <translation type="gettext">liferea</translation>
   <content_rating type="oars-1.1"/>
+  <branding>
+    <color type="primary" scheme_preference="light">#CBCFD3</color>
+    <color type="primary" scheme_preference="dark">#64647D</color>
+  </branding>
   <releases>
     <release date="2023-12-24" version="1.15.5">
       <description>

--- a/net.sourceforge.liferea.appdata.xml.in
+++ b/net.sourceforge.liferea.appdata.xml.in
@@ -9,7 +9,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>Liferea</name>
-  <developer_name>Lars Windolf</developer_name>
+  <developer id="de.lzone">
+    <name>Lars Windolf</name>
+  </developer>
   <update_contact>lars.windolf_at_gmx.de</update_contact>
   <summary>Keep up with your feeds</summary>
   <description>


### PR DESCRIPTION
appstream-util is deprecated since 2020 and Flathub started using the newer appstreamcli tool to validate since 2 weeks ago.

So this can be finally switched.