### PR TITLE
Fixes missing icon in headerbar plugin for mark all as read 

### DIFF
--- a/plugins/headerbar.py
+++ b/plugins/headerbar.py
@@ -82,7 +82,7 @@ class HeaderBarPlugin(GObject.Object, Liferea.Activatable, Liferea.ShellActivata
         box.add(button)
 
         button = Gtk.Button()
-        icon = Gio.ThemedIcon(name="emblem-ok-symbolic")
+        icon = Gio.ThemedIcon(name="object-select-symbolic")
         image = Gtk.Image.new_from_gicon(icon, Gtk.IconSize.BUTTON)
         button.add(image)
         button.set_action_name("app.mark-selected-feed-as-read")


### PR DESCRIPTION
Uses alternative symbolic icon instead of one removed from default Gnome theme[1]

[1] https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/merge_requests/78