### PR TITLE
Add libxml2 2.14 support to parse RSS test

### DIFF
--- a/src/tests/parse_rss.c
+++ b/src/tests/parse_rss.c
@@ -20,6 +20,7 @@
 
 #include <glib.h>
 #include <string.h>
+#include <libxml/xmlversion.h>
 
 #include "debug.h"
 #include "node_providers/feed.h"
@@ -41,7 +42,15 @@ gchar *tc_rss_feed1[] = {
 	"<rss version=\"2.0\"><channel><title>T</title><link>http://localhost</link><item><title>i1</title><link>http://localhost/item1.html</link><description>D</description></item><item><title>i2</title><link>https://localhost/item2.html</link></item></channel></rss>",
 	"true",
 	"2",
-	"{\"id\":0,\"title\":\"i1\",\"description\":\"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\"><p>D</p></div>\",\"source\":\"http://localhost/item1.html\",\"readStatus\":false,\"updateStatus\":false,\"flagStatus\":false,\"time\":1678397817,\"validTime\":false,\"validGuid\":false,\"hasEnclosure\":false,\"sourceId\":null,\"nodeId\":null,\"parentNodeId\":null,\"metadata\":[],\"enclosures\":[]}",
+	"{\"id\":0,\"title\":\"i1\",\"description\":\"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\">"
+#if LIBXML_VERSION < 21400
+	"<p>"
+#endif
+	"D"
+#if LIBXML_VERSION < 21400
+	"</p>"
+#endif
+	"</div>\",\"source\":\"http://localhost/item1.html\",\"readStatus\":false,\"updateStatus\":false,\"flagStatus\":false,\"time\":1678397817,\"validTime\":false,\"validGuid\":false,\"hasEnclosure\":false,\"sourceId\":null,\"nodeId\":null,\"parentNodeId\":null,\"metadata\":[],\"enclosures\":[]}",
 	"{\"id\":0,\"title\":\"i2\",\"description\":null,\"source\":\"https://localhost/item2.html\",\"readStatus\":false,\"updateStatus\":false,\"flagStatus\":false,\"time\":1678397817,\"validTime\":false,\"validGuid\":false,\"hasEnclosure\":false,\"sourceId\":null,\"nodeId\":null,\"parentNodeId\":null,\"metadata\":[],\"enclosures\":[]}",
 	NULL
 };


### PR DESCRIPTION
- libxml2 removed implied `<p>` tags https://gitlab.gnome.org/GNOME/libxml2/-/commit/8cf6129bbd836e666e7eda8c9e61c00387ae388b.
- Only add `<p>` tags for libxml2 versions before 2.14 (< 21400).
- Related https://github.com/lwindolf/liferea/issues/1448.