### PR TITLE
Fix requiring Liferea with girepository-2.0

### DIFF
--- a/plugins/download-manager.py
+++ b/plugins/download-manager.py
@@ -24,7 +24,6 @@ import os
 import time
 
 gi.require_version('Gtk', '4.0')
-gi.require_version('Liferea', '3.0')
 
 from gi.repository import GObject, GLib, Gtk, Gio, Liferea, Pango
 from urllib.parse import urlparse

--- a/plugins/gnome-keyring.py
+++ b/plugins/gnome-keyring.py
@@ -19,7 +19,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import gi
-gi.require_version('Liferea', '3.0')
 gi.require_version('Secret', '1')
 from gi.repository import GObject, Liferea, Secret
 

--- a/src/plugins/plugins_engine.c
+++ b/src/plugins/plugins_engine.c
@@ -112,8 +112,7 @@ liferea_plugins_engine_init (LifereaPluginsEngine *plugins)
 		error = NULL;
 	}
 #else
-	g_autoptr(GIRepository) repo = gi_repository_new ();
-	if (!gi_repository_require_private (repo,
+	if (!gi_repository_require_private (gi_repository_dup_default (),
 		typelib_dir, "Liferea", "3.0", 0, &error)) {
 		g_warning ("Could not load Liferea repository: %s", error->message);
 		g_error_free (error);


### PR DESCRIPTION
Remove erroneous gi.require_version() from certain plugins, which should already be loaded by gi_repository_require_private().

Use gi_repository_dup_default() instead of just calling gi_repository_new() and throwing it away immediately after. This ensures the plugins get the typelib already loaded when pygobject calls Repository.get_default().

Closes: https://github.com/lwindolf/liferea/issues/1458