### PR TITLE
Refactor item list to GtkListBox

### DIFF
--- a/resources/node.xml.in
+++ b/resources/node.xml.in
@@ -30,6 +30,11 @@
 		</header>
 
 		{{#if node.nodeSource}}
+			{{#compare node.nodeSource.type "==" "fl_dummy"}}
+				<div id="errors">
+					<p><_span>⛔ Unknown account type '{{node.nodeSource.type}}'! This can happen if you downgrade Liferea and this version does not support this account type yet or when support for this account type was dropped. You can 'Convert To Local Subscriptions' from the feed list context menu!</_span></p>
+				</div>
+			{{/compare}}
 			{{#with node.nodeSource}}
 				{{#compare loginState "==" 4}}
 					<div id="errors">

--- a/src/actions/item_actions.c
+++ b/src/actions/item_actions.c
@@ -187,6 +187,59 @@ on_next_unread_item_activate (GSimpleAction *menuitem, GVariant*parameter, gpoin
 	itemlist_select_next_unread ();	
 }
 
+static void
+item_actions_apply_sort (nodeViewSortType sort_column, gboolean sort_reversed)
+{
+	Node *node = feedlist_get_selected ();
+
+	if (!node)
+		return;
+
+	if (!node_set_sort_column (node, sort_column, sort_reversed))
+		return;
+
+	feedlist_schedule_save ();
+
+	/* Rebuild visible item list to apply changed ordering immediately. */
+	itemlist_unload ();
+	itemlist_load (node);
+}
+
+static void
+on_sort_items_by_time (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+{
+	item_actions_apply_sort (NODE_VIEW_SORT_BY_TIME, TRUE);
+}
+
+static void
+on_sort_items_by_title (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+{
+	item_actions_apply_sort (NODE_VIEW_SORT_BY_TITLE, FALSE);
+}
+
+static void
+on_sort_items_by_source (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+{
+	item_actions_apply_sort (NODE_VIEW_SORT_BY_PARENT, FALSE);
+}
+
+static void
+on_sort_items_by_state (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+{
+	item_actions_apply_sort (NODE_VIEW_SORT_BY_STATE, FALSE);
+}
+
+static void
+on_sort_items_reverse (GSimpleAction *action, GVariant *parameter, gpointer user_data)
+{
+	Node *node = feedlist_get_selected ();
+
+	if (!node)
+		return;
+
+	item_actions_apply_sort (node->sortColumn, !node->sortReversed);
+}
+
 static const GActionEntry gaction_entries[] = {
 	// menu actions
 	{"toggle-selected-item-read-status", on_toggle_unread_status, NULL, NULL, NULL},
@@ -205,7 +258,14 @@ static const GActionEntry gaction_entries[] = {
 	{"open-item-in-tab", on_launch_item_in_tab, "t", NULL, NULL},
 	{"open-item-in-browser", on_launch_item_in_browser, "t", NULL, NULL},
 	{"open-item-in-external-browser", on_launch_item_in_external_browser, "t", NULL, NULL},
-	{"email-the-author", email_the_author, "t", NULL, NULL}
+	{"email-the-author", email_the_author, "t", NULL, NULL},
+
+	/* item list sorting popup actions */
+	{"sort-items-by-time", on_sort_items_by_time, NULL, NULL, NULL},
+	{"sort-items-by-title", on_sort_items_by_title, NULL, NULL, NULL},
+	{"sort-items-by-source", on_sort_items_by_source, NULL, NULL, NULL},
+	{"sort-items-by-state", on_sort_items_by_state, NULL, NULL, NULL},
+	{"sort-items-reverse", on_sort_items_reverse, NULL, NULL, NULL}
 };
 
 static void

--- a/src/node_source.c
+++ b/src/node_source.c
@@ -698,15 +698,18 @@ node_source_convert_to_local (Node *node)
 void
 node_source_to_json (Node *node, JsonBuilder *b)
 {
-	if (!(NODE_SOURCE_TYPE (node)->capabilities & NODE_SOURCE_CAPABILITY_CAN_LOGIN))
-		return;
-
 	json_builder_set_member_name (b, "nodeSource");
 	json_builder_begin_object (b);
 	json_builder_set_member_name (b, "title");
 	json_builder_add_string_value (b, node->source->root->title);
-	json_builder_set_member_name (b, "loginState");
-	json_builder_add_int_value (b, node->source->loginState);
+	json_builder_set_member_name (b, "type");
+	json_builder_add_string_value (b, node->source->type->id);
+
+	if (!(NODE_SOURCE_TYPE (node)->capabilities & NODE_SOURCE_CAPABILITY_CAN_LOGIN)) {
+		json_builder_set_member_name (b, "loginState");
+		json_builder_add_int_value (b, node->source->loginState);
+	}
+
 	json_builder_set_member_name (b, "actionQueueLength");
 	json_builder_add_int_value (b, g_queue_get_length (node->source->actionQueue));
 	json_builder_end_object (b);

--- a/src/node_sources/dummy_source.c
+++ b/src/node_sources/dummy_source.c
@@ -27,6 +27,10 @@ static void dummy_source_new (Node *node) {
 
 	// brrr... mutating the node is bad style
 	node->icon = (gpointer)icon_get (ICON_UNAVAILABLE);
+	node->source->loginState = NODE_SOURCE_STATE_AUTH_FAILED;
+
+	// special rendering to inform the user about the problem of the dummy source
+	// happens in resources/node.xml.in
 }
 
 static struct nodeSourceType nst = {
@@ -34,7 +38,7 @@ static struct nodeSourceType nst = {
 	.name			= "Dummy Feed List Source",
 	.source_type_init	= NULL,
 	.source_type_deinit	= NULL,
-	.source_new		= dummy_source_new,
+	.source_new		= dummy_source_new
 };
 
 nodeSourceTypePtr dummy_source_get_type(void) { return &nst; }

--- a/src/subscription.c
+++ b/src/subscription.c
@@ -381,7 +381,7 @@ subscription_auto_update (subscriptionPtr subscription, updateFlags flags)
 	gint	interval;
 	guint64	now;
 
-	if (!subscription)
+	if (!subscription || !subscription->type)
 		return;
 
 	interval = subscription_get_update_interval (subscription);

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -135,7 +135,10 @@ item_list_truncate_utf8 (const gchar *text, guint max_chars)
 		return g_strdup (text);
 
 	const gchar *end = g_utf8_offset_to_pointer (text, max_chars);
-	return g_strndup (text, end - text);
+	gchar *truncated = g_strndup (text, end - text);
+	gchar *result = g_strconcat (truncated, "...", NULL);
+	g_free (truncated);
+	return result;
 }
 
 static void
@@ -150,10 +153,14 @@ item_list_view_apply_row_visibility (ItemListView *ilv, ItemListRow *row)
 static void
 item_list_view_apply_row_layout (ItemListView *ilv, ItemListRow *row)
 {
+	GtkWidget *box = gtk_list_box_row_get_child (GTK_LIST_BOX_ROW (row->row));
+
 	if (ilv->wideView) {
 		gtk_image_set_icon_size (GTK_IMAGE (row->favicon_image), GTK_ICON_SIZE_LARGE);
 		gtk_widget_set_margin_start (row->favicon_image, 6);
 		gtk_widget_set_margin_end (row->favicon_image, 6);
+		gtk_widget_set_margin_top (box, 6);
+		gtk_widget_set_margin_bottom (box, 6);
 		gtk_label_set_wrap (GTK_LABEL (row->headline_label), TRUE);
 		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_WORD_CHAR);
 		gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_NONE);
@@ -165,6 +172,8 @@ item_list_view_apply_row_layout (ItemListView *ilv, ItemListRow *row)
 		gtk_image_set_icon_size (GTK_IMAGE (row->favicon_image), GTK_ICON_SIZE_NORMAL);
 		gtk_widget_set_margin_start (row->favicon_image, 0);
 		gtk_widget_set_margin_end (row->favicon_image, 0);
+		gtk_widget_set_margin_top (box, 2);
+		gtk_widget_set_margin_bottom (box, 2);
 		gtk_label_set_wrap (GTK_LABEL (row->headline_label), FALSE);
 		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_NONE);
 		gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_END);
@@ -493,8 +502,7 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 	}
 
 	if (ilv->wideView) {
-		const gchar *important = _(" <span background='red' color='white'> important </span> ");
-		const gchar *important_prefix = item->flagStatus ? important : "";
+		const gchar *important = item->flagStatus ? _(" <span background='red' color='white'> important </span> ") : "";
 		gchar *teaser = NULL;
 		gchar *teaser_markup = NULL;
 
@@ -509,11 +517,11 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 			title_limited_escaped);
 
 		preview_markup = g_strdup_printf (
-			"%s<span weight='%s'>%s%s</span><span size='smaller' weight='ultralight'> — %s</span>",
-			important_prefix,
+			"<span weight='%s'>%s%s</span>%s<span size='smaller' weight='ultralight'> — %s</span>",
 			item->readStatus ? "ultralight" : "light",
 			teaser_markup ? teaser_markup : "",
 			teaser_markup ? "..." : "",
+			important,
 			time_str_escaped);
 		g_free (teaser_markup);
 		g_free (teaser);
@@ -542,7 +550,7 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 	gtk_label_set_text (GTK_LABEL (row->date_label), time_str);
 
 	if (state_icon)
-		gtk_image_set_from_gicon (GTK_IMAGE (row->state_image), state_icon);
+		gtk_image_set_from_gicon (GTK_IMAGE (row->state_image), (GIcon *)state_icon);
 	else
 		gtk_image_clear (GTK_IMAGE (row->state_image));
 
@@ -732,25 +740,24 @@ item_list_view_widget_is_descendant (GtkWidget *widget, GtkWidget *ancestor)
 	return FALSE;
 }
 
-static gboolean
+static void
 on_item_list_view_pressed_event (GtkGestureClick *gesture, guint n_press, gdouble x, gdouble y, gpointer user_data)
 {
 	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
 	GtkListBoxRow *row = gtk_list_box_get_row_at_y (ilv->listbox, (int)y);
 	ItemListRow *item_row;
 	itemPtr item;
-	gboolean result = FALSE;
 
 	if (!row)
-		return FALSE;
+		return;
 
 	item_row = g_object_get_data (G_OBJECT (row), "item-list-row");
 	if (!item_row)
-		return FALSE;
+		return;
 
 	item = item_load (item_row->id);
 	if (!item)
-		return FALSE;
+		return;
 
 	if (n_press == 1) {
 		switch (gtk_gesture_single_get_current_button (GTK_GESTURE_SINGLE (gesture))) {
@@ -759,15 +766,14 @@ on_item_list_view_pressed_event (GtkGestureClick *gesture, guint n_press, gdoubl
 				if (picked &&
 				    (item_list_view_widget_is_descendant (picked, item_row->favicon_image) ||
 				     item_list_view_widget_is_descendant (picked, item_row->state_image))) {
+                                        gtk_gesture_set_state (GTK_GESTURE (gesture), GTK_EVENT_SEQUENCE_CLAIMED);
 					itemlist_toggle_flag (item);
-					result = TRUE;
 				}
 				break;
 			}
 			case GDK_BUTTON_MIDDLE:
 				gtk_gesture_set_state (GTK_GESTURE (gesture), GTK_EVENT_SEQUENCE_CLAIMED);
 				itemlist_toggle_read_status (item);
-				result = TRUE;
 				break;
 			case GDK_BUTTON_SECONDARY: {
 				GMenu *menu = item_list_view_popup_menu (ilv, item);
@@ -782,14 +788,12 @@ on_item_list_view_pressed_event (GtkGestureClick *gesture, guint n_press, gdoubl
 				gtk_popover_set_pointing_to (GTK_POPOVER (popover), &rect);
 				gtk_popover_popup (GTK_POPOVER (popover));
 				g_object_unref (menu);
-				result = TRUE;
 				break;
 			}
 		}
 	}
 
 	item_unload (item);
-	return result;
 }
 
 static void
@@ -890,8 +894,6 @@ item_list_view_create_row (ItemListView *ilv, itemPtr item, Node *node)
 
 	gtk_widget_set_margin_start (box, 6);
 	gtk_widget_set_margin_end (box, 6);
-	gtk_widget_set_margin_top (row->row, 3);
-	gtk_widget_set_margin_bottom (row->row, 3);
 
 	gtk_list_box_row_set_child (GTK_LIST_BOX_ROW (row->row), box);
 	g_object_set_data (G_OBJECT (row->row), "item-list-row", row);
@@ -979,7 +981,6 @@ item_list_view_create (FeedList *feedlist, ItemList *itemlist)
 	ilv->ilscrolledwindow = gtk_scrolled_window_new ();
 	gtk_widget_set_vexpand (ilv->ilscrolledwindow, TRUE);
 	g_object_ref_sink (ilv->ilscrolledwindow);
-	gtk_widget_show (ilv->ilscrolledwindow);
 
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (ilv->ilscrolledwindow), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 
@@ -989,7 +990,6 @@ item_list_view_create (FeedList *feedlist, ItemList *itemlist)
 	gtk_list_box_set_sort_func (ilv->listbox, item_list_view_sort_func, ilv, NULL);
 	gtk_list_box_set_show_separators (ilv->listbox, FALSE);
 	gtk_scrolled_window_set_child (GTK_SCROLLED_WINDOW (ilv->ilscrolledwindow), GTK_WIDGET (ilv->listbox));
-	gtk_widget_show (GTK_WIDGET (ilv->listbox));
 	gtk_widget_set_name (GTK_WIDGET (ilv->listbox), "itemlist");
 
 	g_signal_connect (G_OBJECT (ilv->listbox), "selected-rows-changed", G_CALLBACK (on_itemlist_selection_changed), ilv);

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -1,5 +1,5 @@
 /*
- * @file item_list_view.c  presenting items in a GtkTreeView
+ * @file item_list_view.c  presenting items in a GtkListBox
  *
  * Copyright (C) 2004-2026 Lars Windolf <lars.windolf@gmx.de>
  * Copyright (C) 2004-2006 Nathan J. Conrad <t98502@users.sourceforge.net>
@@ -31,7 +31,6 @@
 
 #include "browser.h"
 #include "common.h"
-#include "conf.h"
 #include "date.h"
 #include "debug.h"
 #include "node_providers/feed.h"
@@ -45,35 +44,19 @@
 #include "ui/browser_tabs.h"
 #include "ui/icons.h"
 #include "ui/liferea_shell.h"
-#include "ui/ui_common.h"
 
-/*
- * Important performance considerations: Early versions had performance problems
- * with the item list loading because of the following two problems:
- *
- * 1.) Mass-adding items to a sorting enabled tree store.
- * 2.) Mass-loading items to an attached tree store.
- *
- * To avoid both problems we merge against a visible tree store only for single
- * items that are added/removed by background updates and load complete feeds or
- * collections of feeds only by adding items to a new unattached tree store.
- */
-
-/* Enumeration of the columns in the itemstore. */
-enum is_columns {
-	IS_TIME,		/*<< Time of item creation */
-	IS_TIME_STR,		/*<< Time of item creation as a string*/
-	IS_LABEL,		/*<< Displayed name */
-	IS_STATEICON,		/*<< Pixbuf reference to the item's state icon */
-	IS_NR,			/*<< Item id, to lookup item ptr from parent feed */
-	IS_PARENT,		/*<< Parent node pointer */
-	IS_FAVICON,		/*<< Pixbuf reference to the item's feed's icon */
-	IS_SOURCE,		/*<< Source node pointer */
-	IS_STATE,		/*<< Original item state (unread, flagged...) for sorting */
-	ITEMSTORE_WEIGHT,	/*<< Flag whether weight is to be bold and "unread" icon is to be shown */
-	ITEMSTORE_ALIGN,        /*<< How to align title (RTL support) */
-	ITEMSTORE_LEN		/*<< Number of columns in the itemstore */
-};
+typedef struct {
+	gulong		id;
+	guint64		time;
+	gchar		*sort_label;
+	guint		state;
+	GtkWidget	*row;
+	GtkWidget	*state_image;
+	GtkWidget	*favicon_image;
+	GtkWidget	*headline_label;
+	GtkWidget	*date_label;
+	Node		*source;
+} ItemListRow;
 
 struct _ItemListView {
 	GObject		parentInstance;
@@ -83,18 +66,17 @@ struct _ItemListView {
 	GtkGesture	*popup_gesture;
 	GtkGesture	*middle_gesture;
 
-	GtkTreeView	*treeview;
+	GtkListBox	*listbox;
 	GtkWidget 	*ilscrolledwindow;	/*<< The complete ItemListView widget */
 	GSList		*item_ids;		/*<< list of all currently known item ids */
+	GHashTable	*rows_by_id;		/*<< gulong id -> ItemListRow* */
 
-	gboolean	batch_mode;		/*<< TRUE if we are in batch adding mode */
-	GtkTreeStore	*batch_itemstore;	/*<< GtkTreeStore prepared unattached and to be set on update() */
+	gboolean	batch_mode;
+	gboolean	wideView;
+	gboolean	favicon_enabled;
 
-	GHashTable	*columns;               /*<< Named GtkTreeViewColumns */
-	GtkCellRenderer *faviconRenderer;	/*<< Renderer for the favicon column */
-	GtkCellRenderer *headlineRenderer;	/*<< Renderer for the headline column */
-
-	gboolean	wideView;		/*<< TRUE for wide view mode */
+	nodeViewSortType	sort_type;
+	gboolean	sort_reversed;
 };
 
 enum {
@@ -112,36 +94,146 @@ static guint item_list_view_signals[LAST_SIGNAL] = { 0 };
 G_DEFINE_TYPE (ItemListView, item_list_view, G_TYPE_OBJECT);
 
 static void
-item_list_view_finalize (GObject *object)
+item_list_row_free (ItemListRow *row)
 {
-	ItemListView *ilv = ITEM_LIST_VIEW (object);
+	g_free (row->sort_label);
+	g_free (row);
+}
 
-	/* Disconnect the treeview signals to avoid spurious calls during teardown */
-	g_signal_handlers_disconnect_by_data (G_OBJECT (ilv->treeview), object);
+static ItemListRow *
+item_list_view_id_to_row (ItemListView *ilv, gulong id)
+{
+	return g_hash_table_lookup (ilv->rows_by_id, GUINT_TO_POINTER (id));
+}
 
-	g_hash_table_destroy (ilv->columns);
+static gfloat
+item_list_title_alignment (gchar *title)
+{
+	if (!title || strlen (title) == 0)
+		return 0.;
 
-	g_slist_free (ilv->item_ids);
-	if (ilv->batch_itemstore)
-		g_object_unref (ilv->batch_itemstore);
-	if (ilv->ilscrolledwindow)
-		g_object_unref (ilv->ilscrolledwindow);
-
-	g_object_unref (ilv->gesture);
-	g_object_unref (ilv->popup_gesture);
-	g_object_unref (ilv->middle_gesture);
+	int txt_direction = common_find_base_dir (title, -1);
+	int app_direction = gtk_widget_get_default_direction ();
+	if ((txt_direction == PANGO_DIRECTION_LTR &&
+	     app_direction == GTK_TEXT_DIR_LTR) ||
+	    (txt_direction == PANGO_DIRECTION_RTL &&
+	     app_direction == GTK_TEXT_DIR_RTL))
+		return 0.;
+	else
+		return 1.;
 }
 
 static void
-item_list_view_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
+item_list_view_apply_row_visibility (ItemListView *ilv, ItemListRow *row)
 {
-        ItemListView *ilv = ITEM_LIST_VIEW (object);
+	gtk_widget_set_visible (row->favicon_image, ilv->favicon_enabled);
+	gtk_widget_set_visible (row->date_label, !ilv->wideView);
+	gtk_widget_set_visible (row->state_image, !ilv->wideView || !ilv->favicon_enabled);
+}
 
-        switch (prop_id) {
-	        case PROP_WIDE_VIEW:
-			g_value_set_boolean (value, ilv->wideView);
+static void
+item_list_view_apply_row_layout (ItemListView *ilv, ItemListRow *row)
+{
+	if (ilv->wideView) {
+		gtk_image_set_icon_size (GTK_IMAGE (row->favicon_image), GTK_ICON_SIZE_LARGE);
+		gtk_widget_set_margin_start (row->favicon_image, 6);
+		gtk_label_set_wrap (GTK_LABEL (row->headline_label), TRUE);
+		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_WORD);
+		gtk_label_set_max_width_chars (GTK_LABEL (row->headline_label), -1);
+	} else {
+		gtk_image_set_icon_size (GTK_IMAGE (row->favicon_image), GTK_ICON_SIZE_NORMAL);
+		gtk_widget_set_margin_start (row->favicon_image, 0);
+		gtk_label_set_wrap (GTK_LABEL (row->headline_label), FALSE);
+		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_NONE);
+		gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_END);
+	}
+
+	item_list_view_apply_row_visibility (ilv, row);
+}
+
+static void
+item_list_view_for_each_row (ItemListView *ilv, GFunc func, gpointer user_data)
+{
+	for (GtkWidget *child = gtk_widget_get_first_child (GTK_WIDGET (ilv->listbox));
+	     child;
+	     child = gtk_widget_get_next_sibling (child)) {
+		func (g_object_get_data (G_OBJECT (child), "item-list-row"), user_data);
+	}
+}
+
+static void
+item_list_view_update_wide_mode_cb (gpointer data, gpointer user_data)
+{
+	ItemListRow *row = data;
+	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
+	item_list_view_apply_row_layout (ilv, row);
+}
+
+static nodeViewSortType
+item_list_view_effective_sort_type (ItemListView *ilv)
+{
+	if (ilv->sort_type == NODE_VIEW_SORT_BY_TITLE && ilv->wideView)
+		return NODE_VIEW_SORT_BY_TIME;
+
+	return ilv->sort_type;
+}
+
+static gint
+item_list_view_cmp_rows (ItemListView *ilv, ItemListRow *a, ItemListRow *b)
+{
+	nodeViewSortType sort_type = item_list_view_effective_sort_type (ilv);
+	gint cmp = 0;
+
+	switch (sort_type) {
+		case NODE_VIEW_SORT_BY_TITLE:
+			cmp = g_strcmp0 (a->sort_label, b->sort_label);
+			break;
+		case NODE_VIEW_SORT_BY_PARENT:
+			if (!a->source || !a->source->id || !b->source || !b->source->id)
+				cmp = 0;
+			else
+				cmp = strcmp (a->source->id, b->source->id);
+			break;
+		case NODE_VIEW_SORT_BY_STATE:
+			cmp = (gint)a->state - (gint)b->state;
+			break;
+		case NODE_VIEW_SORT_BY_TIME:
+		default:
+			if (a->time > b->time)
+				cmp = -1;
+			else if (a->time < b->time)
+				cmp = 1;
+			else
+				cmp = 0;
 			break;
 	}
+
+	if (cmp == 0) {
+		if (a->time > b->time)
+			cmp = -1;
+		else if (a->time < b->time)
+			cmp = 1;
+		else
+			cmp = (a->id < b->id) ? -1 : (a->id > b->id ? 1 : 0);
+	}
+
+	if (ilv->sort_reversed)
+		cmp = -cmp;
+
+	return cmp;
+}
+
+static gint
+item_list_view_sort_func (GtkListBoxRow *row_a, GtkListBoxRow *row_b, gpointer user_data)
+{
+	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
+	ItemListRow *a = g_object_get_data (G_OBJECT (row_a), "item-list-row");
+	ItemListRow *b = g_object_get_data (G_OBJECT (row_b), "item-list-row");
+
+	if (!a || !b)
+		return 0;
+
+	return item_list_view_cmp_rows (ilv, a, b);
 }
 
 static void
@@ -150,55 +242,52 @@ item_list_view_set_property (GObject *object, guint prop_id, const GValue *value
 	ItemListView *ilv = ITEM_LIST_VIEW (object);
 
 	switch (prop_id) {
-	        case PROP_WIDE_VIEW:
+		case PROP_WIDE_VIEW:
 			ilv->wideView = g_value_get_boolean (value);
-
-			GtkTreeViewColumn *state = g_hash_table_lookup (ilv->columns, "state");
-			GtkTreeViewColumn *date = g_hash_table_lookup (ilv->columns, "date");
-			GtkTreeViewColumn *favicon = g_hash_table_lookup (ilv->columns, "favicon");
-			GtkTreeViewColumn *headline = g_hash_table_lookup (ilv->columns, "headline");
-
-			gtk_tree_view_column_set_visible (state, !ilv->wideView);
-			gtk_tree_view_column_set_visible (date, !ilv->wideView);
-			gtk_tree_view_column_clear_attributes (headline, ilv->headlineRenderer);
-			gtk_tree_view_column_add_attribute (headline, ilv->headlineRenderer, "markup", IS_LABEL);
-			gtk_tree_view_column_add_attribute (headline, ilv->headlineRenderer, "xalign", ITEMSTORE_ALIGN);
-			gtk_tree_view_column_add_attribute (headline, ilv->headlineRenderer, "weight", ITEMSTORE_WEIGHT);
-
-			if (ilv->wideView) {				
-				gtk_tree_view_set_grid_lines (ilv->treeview, GTK_TREE_VIEW_GRID_LINES_HORIZONTAL);
-				gtk_tree_view_column_set_sizing (state, GTK_TREE_VIEW_COLUMN_FIXED);
-				gtk_tree_view_column_set_sizing (date, GTK_TREE_VIEW_COLUMN_FIXED);
-				gtk_tree_view_column_set_sizing (favicon, GTK_TREE_VIEW_COLUMN_FIXED);
-				gtk_tree_view_column_set_sizing (headline, GTK_TREE_VIEW_COLUMN_FIXED);
-
-				gtk_tree_view_column_set_sort_column_id (headline, IS_TIME);
-
-				g_object_set (ilv->faviconRenderer, "icon-size", GTK_ICON_SIZE_LARGE, NULL);
-				g_object_set (ilv->faviconRenderer, "xpad", 6, NULL);
-				g_object_set (ilv->headlineRenderer, "ellipsize", PANGO_ELLIPSIZE_NONE, NULL);
-				g_object_set (ilv->headlineRenderer, "wrap-mode", PANGO_WRAP_WORD, NULL);
-				g_object_set (ilv->headlineRenderer, "wrap-width", 300, NULL);
-				g_object_set (ilv->headlineRenderer, "ypad", 6, NULL);
-			} else {
-				
-				gtk_tree_view_set_grid_lines (ilv->treeview, GTK_TREE_VIEW_GRID_LINES_NONE);
-				gtk_tree_view_column_set_sizing (date, GTK_TREE_VIEW_COLUMN_GROW_ONLY);
-				gtk_tree_view_column_set_sizing (headline, GTK_TREE_VIEW_COLUMN_GROW_ONLY);
-
-				gtk_tree_view_column_set_sort_column_id (headline, IS_LABEL);
-
-				g_object_set (ilv->faviconRenderer, "icon-size", GTK_ICON_SIZE_NORMAL, NULL);
-				g_object_set (ilv->faviconRenderer, "xpad", 0, NULL);
-				g_object_set (ilv->headlineRenderer, "ellipsize", PANGO_ELLIPSIZE_END, NULL);
-				g_object_set (ilv->headlineRenderer, "wrap-mode", PANGO_WRAP_NONE, NULL);
-				g_object_set (ilv->headlineRenderer, "ypad", 0, NULL);
-			}
-
-			gtk_tree_view_set_fixed_height_mode (ilv->treeview, ilv->wideView);
-
+			gtk_list_box_set_show_separators (ilv->listbox, ilv->wideView);
+			item_list_view_for_each_row (ilv, item_list_view_update_wide_mode_cb, ilv);
+			gtk_list_box_invalidate_sort (ilv->listbox);
+			break;
+		default:
+			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 			break;
 	}
+}
+
+static void
+item_list_view_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
+{
+	ItemListView *ilv = ITEM_LIST_VIEW (object);
+
+	switch (prop_id) {
+		case PROP_WIDE_VIEW:
+			g_value_set_boolean (value, ilv->wideView);
+			break;
+		default:
+			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+			break;
+	}
+}
+
+static void
+item_list_view_finalize (GObject *object)
+{
+	ItemListView *ilv = ITEM_LIST_VIEW (object);
+
+	g_signal_handlers_disconnect_by_data (G_OBJECT (ilv->listbox), object);
+
+	g_hash_table_destroy (ilv->rows_by_id);
+	g_slist_free (ilv->item_ids);
+
+	if (ilv->ilscrolledwindow)
+		g_object_unref (ilv->ilscrolledwindow);
+
+	g_object_unref (ilv->gesture);
+	g_object_unref (ilv->popup_gesture);
+	g_object_unref (ilv->middle_gesture);
+	g_object_unref (ilv->keypress);
+
+	G_OBJECT_CLASS (item_list_view_parent_class)->finalize (object);
 }
 
 static void
@@ -223,329 +312,105 @@ item_list_view_class_init (ItemListViewClass *klass)
 		G_TYPE_INT);
 
 	g_object_class_install_property (object_class,
-		                         PROP_WIDE_VIEW,
-		                         g_param_spec_boolean ("wide-view",
-		                                               "Wide View",
-		                                               "TRUE if wide mode rendering with more text and less columns is used",
-		                                               FALSE,
-		                                               G_PARAM_READWRITE));
+					 PROP_WIDE_VIEW,
+					 g_param_spec_boolean ("wide-view",
+					                       "Wide View",
+					                       "TRUE if wide mode rendering with more text and less columns is used",
+					                       FALSE,
+					                       G_PARAM_READWRITE));
 }
 
-/* helper functions for item <-> iter conversion */
-
-static gulong
-item_list_view_iter_to_id (ItemListView *ilv, GtkTreeIter *iter)
+static void
+item_list_view_clear_rows (ItemListView *ilv)
 {
-	gulong	id = 0;
+	GtkListBoxRow *selected = gtk_list_box_get_selected_row (ilv->listbox);
+	if (selected)
+		gtk_list_box_unselect_row (ilv->listbox, selected);
 
-	gtk_tree_model_get (gtk_tree_view_get_model (ilv->treeview), iter, IS_NR, &id, -1);
-	return id;
-}
-
-gboolean
-item_list_view_contains_id (ItemListView *ilv, gulong id)
-{
-	return (NULL != g_slist_find (ilv->item_ids, GUINT_TO_POINTER (id)));
-}
-
-static gboolean
-item_list_view_id_to_iter (ItemListView *ilv, gulong id, GtkTreeIter *iter)
-{
-	gboolean        valid;
-	GtkTreeIter		old_iter;
-	GtkTreeModel    *model;
-
-	/* Problem here is batch insertion using batch_itemstore
-	   so the item can be in the GtkTreeView attached store or
-	    in the batch_itemstore */
-
-	if (item_list_view_contains_id (ilv, id)) {
-		/* First search the tree view */
-		model = gtk_tree_view_get_model (ilv->treeview);
-		valid = gtk_tree_model_get_iter_first (model, &old_iter);
-		while (valid) {
-		        gulong current_id = item_list_view_iter_to_id (ilv, &old_iter);
-	                if(current_id == id) {
-				*iter = old_iter;
-	                        return TRUE;
-			}
-	                valid = gtk_tree_model_iter_next (model, &old_iter);
-		}
-
-		/* Next search the batch store */
-		model = GTK_TREE_MODEL (ilv->batch_itemstore);
-		valid = gtk_tree_model_get_iter_first (model, &old_iter);
-		while (valid) {
-			gulong current_id;
-			gtk_tree_model_get (model, &old_iter, IS_NR, &current_id, -1);
-	                if(current_id == id) {
-				*iter = old_iter;
-	                        return TRUE;
-			}
-	                valid = gtk_tree_model_iter_next (model, &old_iter);
-		}
+	GtkWidget *child = gtk_widget_get_first_child (GTK_WIDGET (ilv->listbox));
+	while (child) {
+		GtkWidget *next = gtk_widget_get_next_sibling (child);
+		gtk_list_box_remove (ilv->listbox, child);
+		child = next;
 	}
-	return FALSE;
+
+	g_hash_table_remove_all (ilv->rows_by_id);
 }
 
-static gint
-item_list_view_date_sort_func (GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, gpointer user_data)
+static void
+on_itemlist_selection_changed (GtkListBox *listbox, gpointer user_data)
 {
-	guint64	timea, timeb;
-	double	diff;
+	GtkListBoxRow *row = gtk_list_box_get_selected_row (listbox);
+	ItemListRow *item_row = row ? g_object_get_data (G_OBJECT (row), "item-list-row") : NULL;
+	gulong id = item_row ? item_row->id : 0;
 
-	gtk_tree_model_get (model, a, IS_TIME, &timea, -1);
-	gtk_tree_model_get (model, b, IS_TIME, &timeb, -1);
-	diff = difftime ((time_t)timeb, (time_t)timea);
-
-	if (diff < 0)
-		return 1;
-
-	if (diff > 0)
-		return -1;
-
-	return 0;
-}
-
-static gint
-item_list_view_favicon_sort_func (GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, gpointer user_data)
-{
-	Node	*node1, *node2;
-
-	gtk_tree_model_get (model, a, IS_SOURCE, &node1, -1);
-	gtk_tree_model_get (model, b, IS_SOURCE, &node2, -1);
-
-	if (!node1->id || !node2->id)
-		return 0;
-
-	return strcmp (node1->id, node2->id);
+	g_signal_emit_by_name (user_data, "selection-changed", id);
 }
 
 void
 item_list_view_set_sort_column (ItemListView *ilv, nodeViewSortType sortType, gboolean sortReversed)
 {
-	gint sortColumn;
-
-	switch (sortType) {
-		case NODE_VIEW_SORT_BY_TITLE:
-			/* Some ugly switching here, because in wide view
-			   we do sort headlines by date */
-			if (ilv->wideView)
-				sortColumn = IS_TIME;
-			else
-				sortColumn = IS_LABEL;
-			break;
-		case NODE_VIEW_SORT_BY_PARENT:
-			sortColumn = IS_SOURCE;
-			break;
-		case NODE_VIEW_SORT_BY_STATE:
-			sortColumn = IS_STATE;
-			break;
-		case NODE_VIEW_SORT_BY_TIME:
-		default:
-			sortColumn = IS_TIME;
-			break;
-	}
-
-	gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (gtk_tree_view_get_model (ilv->treeview)),
-	                                      sortColumn,
-	                                      sortReversed?GTK_SORT_DESCENDING:GTK_SORT_ASCENDING);
-}
-
-/*
- * Creates a GtkTreeStore to be filled with ui_itemlist_set_items
- * and to be set with ui_itemlist_set_tree_store().
- */
-static GtkTreeStore *
-item_list_view_create_tree_store (void)
-{
-	return gtk_tree_store_new (ITEMSTORE_LEN,
-	                    G_TYPE_INT64,	/* IS_TIME */
-	                    G_TYPE_STRING, 	/* IS_TIME_STR */
-	                    G_TYPE_STRING,	/* IS_LABEL */
-	                    G_TYPE_ICON,	/* IS_STATEICON */
-	                    G_TYPE_ULONG,	/* IS_NR */
-	                    G_TYPE_POINTER,	/* IS_PARENT */
-	                    G_TYPE_ICON,	/* IS_FAVICON */
-	                    G_TYPE_POINTER,	/* IS_SOURCE */
-	                    G_TYPE_UINT,	/* IS_STATE */
-			    G_TYPE_INT,		/* ITEMSTORE_WEIGHT */
-			    G_TYPE_FLOAT        /* ITEMSTORE_ALIGN */
-	);
-}
-
-static void
-on_itemlist_selection_changed (GtkTreeSelection *selection, gpointer user_data)
-{
-	GtkTreeIter 	iter;
-	GtkTreeModel	*model;
-	gulong		id = 0;
-
-	if (gtk_tree_selection_get_selected (selection, &model, &iter)) {
-		id = item_list_view_iter_to_id (ITEM_LIST_VIEW (user_data), &iter);
-		g_signal_emit_by_name (user_data, "selection-changed", id);
-	}
-}
-
-static void
-itemlist_sort_column_changed_cb (GtkTreeSortable *treesortable, gpointer user_data)
-{
-	gint		sortColumn, nodeSort;
-	GtkSortType	sortType;
-	gboolean	sorted, changed;
-
-	if (feedlist_get_selected () == NULL)
-		return;
-
-	sorted = gtk_tree_sortable_get_sort_column_id (treesortable, &sortColumn, &sortType);
-	if (!sorted)
-		return;
-
-	switch (sortColumn) {
-		case IS_TIME:
-		default:
-			nodeSort = NODE_VIEW_SORT_BY_TIME;
-			break;
-		case IS_LABEL:
-			nodeSort = NODE_VIEW_SORT_BY_TITLE;
-			break;
-		case IS_STATE:
-			nodeSort = NODE_VIEW_SORT_BY_STATE;
-			break;
-		case IS_PARENT:
-		case IS_SOURCE:
-			nodeSort = NODE_VIEW_SORT_BY_PARENT;
-			break;
-	}
-
-	changed = node_set_sort_column (feedlist_get_selected (), nodeSort, sortType == GTK_SORT_DESCENDING);
-	if (changed)
-		feedlist_schedule_save ();
-}
-
-/*
- * Sets a GtkTreeView to the active GtkTreeView.
- */
-static void
-item_list_view_set_tree_store (ItemListView *ilv, GtkTreeStore *itemstore)
-{
-	GtkTreeModel    	*model;
-	GtkTreeSelection	*select;
-
-	/* drop old tree store */
-	model = gtk_tree_view_get_model (ilv->treeview);
-	gtk_tree_view_set_model (ilv->treeview, NULL);
-	if (model)
-		g_object_unref (model);
-
-	gtk_tree_sortable_set_sort_func (GTK_TREE_SORTABLE (itemstore), IS_TIME, item_list_view_date_sort_func, NULL, NULL);
-	gtk_tree_sortable_set_sort_func (GTK_TREE_SORTABLE (itemstore), IS_SOURCE, item_list_view_favicon_sort_func, NULL, NULL);
-	g_signal_connect (G_OBJECT (itemstore), "sort-column-changed", G_CALLBACK (itemlist_sort_column_changed_cb), NULL);
-
-	gtk_tree_view_set_model (ilv->treeview, GTK_TREE_MODEL (itemstore));
-
-	/* Setup the selection handler */
-	select = gtk_tree_view_get_selection (ilv->treeview);
-	gtk_tree_selection_set_mode (select, GTK_SELECTION_SINGLE);
-	g_signal_connect (G_OBJECT (select), "changed", G_CALLBACK (on_itemlist_selection_changed), ilv);
+	ilv->sort_type = sortType;
+	ilv->sort_reversed = sortReversed;
+	gtk_list_box_invalidate_sort (ilv->listbox);
 }
 
 static void
 item_list_view_all_items_removed (GObject *obj, gpointer user_data)
 {
-	ItemListView	*ilv = ITEM_LIST_VIEW (user_data);
-	GtkTreeModel	*model;
-	GtkTreeSelection *select;
+	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
 
 	debug (DEBUG_CACHE, "item_list_view_all_items_removed()");
 
-	/* Unselect all items */
-	select = gtk_tree_view_get_selection (ilv->treeview);
-	gtk_tree_selection_unselect_all (select);
+	item_list_view_clear_rows (ilv);
 
-	/* Clear the item ids */
-	if (ilv->item_ids)
-		g_slist_free (ilv->item_ids);
+	g_slist_free (ilv->item_ids);
 	ilv->item_ids = NULL;
-
-	/* Clear the tree store */
-	model = gtk_tree_view_get_model (ilv->treeview);
-	gtk_tree_store_clear (GTK_TREE_STORE (model));
 }
 
 static void
 item_list_view_item_removed (GObject *obj, gulong id, gpointer user_data)
 {
-	ItemListView	*ilv = ITEM_LIST_VIEW (user_data);
-	GtkTreeIter	iter;
- 
-	if (item_list_view_id_to_iter (ilv, id, &iter)) {
-		GtkTreeModel *model = gtk_tree_view_get_model (ilv->treeview);
-		GtkTreePath *path = gtk_tree_model_get_path (model, &iter);
-		GtkTreeSelection *select = gtk_tree_view_get_selection (ilv->treeview);
-		GtkTreeIter selected;
-		gboolean removed_was_selected = gtk_tree_selection_get_selected (select, NULL, &selected)
-		                                && gtk_tree_store_iter_is_valid (GTK_TREE_STORE (model), &selected)
-		                                && gtk_tree_store_iter_is_valid (GTK_TREE_STORE (model), &iter)
-		                                && (item_list_view_iter_to_id (ilv, &selected) == id);
-         
-		g_assert (select);
-		g_assert (path);
-		if (removed_was_selected) {
-			GtkTreePath *next = gtk_tree_path_copy (path);
-			GtkTreeIter nextIter;
-			g_assert (next);
-			gtk_tree_path_next (next);
-			if (gtk_tree_model_get_iter (model, &nextIter, next))
-				gtk_tree_selection_select_iter (select, &nextIter);
-			else
-				gtk_tree_selection_unselect_all (select);
-			gtk_tree_path_free (next);
-		}
-         
-		gtk_tree_store_remove (GTK_TREE_STORE (model), &iter);
-		gtk_tree_path_free (path);
-	} else {
-        	debug (DEBUG_GUI, "item id %lu to be removed not found in item id list!", id);
+	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
+	ItemListRow *row = item_list_view_id_to_row (ilv, id);
+
+	if (!row) {
+		debug (DEBUG_GUI, "item id %lu to be removed not found in item id list!", id);
+		ilv->item_ids = g_slist_remove (ilv->item_ids, GUINT_TO_POINTER (id));
+		return;
 	}
+
+	GtkListBoxRow *selected = gtk_list_box_get_selected_row (ilv->listbox);
+	if (selected == GTK_LIST_BOX_ROW (row->row)) {
+		gint index = gtk_list_box_row_get_index (GTK_LIST_BOX_ROW (row->row));
+		GtkListBoxRow *next = gtk_list_box_get_row_at_index (ilv->listbox, index + 1);
+		if (!next && index > 0)
+			next = gtk_list_box_get_row_at_index (ilv->listbox, index - 1);
+		if (next)
+			gtk_list_box_select_row (ilv->listbox, next);
+		else
+			gtk_list_box_unselect_row (ilv->listbox, selected);
+	}
+
+	gtk_list_box_remove (ilv->listbox, row->row);
+	g_hash_table_remove (ilv->rows_by_id, GUINT_TO_POINTER (id));
 	ilv->item_ids = g_slist_remove (ilv->item_ids, GUINT_TO_POINTER (id));
 }
 
-/* cleans up the item list, sets up the iter hash when called for the first time */
 static void
 item_list_view_item_batch_started (GObject *obj, gpointer user_data)
 {
-	ItemListView		*ilv = ITEM_LIST_VIEW (user_data);
-	GtkAdjustment		*adj;
-	GtkTreeStore		*itemstore;
-	GtkTreeSelection	*select;
+	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
+	GtkAdjustment *adj;
 
-        itemstore = GTK_TREE_STORE (gtk_tree_view_get_model (ilv->treeview));
-
-	/* unselecting all items is important to remove items
-	   whose removal is deferred until unselecting */
-	select = gtk_tree_view_get_selection (ilv->treeview);
-	gtk_tree_selection_unselect_all (select);
-
-	adj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (ilv->treeview));
+	adj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (ilv->ilscrolledwindow));
 	gtk_adjustment_set_value (adj, 0.0);
-	gtk_scrollable_set_vadjustment (GTK_SCROLLABLE (ilv->treeview), adj);
 
-	/* Disconnect signal handler to be safe */
-	g_signal_handlers_disconnect_by_func (G_OBJECT (select), G_CALLBACK (on_itemlist_selection_changed), ilv);
-
-	if (itemstore)
-		gtk_tree_store_clear (itemstore);
-	if (ilv->item_ids)
-		g_slist_free (ilv->item_ids);
-
+	item_list_view_clear_rows (ilv);
+	g_slist_free (ilv->item_ids);
 	ilv->item_ids = NULL;
 
-	/* enable batch mode for following item adds */
 	ilv->batch_mode = TRUE;
-	ilv->batch_itemstore = item_list_view_create_tree_store ();
-
-	gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (ilv->batch_itemstore), NULL, NULL, NULL);
 }
 
 static void
@@ -555,39 +420,22 @@ item_list_view_item_batch_ended (GObject *obj, gpointer *n, gpointer user_data)
 	Node *node = (Node *)n;
 
 	g_assert (ilv->batch_mode);
-	item_list_view_set_tree_store (ilv, ilv->batch_itemstore);
+
 	item_list_view_set_sort_column (ilv, node->sortColumn, node->sortReversed);
 	ilv->batch_mode = FALSE;
 }
 
-static gfloat
-item_list_title_alignment (gchar *title)
-{
-	if (!title || strlen(title) == 0)
-		return 0.;
-
-	/* debug5 (DEBUG_HTML, "title ***%s*** first bytes %02hhx%02hhx%02hhx pango %d",
-		title, title[0], title[1], title[2], pango_find_base_dir (title, -1)); */
-	int txt_direction = common_find_base_dir (title, -1);
-  	int app_direction = gtk_widget_get_default_direction ();
-	if ((txt_direction == PANGO_DIRECTION_LTR &&
-	     app_direction == GTK_TEXT_DIR_LTR) ||
-	    (txt_direction == PANGO_DIRECTION_RTL &&
-	     app_direction == GTK_TEXT_DIR_RTL))
-		return 0.; /* same direction, regular ("left") alignment */
-	else
-		return 1.;
-}
-
 static void
-item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, GtkTreeIter *iter, Node *node)
+item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRow *row, Node *node)
 {
-	GtkTreeStore	*itemstore;
-	gchar		*title, *time_str, *tmp = NULL;
-	const GIcon	*state_icon;
-	gint		state = 0;
-	gboolean	noTitle = FALSE;
-        int fontWeight = PANGO_WEIGHT_BOLD;
+	gchar *plain_title;
+	gchar *escaped_title;
+	gchar *time_str;
+	gchar *title_markup;
+	gchar *tmp = NULL;
+	const GIcon *state_icon;
+	gint state = 0;
+	gboolean no_title = FALSE;
 
 	if (item->flagStatus)
 		state += 2;
@@ -596,87 +444,93 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, GtkTreeIte
 
 	time_str = (0 != item->time) ? date_format ((time_t)item->time, NULL) : g_strdup ("");
 
-	if(item->title && strlen (item->title)) {
-		title = item->title;
-		title = g_strstrip (g_markup_escape_text (title, -1));
+	if (item->title && strlen (item->title)) {
+		escaped_title = g_markup_escape_text (item->title, -1);
+		g_strstrip (escaped_title);
+		plain_title = g_strdup (escaped_title);
 	} else {
-		// when there is no title use the teaser
 		tmp = item_get_teaser (item);
-		title = g_strdup_printf("%s…", tmp);
+		plain_title = g_strdup_printf ("%s...", tmp ? tmp : "");
+		escaped_title = g_markup_escape_text (plain_title, -1);
 		g_free (tmp);
-		noTitle = TRUE;
+		no_title = TRUE;
 	}
 
 	if (ilv->wideView) {
 		const gchar *important = _(" <span background='red' color='white'> important </span> ");
 		gchar *teaser = NULL;
-		if(!noTitle)
-			teaser = item_get_teaser (item);
+		gchar *teaser_markup = NULL;
 
-		tmp = title;
-		title = g_strdup_printf ("<span weight='%s' size='larger'>%s</span>%s\n<span weight='%s'>%s%s</span><span size='smaller' weight='ultralight'> — %s</span>",
-		                         item->readStatus?"normal":"ultrabold",
-		                         title,
-		                         item->flagStatus?important:"",
-		                         item->readStatus?"ultralight":"light",
-		                         teaser?teaser:"",
-		                         teaser?"…":"",
-					 time_str);
-		g_free (tmp);
+		if (!no_title)
+			teaser = item_get_teaser (item);
+		if (teaser)
+			teaser_markup = g_markup_escape_text (teaser, -1);
+
+		title_markup = g_strdup_printf (
+			"<span weight='%s' size='larger'>%s</span>%s\n"
+			"<span weight='%s'>%s%s</span><span size='smaller' weight='ultralight'> - %s</span>",
+			item->readStatus ? "normal" : "bold",
+			escaped_title,
+			item->flagStatus ? important : "",
+			item->readStatus ? "ultralight" : "light",
+			teaser_markup ? teaser_markup : "",
+			teaser_markup ? "..." : "",
+			time_str);
+		g_free (teaser_markup);
 		g_free (teaser);
+	} else {
+		title_markup = g_strdup_printf ("<span weight='%s'>%s</span>",
+		                               item->readStatus ? "normal" : "bold",
+		                               escaped_title);
 	}
 
 	state_icon = item->flagStatus ? icon_get (ICON_FLAG) :
 	             !item->readStatus ? icon_get (ICON_UNREAD) :
-		     NULL;
+	             NULL;
 
-        if (item->readStatus)
-                fontWeight = item->isHidden ? PANGO_WEIGHT_ULTRALIGHT : PANGO_WEIGHT_NORMAL;
+	row->time = item->time;
+	row->state = state;
+	row->source = node ? node : row->source;
 
-	if (ilv->batch_mode)
-		itemstore = ilv->batch_itemstore;
+	g_free (row->sort_label);
+	row->sort_label = g_utf8_casefold (plain_title, -1);
+
+	gtk_label_set_markup (GTK_LABEL (row->headline_label), title_markup);
+	gtk_label_set_xalign (GTK_LABEL (row->headline_label), item_list_title_alignment (plain_title));
+	gtk_label_set_text (GTK_LABEL (row->date_label), time_str);
+
+	if (state_icon)
+		gtk_image_set_from_gicon (GTK_IMAGE (row->state_image), state_icon);
 	else
-		itemstore = GTK_TREE_STORE (gtk_tree_view_get_model (ilv->treeview));
+		gtk_image_clear (GTK_IMAGE (row->state_image));
 
-        if (NULL == node) {
-                gtk_tree_store_set (itemstore, iter,
-		            IS_LABEL, title,
-	                    IS_TIME, item->time,
-			    IS_TIME_STR, time_str,
-                            IS_NR, item->id,
-			    IS_STATEICON, state_icon,
-			    ITEMSTORE_ALIGN, item_list_title_alignment (title),
-		            IS_STATE, state,
-	                    ITEMSTORE_WEIGHT, fontWeight,
-			    -1);
-        } else {
-                gtk_tree_store_set (itemstore, iter,
-		            IS_LABEL, title,
-                            IS_TIME, item->time,
-			    IS_TIME_STR, time_str,
-                            IS_NR, item->id,
-			    IS_STATEICON, state_icon,
-                            IS_PARENT, node,
-                            IS_FAVICON, node_get_icon (node),
-                            IS_SOURCE, node,
-                            IS_STATE, state,
-	                    ITEMSTORE_WEIGHT, fontWeight,
-                            -1);
-        }
+	if (row->source)
+		gtk_image_set_from_gicon (GTK_IMAGE (row->favicon_image), node_get_icon (row->source));
+	else
+		gtk_image_clear (GTK_IMAGE (row->favicon_image));
 
+	item_list_view_apply_row_layout (ilv, row);
+
+	gtk_widget_set_tooltip_text (row->headline_label, plain_title);
+
+	g_free (title_markup);
+	g_free (escaped_title);
+	g_free (plain_title);
 	g_free (time_str);
-	g_free (title);
+
+	if (!ilv->batch_mode)
+		gtk_list_box_invalidate_sort (ilv->listbox);
 }
 
 void
 item_list_view_update_item (ItemListView *ilv, itemPtr item)
 {
-	GtkTreeIter	iter;
+	ItemListRow *row = item_list_view_id_to_row (ilv, item->id);
 
-	if (!item_list_view_id_to_iter (ilv, item->id, &iter))
+	if (!row)
 		return;
 
-        item_list_view_update_item_internal (ilv, item, &iter, NULL);
+	item_list_view_update_item_internal (ilv, item, row, NULL);
 }
 
 static void
@@ -690,28 +544,24 @@ item_list_view_item_updated (GObject *obj, gint itemId, gpointer user_data)
 static void
 item_list_view_update_all_items (GObject *obj, const gchar *nodeId, gpointer user_data)
 {
-	ItemListView	*ilv = ITEM_LIST_VIEW (user_data);
-        gboolean        valid;
-        GtkTreeIter     iter;
-        gulong          id;
-	GtkTreeModel    *model;
+	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
 
-	model = gtk_tree_view_get_model (ilv->treeview);
-        valid = gtk_tree_model_get_iter_first (model, &iter);
-	while (valid) {
-		gtk_tree_model_get (model, &iter, IS_NR, &id, -1);
-                itemPtr	item = item_load (id);
-                item_list_view_update_item (ilv, item);
-                item_unload (item);
-                valid = gtk_tree_model_iter_next (model, &iter);
+	for (GtkWidget *child = gtk_widget_get_first_child (GTK_WIDGET (ilv->listbox));
+	     child;
+	     child = gtk_widget_get_next_sibling (child)) {
+		ItemListRow *row = g_object_get_data (G_OBJECT (child), "item-list-row");
+		if (!row)
+			continue;
+
+		itemPtr item = item_load (row->id);
+		item_list_view_update_item (ilv, item);
+		item_unload (item);
 	}
 }
 
 static gboolean
 on_item_list_view_key_pressed_event (GtkEventControllerKey *controller, guint keyval, guint keycode, GdkModifierType state, gpointer user_data)
 {
-	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
-
 	switch (keyval) {
 		case GDK_KEY_Delete:
 		case GDK_KEY_KP_Delete:
@@ -732,10 +582,10 @@ on_item_list_view_key_pressed_event (GtkEventControllerKey *controller, guint ke
 static GMenu *
 item_list_view_popup_menu (ItemListView *ilv, itemPtr item)
 {
-	GMenu		*menu = g_menu_new();
-	GMenuItem	*menu_item;
-	gchar		*text, *item_link;
-	const		gchar *author;
+	GMenu *menu = g_menu_new ();
+	GMenuItem *menu_item;
+	gchar *text, *item_link;
+	const gchar *author;
 
 	item_link = item_make_link (item);
 	author = item_get_author (item);
@@ -743,191 +593,172 @@ item_list_view_popup_menu (ItemListView *ilv, itemPtr item)
 	GMenu *section = g_menu_new ();
 	menu_item = g_menu_item_new (NULL, NULL);
 
-	g_menu_item_set_label(menu_item, _("Open In _Tab"));
-	g_menu_item_set_action_and_target(menu_item, "app.open-item-in-tab", "t", (guint64) item->id);
-	g_menu_append_item(section, menu_item);
+	g_menu_item_set_label (menu_item, _("Open In _Tab"));
+	g_menu_item_set_action_and_target (menu_item, "app.open-item-in-tab", "t", (guint64)item->id);
+	g_menu_append_item (section, menu_item);
 
-	g_menu_item_set_label(menu_item, _("_Open In Browser"));
-	g_menu_item_set_action_and_target(menu_item, "app.open-item-in-browser", "t", (guint64) item->id);
-	g_menu_append_item(section, menu_item);
+	g_menu_item_set_label (menu_item, _("_Open In Browser"));
+	g_menu_item_set_action_and_target (menu_item, "app.open-item-in-browser", "t", (guint64)item->id);
+	g_menu_append_item (section, menu_item);
 
-	g_menu_item_set_label(menu_item, _("Open In _External Browser"));
-	g_menu_item_set_action_and_target(menu_item, "app.open-item-in-external-browser", "t", (guint64) item->id);
-	g_menu_append_item(section, menu_item);
+	g_menu_item_set_label (menu_item, _("Open In _External Browser"));
+	g_menu_item_set_action_and_target (menu_item, "app.open-item-in-external-browser", "t", (guint64)item->id);
+	g_menu_append_item (section, menu_item);
 
-	if(author){
-		g_menu_item_set_label(menu_item, _("Email The Author"));
-		g_menu_item_set_action_and_target(menu_item, "app.email-the-author", "t", (guint64) item->id);
-		g_menu_append_item(section, menu_item);
+	if (author) {
+		g_menu_item_set_label (menu_item, _("Email The Author"));
+		g_menu_item_set_action_and_target (menu_item, "app.email-the-author", "t", (guint64)item->id);
+		g_menu_append_item (section, menu_item);
 	}
 
-	g_menu_append_section(menu, NULL, G_MENU_MODEL(section));
-	g_object_unref(section);
+	g_menu_append_section (menu, NULL, G_MENU_MODEL (section));
+	g_object_unref (section);
 
-	GSList *iter = newsbin_get_list();
+	GSList *iter = newsbin_get_list ();
 	if (iter) {
 		GMenu *submenu;
 		guint32 i = 0;
 
-		section = g_menu_new();
-		submenu = g_menu_new();
+		section = g_menu_new ();
+		submenu = g_menu_new ();
 
 		while (iter) {
 			Node *node = (Node *)iter->data;
-			g_menu_item_set_label(menu_item, node_get_title(node));
-			g_menu_item_set_action_and_target(menu_item, "app.copy-item-to-newsbin", "(ut)", i, (guint64) item->id);
-			g_menu_append_item(submenu, menu_item);
-			iter = g_slist_next(iter);
+			g_menu_item_set_label (menu_item, node_get_title (node));
+			g_menu_item_set_action_and_target (menu_item, "app.copy-item-to-newsbin", "(ut)", i, (guint64)item->id);
+			g_menu_append_item (submenu, menu_item);
+			iter = g_slist_next (iter);
 			i++;
 		}
 
-		g_menu_append_submenu(section, _("Copy to News Bin"), G_MENU_MODEL(submenu));
-		g_object_unref(submenu);
-		g_menu_append_section(menu, NULL, G_MENU_MODEL(section));
-		g_object_unref(section);
+		g_menu_append_submenu (section, _("Copy to News Bin"), G_MENU_MODEL (submenu));
+		g_object_unref (submenu);
+		g_menu_append_section (menu, NULL, G_MENU_MODEL (section));
+		g_object_unref (section);
 	}
 
-	section = g_menu_new();
+	section = g_menu_new ();
 
-	text = g_strdup_printf(_("_Bookmark at %s"), social_get_bookmark_site());
-	g_menu_item_set_label(menu_item, text);
-	g_menu_item_set_action_and_target(menu_item, "app.social-bookmark-link", "(ss)", item_link, item_get_title(item));
-	g_menu_append_item(section, menu_item);
-	g_free(text);
+	text = g_strdup_printf (_("_Bookmark at %s"), social_get_bookmark_site ());
+	g_menu_item_set_label (menu_item, text);
+	g_menu_item_set_action_and_target (menu_item, "app.social-bookmark-link", "(ss)", item_link, item_get_title (item));
+	g_menu_append_item (section, menu_item);
+	g_free (text);
 
-	g_menu_item_set_label(menu_item, _("Copy Item _Location"));
-	g_menu_item_set_action_and_target(menu_item, "app.copy-link-to-clipboard", "s", item_link);
-	g_menu_append_item(section, menu_item);
+	g_menu_item_set_label (menu_item, _("Copy Item _Location"));
+	g_menu_item_set_action_and_target (menu_item, "app.copy-link-to-clipboard", "s", item_link);
+	g_menu_append_item (section, menu_item);
 
-	g_menu_append_section(menu, NULL, G_MENU_MODEL(section));
-	g_object_unref(section);
+	g_menu_append_section (menu, NULL, G_MENU_MODEL (section));
+	g_object_unref (section);
 
-	section = g_menu_new();
+	section = g_menu_new ();
 
-	g_menu_item_set_label(menu_item, _("Toggle _Read Status"));
-	g_menu_item_set_action_and_target(menu_item, "app.toggle-item-read-status", "t", (guint64) item->id);
-	g_menu_append_item(section, menu_item);
+	g_menu_item_set_label (menu_item, _("Toggle _Read Status"));
+	g_menu_item_set_action_and_target (menu_item, "app.toggle-item-read-status", "t", (guint64)item->id);
+	g_menu_append_item (section, menu_item);
 
-	g_menu_item_set_label(menu_item, _("Toggle Item _Flag"));
-	g_menu_item_set_action_and_target(menu_item, "app.toggle-item-flag", "t", (guint64) item->id);
-	g_menu_append_item(section, menu_item);
+	g_menu_item_set_label (menu_item, _("Toggle Item _Flag"));
+	g_menu_item_set_action_and_target (menu_item, "app.toggle-item-flag", "t", (guint64)item->id);
+	g_menu_append_item (section, menu_item);
 
-	g_menu_item_set_label(menu_item, _("R_emove Item"));
-	g_menu_item_set_action_and_target(menu_item, "app.remove-item", "t", (guint64) item->id);
-	g_menu_append_item(section, menu_item);
+	g_menu_item_set_label (menu_item, _("R_emove Item"));
+	g_menu_item_set_action_and_target (menu_item, "app.remove-item", "t", (guint64)item->id);
+	g_menu_append_item (section, menu_item);
 
-	g_menu_append_section(menu, NULL, G_MENU_MODEL(section));
-	g_object_unref(section);
+	g_menu_append_section (menu, NULL, G_MENU_MODEL (section));
+	g_object_unref (section);
 
-	g_object_unref(menu_item);
-	g_free(item_link);
+	g_object_unref (menu_item);
+	g_free (item_link);
 
 	return menu;
 }
 
 static gboolean
-on_item_list_view_pressed_event (GtkGestureClick *gesture, guint n_press, gdouble x, gdouble y, gpointer user_data)
+item_list_view_widget_is_descendant (GtkWidget *widget, GtkWidget *ancestor)
 {
-	ItemListView		*ilv = ITEM_LIST_VIEW (user_data);
-	GtkTreePath		*path;
-	GtkTreeIter		iter;
-	GtkTreeViewColumn	*column;
-	itemPtr			item = NULL;
-	gboolean		result = FALSE;
-	gint			bx, by;
-
-	gtk_tree_view_convert_widget_to_bin_window_coords (ilv->treeview, (int)x, (int)y, &bx, &by);
-
-	if (gtk_tree_view_get_path_at_pos (ilv->treeview, (gint)bx, (gint)by, &path, &column, NULL, NULL)) {
-		if (gtk_tree_model_get_iter (gtk_tree_view_get_model (ilv->treeview), &iter, path))
-			item = item_load (item_list_view_iter_to_id (ilv, &iter));
-		gtk_tree_path_free (path);
+	for (GtkWidget *iter = widget; iter; iter = gtk_widget_get_parent (iter)) {
+		if (iter == ancestor)
+			return TRUE;
 	}
 
-	if (item) {
-		if (n_press == 1) {
-			switch (gtk_gesture_single_get_current_button (GTK_GESTURE_SINGLE (gesture))) {
-				case GDK_BUTTON_PRIMARY:
-					if (column == g_hash_table_lookup (ilv->columns, "favicon") ||
-					    column == g_hash_table_lookup (ilv->columns, "state")) {
-						itemlist_toggle_flag (item);
-						result = TRUE;
-					}
-					break;
-				case GDK_BUTTON_MIDDLE:
-					/* Middle mouse click toggles read status (and does not select)... */
-					gtk_gesture_set_state (GTK_GESTURE (gesture), GTK_EVENT_SEQUENCE_CLAIMED);
-					itemlist_toggle_read_status (item);
-					result = TRUE;
-					break;
-				case GDK_BUTTON_SECONDARY:
-					/* Create a context menu */
-					GMenu *menu = item_list_view_popup_menu (ilv, item);
-					GtkWidget *popover = gtk_popover_menu_new_from_model (G_MENU_MODEL(menu));
-					gtk_widget_set_parent (popover, gtk_widget_get_parent (GTK_WIDGET (ilv->treeview)));		// use itemlist wrapper to avoid gtk_css_node_insert_after critical
-					GdkRectangle rect;
-					rect.x = (int)x;
-					rect.y = (int)y;
-					rect.width = 1;
-					rect.height = 1;
-					gtk_popover_set_pointing_to (GTK_POPOVER (popover), &rect);
-					gtk_popover_popup (GTK_POPOVER (popover));
-					g_object_unref(menu);
-					result = TRUE;
-					break;
-			}
-		}
-		item_unload (item);
-	}
-
-	return result;
-} 
-
-static void
-on_item_list_row_activated (GtkTreeView *treeview,
-                           GtkTreePath *path,
-			   GtkTreeViewColumn *column,
-			   gpointer user_data)
-{
-	GtkTreeModel *model = gtk_tree_view_get_model (treeview);
-	GtkTreeIter iter;
-
-	if (gtk_tree_model_get_iter (model, &iter, path)) {
-		itemPtr item = item_load (item_list_view_iter_to_id (ITEM_LIST_VIEW (user_data), &iter));
-		browser_launch_item (item, BROWSER_LAUNCH_DEFAULT);
-		item_unload (item);
-	}
+	return FALSE;
 }
 
-static void
-on_item_list_view_columns_changed (GtkTreeView *treeview, ItemListView *ilv)
+static gboolean
+on_item_list_view_pressed_event (GtkGestureClick *gesture, guint n_press, gdouble x, gdouble y, gpointer user_data)
 {
-	gint i = 0;
-	GList *columns;
-	GHashTableIter iter;
-	gpointer colname, colptr;
-	gchar *strv[5];
+	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
+	GtkListBoxRow *row = gtk_list_box_get_row_at_y (ilv->listbox, (int)y);
+	ItemListRow *item_row;
+	itemPtr item;
+	gboolean result = FALSE;
 
-	/* This handler is only used for drag and drop reordering, so it
-	   should not be hooked up with less than the full number of columns
-	   eg: on item_list_view creation or teardown */
-	if (gtk_tree_view_get_n_columns(treeview) != 4)
-		return;
+	if (!row)
+		return FALSE;
 
-	columns = gtk_tree_view_get_columns (treeview);
-	for (GList *li = columns; li; li = li->next) {
-		g_hash_table_iter_init (&iter, ilv->columns);
-		while (g_hash_table_iter_next (&iter, &colname, &colptr)) {
-			if (li->data == colptr) {
-				strv[i++] = colname;
-				strv[i] = NULL;
+	item_row = g_object_get_data (G_OBJECT (row), "item-list-row");
+	if (!item_row)
+		return FALSE;
+
+	item = item_load (item_row->id);
+	if (!item)
+		return FALSE;
+
+	if (n_press == 1) {
+		switch (gtk_gesture_single_get_current_button (GTK_GESTURE_SINGLE (gesture))) {
+			case GDK_BUTTON_PRIMARY: {
+				GtkWidget *picked = gtk_widget_pick (GTK_WIDGET (ilv->listbox), x, y, GTK_PICK_DEFAULT);
+				if (picked &&
+				    (item_list_view_widget_is_descendant (picked, item_row->favicon_image) ||
+				     item_list_view_widget_is_descendant (picked, item_row->state_image))) {
+					itemlist_toggle_flag (item);
+					result = TRUE;
+				}
+				break;
+			}
+			case GDK_BUTTON_MIDDLE:
+				gtk_gesture_set_state (GTK_GESTURE (gesture), GTK_EVENT_SEQUENCE_CLAIMED);
+				itemlist_toggle_read_status (item);
+				result = TRUE;
+				break;
+			case GDK_BUTTON_SECONDARY: {
+				GMenu *menu = item_list_view_popup_menu (ilv, item);
+				GtkWidget *popover = gtk_popover_menu_new_from_model (G_MENU_MODEL (menu));
+				GdkRectangle rect;
+
+				gtk_widget_set_parent (popover, ilv->ilscrolledwindow);
+				rect.x = (int)x;
+				rect.y = (int)y;
+				rect.width = 1;
+				rect.height = 1;
+				gtk_popover_set_pointing_to (GTK_POPOVER (popover), &rect);
+				gtk_popover_popup (GTK_POPOVER (popover));
+				g_object_unref (menu);
+				result = TRUE;
 				break;
 			}
 		}
 	}
-	conf_set_strv_value (LIST_VIEW_COLUMN_ORDER, (const gchar **)strv);
 
-	g_list_free (columns);
+	item_unload (item);
+	return result;
+}
+
+static void
+on_item_list_row_activated (GtkListBox *listbox, GtkListBoxRow *row, gpointer user_data)
+{
+	ItemListRow *item_row = g_object_get_data (G_OBJECT (row), "item-list-row");
+	if (!item_row)
+		return;
+
+	itemPtr item = item_load (item_row->id);
+	if (!item)
+		return;
+
+	browser_launch_item (item, BROWSER_LAUNCH_DEFAULT);
+	item_unload (item);
 }
 
 GtkWidget *
@@ -939,82 +770,130 @@ item_list_view_get_widget (ItemListView *ilv)
 void
 item_list_view_move_cursor (ItemListView *ilv, int step)
 {
-	ui_common_treeview_move_cursor (ilv->treeview, step);
+	GtkListBoxRow *selected = gtk_list_box_get_selected_row (ilv->listbox);
+	gint index = selected ? gtk_list_box_row_get_index (selected) : 0;
+	gint target = index + step;
+
+	if (!selected && step < 0)
+		target = G_MAXINT;
+	if (target < 0)
+		target = 0;
+
+	GtkListBoxRow *row = gtk_list_box_get_row_at_index (ilv->listbox, target);
+	if (!row && target > 0)
+		row = gtk_list_box_get_row_at_index (ilv->listbox, target - 1);
+	if (row)
+		gtk_list_box_select_row (ilv->listbox, row);
 }
 
 void
 item_list_view_move_cursor_to_first (ItemListView *ilv)
 {
-	ui_common_treeview_move_cursor_to_first (ilv->treeview);
+	GtkListBoxRow *row = gtk_list_box_get_row_at_index (ilv->listbox, 0);
+	if (row)
+		gtk_list_box_select_row (ilv->listbox, row);
+}
+
+static ItemListRow *
+item_list_view_create_row (ItemListView *ilv, itemPtr item, Node *node)
+{
+	ItemListRow *row = g_new0 (ItemListRow, 1);
+	GtkWidget *box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+	GtkWidget *text_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 2);
+	GtkWidget *header_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+
+	row->id = item->id;
+	row->source = node;
+	row->row = gtk_list_box_row_new ();
+	row->state_image = gtk_image_new ();
+	row->favicon_image = gtk_image_new ();
+	row->headline_label = gtk_label_new (NULL);
+	row->date_label = gtk_label_new (NULL);
+
+	gtk_label_set_use_markup (GTK_LABEL (row->headline_label), TRUE);
+	gtk_label_set_xalign (GTK_LABEL (row->headline_label), 0.0);
+	gtk_label_set_wrap (GTK_LABEL (row->headline_label), FALSE);
+	gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_END);
+
+	gtk_label_set_xalign (GTK_LABEL (row->date_label), 1.0);
+	gtk_widget_set_halign (row->date_label, GTK_ALIGN_END);
+	gtk_widget_set_hexpand (row->date_label, FALSE);
+	gtk_widget_add_css_class (row->date_label, "dim-label");
+
+	gtk_widget_set_halign (row->state_image, GTK_ALIGN_START);
+	gtk_widget_set_halign (row->favicon_image, GTK_ALIGN_START);
+	gtk_widget_set_hexpand (row->headline_label, TRUE);
+
+	gtk_box_append (GTK_BOX (header_box), row->headline_label);
+	gtk_box_append (GTK_BOX (header_box), row->date_label);
+	gtk_box_append (GTK_BOX (text_box), header_box);
+
+	gtk_box_append (GTK_BOX (box), row->state_image);
+	gtk_box_append (GTK_BOX (box), row->favicon_image);
+	gtk_box_append (GTK_BOX (box), text_box);
+
+	gtk_widget_set_margin_start (box, 6);
+	gtk_widget_set_margin_end (box, 6);
+	gtk_widget_set_margin_top (box, 3);
+	gtk_widget_set_margin_bottom (box, 3);
+
+	gtk_list_box_row_set_child (GTK_LIST_BOX_ROW (row->row), box);
+	g_object_set_data (G_OBJECT (row->row), "item-list-row", row);
+
+	item_list_view_update_item_internal (ilv, item, row, node);
+	return row;
 }
 
 static void
-item_list_view_add_item_to_tree_store (ItemListView *ilv, GtkTreeStore *itemstore, itemPtr item)
+item_list_view_add_item_to_listbox (ItemListView *ilv, itemPtr item)
 {
-	Node		*node;
-	GtkTreeIter	iter;
-	gboolean	exists = FALSE;
+	Node *node = node_from_id (item->nodeId);
+	ItemListRow *row;
 
-	node = node_from_id (item->nodeId);
-	if(!node)
-		return;	/* comment items do cause this... maybe filtering them earlier would be a good idea... */
+	if (!node)
+		return;
 
-        if (!ilv->batch_mode)
-            exists = item_list_view_id_to_iter (ilv, item->id, &iter);
-
-	if (!exists) {
-		gtk_tree_store_prepend (itemstore, &iter, NULL);
+	row = item_list_view_id_to_row (ilv, item->id);
+	if (!row) {
+		row = item_list_view_create_row (ilv, item, node);
+		gtk_list_box_append (ilv->listbox, row->row);
+		g_hash_table_insert (ilv->rows_by_id, GUINT_TO_POINTER (item->id), row);
 		ilv->item_ids = g_slist_prepend (ilv->item_ids, GUINT_TO_POINTER (item->id));
+	} else {
+		item_list_view_update_item_internal (ilv, item, row, node);
 	}
-
-	item_list_view_update_item_internal (ilv, item, &iter, node);
 }
 
 static void
-item_list_view_item_added (GObject *obj, gint itemId, gpointer userdata)
+item_list_view_item_added (GObject *obj, gint itemId, gpointer user_data)
 {
-	ItemListView	*ilv = ITEM_LIST_VIEW (userdata);
-	GtkTreeStore	*itemstore;
+	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
 	itemPtr item = item_load (itemId);
 
-	if (ilv->batch_mode) {
-		/* either merge to new unattached GtkTreeStore */
-		item_list_view_add_item_to_tree_store (ilv, ilv->batch_itemstore, item);
-	} else {
-		/* or merge to visible item store */
-		itemstore = GTK_TREE_STORE (gtk_tree_view_get_model (ilv->treeview));
-		item_list_view_add_item_to_tree_store (ilv, itemstore, item);
-	}
+	item_list_view_add_item_to_listbox (ilv, item);
+	item_unload (item);
+
+	if (!ilv->batch_mode)
+		gtk_list_box_invalidate_sort (ilv->listbox);
 }
 
 static void
 item_list_view_select (GObject *obj, gint id, gpointer user_data)
 {
-	ItemListView		*ilv = ITEM_LIST_VIEW (user_data);
-	GtkTreeView		*treeview = ilv->treeview;
-	GtkTreeSelection	*selection;
-	GtkTreeIter		iter;
-
-	if (!treeview)
-		return;
-
-	selection = gtk_tree_view_get_selection (treeview);
+	ItemListView *ilv = ITEM_LIST_VIEW (user_data);
 
 	if (id) {
-		if (item_list_view_id_to_iter (ilv, id, &iter)) {
-			GtkTreePath	*path = NULL;
-
-			path = gtk_tree_model_get_path (gtk_tree_view_get_model (treeview), &iter);
-			if (path) {
-				gtk_tree_view_set_cursor (treeview, path, NULL, FALSE);
-				gtk_tree_view_scroll_to_cell (treeview, path, NULL, FALSE, 0.0, 0.0);
-				gtk_tree_path_free (path);
-			}
+		ItemListRow *row = item_list_view_id_to_row (ilv, id);
+		if (row) {
+			gtk_list_box_select_row (ilv->listbox, GTK_LIST_BOX_ROW (row->row));
+			gtk_widget_grab_focus (row->row);
 		} else {
 			debug (DEBUG_GUI, "item_list_view_select: ignore missing item id %d in current view", id);
 		}
 	} else {
-		gtk_tree_selection_unselect_all (selection);
+		GtkListBoxRow *selected = gtk_list_box_get_selected_row (ilv->listbox);
+		if (selected)
+			gtk_list_box_unselect_row (ilv->listbox, selected);
 	}
 }
 
@@ -1026,15 +905,15 @@ item_list_view_init (ItemListView *ilv)
 ItemListView *
 item_list_view_create (FeedList *feedlist, ItemList *itemlist)
 {
-	ItemListView		*ilv;
-	GtkCellRenderer		*renderer;
-	GtkTreeViewColumn 	*column, *headline_column;
-	gchar			**conf_column_order;
+	ItemListView *ilv;
 
 	ilv = g_object_new (ITEM_LIST_VIEW_TYPE, NULL);
 	ilv->wideView = FALSE;
+	ilv->favicon_enabled = TRUE;
+	ilv->sort_type = NODE_VIEW_SORT_BY_TIME;
+	ilv->sort_reversed = FALSE;
 
-	ilv->columns = g_hash_table_new (g_str_hash, g_str_equal);
+	ilv->rows_by_id = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, (GDestroyNotify)item_list_row_free);
 
 	ilv->keypress = gtk_event_controller_key_new ();
 	ilv->gesture = gtk_gesture_click_new ();
@@ -1048,57 +927,17 @@ item_list_view_create (FeedList *feedlist, ItemList *itemlist)
 
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (ilv->ilscrolledwindow), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 
-	ilv->treeview = GTK_TREE_VIEW (gtk_tree_view_new ());
-	gtk_tree_view_set_enable_search (ilv->treeview, FALSE);
-	gtk_tree_view_set_show_expanders (ilv->treeview, FALSE);
-	gtk_scrolled_window_set_child (GTK_SCROLLED_WINDOW (ilv->ilscrolledwindow), GTK_WIDGET (ilv->treeview));
-	gtk_widget_show (GTK_WIDGET (ilv->treeview));
-	gtk_widget_set_name (GTK_WIDGET (ilv->treeview), "itemlist");
+	ilv->listbox = GTK_LIST_BOX (gtk_list_box_new ());
+	gtk_list_box_set_selection_mode (ilv->listbox, GTK_SELECTION_SINGLE);
+	gtk_list_box_set_activate_on_single_click (ilv->listbox, FALSE);
+	gtk_list_box_set_sort_func (ilv->listbox, item_list_view_sort_func, ilv, NULL);
+	gtk_list_box_set_show_separators (ilv->listbox, FALSE);
+	gtk_scrolled_window_set_child (GTK_SCROLLED_WINDOW (ilv->ilscrolledwindow), GTK_WIDGET (ilv->listbox));
+	gtk_widget_show (GTK_WIDGET (ilv->listbox));
+	gtk_widget_set_name (GTK_WIDGET (ilv->listbox), "itemlist");
 
-	item_list_view_set_tree_store (ilv, item_list_view_create_tree_store ());
-
-	renderer = gtk_cell_renderer_pixbuf_new ();
-	column = gtk_tree_view_column_new_with_attributes ("", renderer, "gicon", IS_STATEICON, NULL);
-	
-	g_hash_table_insert (ilv->columns, "state", column);
-	gtk_tree_view_column_set_sort_column_id (column, IS_STATE);
-
-	ilv->faviconRenderer = gtk_cell_renderer_pixbuf_new ();
-	column = gtk_tree_view_column_new_with_attributes ("", ilv->faviconRenderer, "gicon", IS_FAVICON, NULL);
-	gtk_tree_view_column_set_sort_column_id (column, IS_SOURCE);
-	g_hash_table_insert (ilv->columns, "favicon", column);
-
-	ilv->headlineRenderer = gtk_cell_renderer_text_new ();
-	headline_column = gtk_tree_view_column_new_with_attributes (_("Headline"), ilv->headlineRenderer,
-	                                                   "markup", IS_LABEL,
-							   "xalign", ITEMSTORE_ALIGN,
-							   NULL);
-	gtk_tree_view_column_set_expand (headline_column, TRUE);
-	g_hash_table_insert (ilv->columns, "headline", headline_column);
-	g_object_set (headline_column, "resizable", TRUE, NULL);
-
-	renderer = gtk_cell_renderer_text_new ();
-	column = gtk_tree_view_column_new_with_attributes (_("Date"), renderer,
-		                                           "text", IS_TIME_STR,
-	                                                   "weight", ITEMSTORE_WEIGHT,
-							   NULL);
-	gtk_tree_view_column_set_sizing (column, GTK_TREE_VIEW_COLUMN_GROW_ONLY);
-	g_hash_table_insert (ilv->columns, "date", column);
-	gtk_tree_view_column_set_sort_column_id(column, IS_TIME);
-
-	conf_get_strv_value (LIST_VIEW_COLUMN_ORDER, &conf_column_order);
-	for (gchar **li = conf_column_order; *li; li++) {
-		column = g_hash_table_lookup (ilv->columns, *li);
-		if (GTK_IS_TREE_VIEW_COLUMN (column)) {
-			g_object_set (column, "reorderable", TRUE, NULL);
-			gtk_tree_view_append_column (ilv->treeview, column);
-		}
-	}
-	g_strfreev (conf_column_order);
-
-	/* And connect signals */
-	g_signal_connect (G_OBJECT (ilv->treeview), "columns_changed", G_CALLBACK (on_item_list_view_columns_changed), ilv);
-	g_signal_connect (G_OBJECT (ilv->treeview), "row_activated", G_CALLBACK (on_item_list_row_activated), ilv);
+	g_signal_connect (G_OBJECT (ilv->listbox), "selected-rows-changed", G_CALLBACK (on_itemlist_selection_changed), ilv);
+	g_signal_connect (G_OBJECT (ilv->listbox), "row-activated", G_CALLBACK (on_item_list_row_activated), ilv);
 
 	gtk_gesture_single_set_button (GTK_GESTURE_SINGLE (ilv->middle_gesture), GDK_BUTTON_MIDDLE);
 	gtk_event_controller_set_propagation_phase (GTK_EVENT_CONTROLLER (ilv->middle_gesture), GTK_PHASE_CAPTURE);
@@ -1107,11 +946,11 @@ item_list_view_create (FeedList *feedlist, ItemList *itemlist)
 	g_signal_connect (ilv->popup_gesture, "pressed", G_CALLBACK (on_item_list_view_pressed_event), ilv);
 	g_signal_connect (ilv->gesture, "pressed", G_CALLBACK (on_item_list_view_pressed_event), ilv);
 	g_signal_connect (ilv->keypress, "key-pressed", G_CALLBACK (on_item_list_view_key_pressed_event), ilv);
-	
-	gtk_widget_add_controller (GTK_WIDGET (ilv->treeview), GTK_EVENT_CONTROLLER (ilv->middle_gesture));
-	gtk_widget_add_controller (GTK_WIDGET (ilv->treeview), GTK_EVENT_CONTROLLER (ilv->popup_gesture));
-	gtk_widget_add_controller (GTK_WIDGET (ilv->treeview), GTK_EVENT_CONTROLLER(ilv->gesture));
-	gtk_widget_add_controller (GTK_WIDGET (ilv->treeview), ilv->keypress);
+
+	gtk_widget_add_controller (GTK_WIDGET (ilv->listbox), GTK_EVENT_CONTROLLER (ilv->middle_gesture));
+	gtk_widget_add_controller (GTK_WIDGET (ilv->listbox), GTK_EVENT_CONTROLLER (ilv->popup_gesture));
+	gtk_widget_add_controller (GTK_WIDGET (ilv->listbox), GTK_EVENT_CONTROLLER (ilv->gesture));
+	gtk_widget_add_controller (GTK_WIDGET (ilv->listbox), ilv->keypress);
 
 	g_signal_connect (feedlist, "items-updated", G_CALLBACK (item_list_view_update_all_items), ilv);
 	g_signal_connect (itemlist, "item-batch-start", G_CALLBACK (item_list_view_item_batch_started), ilv);
@@ -1121,7 +960,7 @@ item_list_view_create (FeedList *feedlist, ItemList *itemlist)
 	g_signal_connect (itemlist, "item-removed", G_CALLBACK (item_list_view_item_removed), ilv);
 	g_signal_connect (itemlist, "item-updated", G_CALLBACK (item_list_view_item_updated), ilv);
 	g_signal_connect (itemlist, "item-selected", G_CALLBACK (item_list_view_select), ilv);
-	
+
 	g_signal_connect (ilv, "selection-changed", G_CALLBACK (itemlist_selection_changed), itemlist);
 
 	return ilv;
@@ -1130,36 +969,41 @@ item_list_view_create (FeedList *feedlist, ItemList *itemlist)
 void
 item_list_view_enable_favicon_column (ItemListView *ilv, gboolean enabled)
 {
-	gtk_tree_view_column_set_visible (g_hash_table_lookup(ilv->columns, "favicon"), enabled);
+	ilv->favicon_enabled = enabled;
+	item_list_view_for_each_row (ilv, item_list_view_update_wide_mode_cb, ilv);
+}
 
-	// In wide view we want to save vertical space and hide the state column
-	if (ilv->wideView)
-		gtk_tree_view_column_set_visible (g_hash_table_lookup(ilv->columns, "state"), !enabled);
+gboolean
+item_list_view_contains_id (ItemListView *ilv, gulong id)
+{
+	return (NULL != item_list_view_id_to_row (ilv, id));
 }
 
 itemPtr
 item_list_view_find_unread_item (ItemListView *ilv, gulong startId)
 {
-	GtkTreeIter		iter;
-	GtkTreeModel		*model;
-	gboolean		valid = TRUE;
+	gint index = 0;
 
-	model = gtk_tree_view_get_model (ilv->treeview);
+	if (startId) {
+		ItemListRow *start = item_list_view_id_to_row (ilv, startId);
+		if (!start)
+			return NULL;
+		index = gtk_list_box_row_get_index (GTK_LIST_BOX_ROW (start->row));
+	}
 
-	if (startId)
-		valid = item_list_view_id_to_iter (ilv, startId, &iter);
-	else
-		valid = gtk_tree_model_get_iter_first (model, &iter);
+	for (GtkListBoxRow *row = gtk_list_box_get_row_at_index (ilv->listbox, index);
+	     row;
+	     row = gtk_list_box_get_row_at_index (ilv->listbox, ++index)) {
+		ItemListRow *item_row = g_object_get_data (G_OBJECT (row), "item-list-row");
+		if (!item_row)
+			continue;
 
-	while (valid) {
-		itemPtr	item = item_load (item_list_view_iter_to_id (ilv, &iter));
+		itemPtr item = item_load (item_row->id);
 		if (item) {
-			/* Skip the selected item */
 			if (!item->readStatus && item->id != startId)
 				return item;
 			item_unload (item);
 		}
-		valid = gtk_tree_model_iter_next (model, &iter);
 	}
 
 	return NULL;
@@ -1168,7 +1012,7 @@ item_list_view_find_unread_item (ItemListView *ilv, gulong startId)
 void
 on_popup_copy_URL_clipboard (GSimpleAction *action, GVariant *parameter, gpointer user_data)
 {
-	itemPtr         item;
+	itemPtr item;
 
 	item = itemlist_get_selected ();
 	if (item) {
@@ -1189,7 +1033,7 @@ on_popup_social_bm_item_selected (GSimpleAction *action, GVariant *parameter, gp
 	if (item) {
 		social_add_bookmark (item);
 		item_unload (item);
-	}
-	else
+	} else {
 		liferea_shell_set_important_status_bar (_("No item has been selected"));
+	}
 }

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -124,11 +124,25 @@ item_list_title_alignment (gchar *title)
 		return 1.;
 }
 
+static gchar *
+item_list_truncate_utf8 (const gchar *text, guint max_chars)
+{
+	if (!text)
+		return g_strdup ("");
+
+	gsize len = g_utf8_strlen (text, -1);
+	if (len <= max_chars)
+		return g_strdup (text);
+
+	const gchar *end = g_utf8_offset_to_pointer (text, max_chars);
+	return g_strndup (text, end - text);
+}
+
 static void
 item_list_view_apply_row_visibility (ItemListView *ilv, ItemListRow *row)
 {
 	gtk_widget_set_visible (row->favicon_image, ilv->favicon_enabled);
-	gtk_widget_set_visible (row->date_label, TRUE);
+	gtk_widget_set_visible (row->date_label, !ilv->wideView);
 	gtk_widget_set_visible (row->preview_label, ilv->wideView);
 	gtk_widget_set_visible (row->state_image, !ilv->wideView || !ilv->favicon_enabled);
 }
@@ -139,9 +153,10 @@ item_list_view_apply_row_layout (ItemListView *ilv, ItemListRow *row)
 	if (ilv->wideView) {
 		gtk_image_set_icon_size (GTK_IMAGE (row->favicon_image), GTK_ICON_SIZE_LARGE);
 		gtk_widget_set_margin_start (row->favicon_image, 6);
-		gtk_label_set_wrap (GTK_LABEL (row->headline_label), FALSE);
-		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_NONE);
-		gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_END);
+		gtk_widget_set_margin_end (row->favicon_image, 6);
+		gtk_label_set_wrap (GTK_LABEL (row->headline_label), TRUE);
+		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_WORD_CHAR);
+		gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_NONE);
 
 		gtk_label_set_wrap (GTK_LABEL (row->preview_label), TRUE);
 		gtk_label_set_wrap_mode (GTK_LABEL (row->preview_label), PANGO_WRAP_WORD_CHAR);
@@ -149,6 +164,7 @@ item_list_view_apply_row_layout (ItemListView *ilv, ItemListRow *row)
 	} else {
 		gtk_image_set_icon_size (GTK_IMAGE (row->favicon_image), GTK_ICON_SIZE_NORMAL);
 		gtk_widget_set_margin_start (row->favicon_image, 0);
+		gtk_widget_set_margin_end (row->favicon_image, 0);
 		gtk_label_set_wrap (GTK_LABEL (row->headline_label), FALSE);
 		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_NONE);
 		gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_END);
@@ -442,7 +458,10 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 	gchar *escaped_title;
 	gchar *preview_markup;
 	gchar *time_str;
+	gchar *time_str_escaped;
 	gchar *headline_markup;
+	gchar *title_limited;
+	gchar *title_limited_escaped;
 	gchar *tmp = NULL;
 	const GIcon *state_icon;
 	gint state = 0;
@@ -454,15 +473,21 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 		state += 1;
 
 	time_str = (0 != item->time) ? date_format ((time_t)item->time, NULL) : g_strdup ("");
+	time_str_escaped = g_markup_escape_text (time_str, -1);
 
 	if (item->title && strlen (item->title)) {
 		escaped_title = g_markup_escape_text (item->title, -1);
 		g_strstrip (escaped_title);
 		plain_title = g_strdup (escaped_title);
+		title_limited = item_list_truncate_utf8 (item->title, 100);
+		title_limited_escaped = g_markup_escape_text (title_limited, -1);
+		g_strstrip (title_limited_escaped);
 	} else {
 		tmp = item_get_teaser (item);
 		plain_title = g_strdup_printf ("%s...", tmp ? tmp : "");
 		escaped_title = g_markup_escape_text (plain_title, -1);
+		title_limited = item_list_truncate_utf8 (plain_title, 100);
+		title_limited_escaped = g_markup_escape_text (title_limited, -1);
 		g_free (tmp);
 		no_title = TRUE;
 	}
@@ -481,14 +506,15 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 		headline_markup = g_strdup_printf (
 			"<span weight='%s' size='larger'>%s</span>",
 			item->readStatus ? "normal" : "bold",
-			escaped_title);
+			title_limited_escaped);
 
 		preview_markup = g_strdup_printf (
-			"%s<span weight='%s'>%s%s</span>",
+			"%s<span weight='%s'>%s%s</span><span size='smaller' weight='ultralight'> — %s</span>",
 			important_prefix,
 			item->readStatus ? "ultralight" : "light",
 			teaser_markup ? teaser_markup : "",
-			teaser_markup ? "..." : "");
+			teaser_markup ? "..." : "",
+			time_str_escaped);
 		g_free (teaser_markup);
 		g_free (teaser);
 	} else {
@@ -531,6 +557,9 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 
 	g_free (headline_markup);
 	g_free (preview_markup);
+	g_free (title_limited_escaped);
+	g_free (title_limited);
+	g_free (time_str_escaped);
 	g_free (escaped_title);
 	g_free (plain_title);
 	g_free (time_str);
@@ -861,8 +890,8 @@ item_list_view_create_row (ItemListView *ilv, itemPtr item, Node *node)
 
 	gtk_widget_set_margin_start (box, 6);
 	gtk_widget_set_margin_end (box, 6);
-	gtk_widget_set_margin_top (box, 3);
-	gtk_widget_set_margin_bottom (box, 3);
+	gtk_widget_set_margin_top (row->row, 3);
+	gtk_widget_set_margin_bottom (row->row, 3);
 
 	gtk_list_box_row_set_child (GTK_LIST_BOX_ROW (row->row), box);
 	g_object_set_data (G_OBJECT (row->row), "item-list-row", row);

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -74,7 +74,6 @@ struct _ItemListView {
 
 	gboolean	batch_mode;
 	gboolean	wideView;
-	gboolean	favicon_enabled;
 
 	nodeViewSortType	sort_type;
 	gboolean	sort_reversed;
@@ -144,10 +143,12 @@ item_list_truncate_utf8 (const gchar *text, guint max_chars)
 static void
 item_list_view_apply_row_visibility (ItemListView *ilv, ItemListRow *row)
 {
-	gtk_widget_set_visible (row->favicon_image, ilv->favicon_enabled);
+	Node *selected = feedlist_get_selected ();
+
+	gtk_widget_set_visible (row->favicon_image, !(selected && !selected->children));
 	gtk_widget_set_visible (row->date_label, !ilv->wideView);
 	gtk_widget_set_visible (row->preview_label, ilv->wideView);
-	gtk_widget_set_visible (row->state_image, !ilv->wideView || !ilv->favicon_enabled);
+	gtk_widget_set_visible (row->state_image, !ilv->wideView);
 }
 
 static void
@@ -170,8 +171,8 @@ item_list_view_apply_row_layout (ItemListView *ilv, ItemListRow *row)
 		gtk_label_set_ellipsize (GTK_LABEL (row->preview_label), PANGO_ELLIPSIZE_NONE);
 	} else {
 		gtk_image_set_icon_size (GTK_IMAGE (row->favicon_image), GTK_ICON_SIZE_NORMAL);
-		gtk_widget_set_margin_start (row->favicon_image, 0);
-		gtk_widget_set_margin_end (row->favicon_image, 0);
+		gtk_widget_set_margin_start (row->favicon_image, 6);
+		gtk_widget_set_margin_end (row->favicon_image, 6);
 		gtk_widget_set_margin_top (box, 2);
 		gtk_widget_set_margin_bottom (box, 2);
 		gtk_label_set_wrap (GTK_LABEL (row->headline_label), FALSE);
@@ -728,7 +729,7 @@ item_list_view_popup_menu (ItemListView *ilv, itemPtr item)
 	GMenu *sort_submenu = g_menu_new ();
 	g_menu_append (sort_submenu, _("By _Date"), "app.sort-items-by-time");
 	g_menu_append (sort_submenu, _("By _Title"), "app.sort-items-by-title");
-	g_menu_append (sort_submenu, _("By _Source"), "app.sort-items-by-source");
+	g_menu_append (sort_submenu, _("By _Feed"), "app.sort-items-by-source");
 	g_menu_append (sort_submenu, _("By _Status"), "app.sort-items-by-state");
 	g_menu_append (sort_submenu, _("_Reverse Order"), "app.sort-items-reverse");
 	g_menu_append_submenu (section, _("_Sort"), G_MENU_MODEL (sort_submenu));
@@ -981,7 +982,6 @@ item_list_view_create (FeedList *feedlist, ItemList *itemlist)
 
 	ilv = g_object_new (ITEM_LIST_VIEW_TYPE, NULL);
 	ilv->wideView = FALSE;
-	ilv->favicon_enabled = TRUE;
 	ilv->sort_type = NODE_VIEW_SORT_BY_TIME;
 	ilv->sort_reversed = FALSE;
 
@@ -1034,13 +1034,6 @@ item_list_view_create (FeedList *feedlist, ItemList *itemlist)
 	g_signal_connect (ilv, "selection-changed", G_CALLBACK (itemlist_selection_changed), itemlist);
 
 	return ilv;
-}
-
-void
-item_list_view_enable_favicon_column (ItemListView *ilv, gboolean enabled)
-{
-	ilv->favicon_enabled = enabled;
-	item_list_view_for_each_row (ilv, item_list_view_update_wide_mode_cb, ilv);
 }
 
 gboolean

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -723,6 +723,20 @@ item_list_view_popup_menu (ItemListView *ilv, itemPtr item)
 	g_menu_append_section (menu, NULL, G_MENU_MODEL (section));
 	g_object_unref (section);
 
+	section = g_menu_new ();
+
+	GMenu *sort_submenu = g_menu_new ();
+	g_menu_append (sort_submenu, _("By _Date"), "app.sort-items-by-time");
+	g_menu_append (sort_submenu, _("By _Title"), "app.sort-items-by-title");
+	g_menu_append (sort_submenu, _("By _Source"), "app.sort-items-by-source");
+	g_menu_append (sort_submenu, _("By _Status"), "app.sort-items-by-state");
+	g_menu_append (sort_submenu, _("_Reverse Order"), "app.sort-items-reverse");
+	g_menu_append_submenu (section, _("_Sort"), G_MENU_MODEL (sort_submenu));
+	g_object_unref (sort_submenu);
+
+	g_menu_append_section (menu, NULL, G_MENU_MODEL (section));
+	g_object_unref (section);
+
 	g_object_unref (menu_item);
 	g_free (item_link);
 

--- a/src/ui/item_list_view.c
+++ b/src/ui/item_list_view.c
@@ -54,6 +54,7 @@ typedef struct {
 	GtkWidget	*state_image;
 	GtkWidget	*favicon_image;
 	GtkWidget	*headline_label;
+	GtkWidget	*preview_label;
 	GtkWidget	*date_label;
 	Node		*source;
 } ItemListRow;
@@ -127,7 +128,8 @@ static void
 item_list_view_apply_row_visibility (ItemListView *ilv, ItemListRow *row)
 {
 	gtk_widget_set_visible (row->favicon_image, ilv->favicon_enabled);
-	gtk_widget_set_visible (row->date_label, !ilv->wideView);
+	gtk_widget_set_visible (row->date_label, TRUE);
+	gtk_widget_set_visible (row->preview_label, ilv->wideView);
 	gtk_widget_set_visible (row->state_image, !ilv->wideView || !ilv->favicon_enabled);
 }
 
@@ -137,15 +139,23 @@ item_list_view_apply_row_layout (ItemListView *ilv, ItemListRow *row)
 	if (ilv->wideView) {
 		gtk_image_set_icon_size (GTK_IMAGE (row->favicon_image), GTK_ICON_SIZE_LARGE);
 		gtk_widget_set_margin_start (row->favicon_image, 6);
-		gtk_label_set_wrap (GTK_LABEL (row->headline_label), TRUE);
-		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_WORD);
-		gtk_label_set_max_width_chars (GTK_LABEL (row->headline_label), -1);
+		gtk_label_set_wrap (GTK_LABEL (row->headline_label), FALSE);
+		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_NONE);
+		gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_END);
+
+		gtk_label_set_wrap (GTK_LABEL (row->preview_label), TRUE);
+		gtk_label_set_wrap_mode (GTK_LABEL (row->preview_label), PANGO_WRAP_WORD_CHAR);
+		gtk_label_set_ellipsize (GTK_LABEL (row->preview_label), PANGO_ELLIPSIZE_NONE);
 	} else {
 		gtk_image_set_icon_size (GTK_IMAGE (row->favicon_image), GTK_ICON_SIZE_NORMAL);
 		gtk_widget_set_margin_start (row->favicon_image, 0);
 		gtk_label_set_wrap (GTK_LABEL (row->headline_label), FALSE);
 		gtk_label_set_wrap_mode (GTK_LABEL (row->headline_label), PANGO_WRAP_NONE);
 		gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_END);
+
+		gtk_label_set_wrap (GTK_LABEL (row->preview_label), FALSE);
+		gtk_label_set_wrap_mode (GTK_LABEL (row->preview_label), PANGO_WRAP_NONE);
+		gtk_label_set_ellipsize (GTK_LABEL (row->preview_label), PANGO_ELLIPSIZE_NONE);
 	}
 
 	item_list_view_apply_row_visibility (ilv, row);
@@ -430,8 +440,9 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 {
 	gchar *plain_title;
 	gchar *escaped_title;
+	gchar *preview_markup;
 	gchar *time_str;
-	gchar *title_markup;
+	gchar *headline_markup;
 	gchar *tmp = NULL;
 	const GIcon *state_icon;
 	gint state = 0;
@@ -458,6 +469,7 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 
 	if (ilv->wideView) {
 		const gchar *important = _(" <span background='red' color='white'> important </span> ");
+		const gchar *important_prefix = item->flagStatus ? important : "";
 		gchar *teaser = NULL;
 		gchar *teaser_markup = NULL;
 
@@ -466,22 +478,24 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 		if (teaser)
 			teaser_markup = g_markup_escape_text (teaser, -1);
 
-		title_markup = g_strdup_printf (
-			"<span weight='%s' size='larger'>%s</span>%s\n"
-			"<span weight='%s'>%s%s</span><span size='smaller' weight='ultralight'> - %s</span>",
+		headline_markup = g_strdup_printf (
+			"<span weight='%s' size='larger'>%s</span>",
 			item->readStatus ? "normal" : "bold",
-			escaped_title,
-			item->flagStatus ? important : "",
+			escaped_title);
+
+		preview_markup = g_strdup_printf (
+			"%s<span weight='%s'>%s%s</span>",
+			important_prefix,
 			item->readStatus ? "ultralight" : "light",
 			teaser_markup ? teaser_markup : "",
-			teaser_markup ? "..." : "",
-			time_str);
+			teaser_markup ? "..." : "");
 		g_free (teaser_markup);
 		g_free (teaser);
 	} else {
-		title_markup = g_strdup_printf ("<span weight='%s'>%s</span>",
+		headline_markup = g_strdup_printf ("<span weight='%s'>%s</span>",
 		                               item->readStatus ? "normal" : "bold",
 		                               escaped_title);
+		preview_markup = g_strdup ("");
 	}
 
 	state_icon = item->flagStatus ? icon_get (ICON_FLAG) :
@@ -495,8 +509,10 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 	g_free (row->sort_label);
 	row->sort_label = g_utf8_casefold (plain_title, -1);
 
-	gtk_label_set_markup (GTK_LABEL (row->headline_label), title_markup);
+	gtk_label_set_markup (GTK_LABEL (row->headline_label), headline_markup);
+	gtk_label_set_markup (GTK_LABEL (row->preview_label), preview_markup);
 	gtk_label_set_xalign (GTK_LABEL (row->headline_label), item_list_title_alignment (plain_title));
+	gtk_label_set_xalign (GTK_LABEL (row->preview_label), item_list_title_alignment (plain_title));
 	gtk_label_set_text (GTK_LABEL (row->date_label), time_str);
 
 	if (state_icon)
@@ -513,7 +529,8 @@ item_list_view_update_item_internal (ItemListView *ilv, itemPtr item, ItemListRo
 
 	gtk_widget_set_tooltip_text (row->headline_label, plain_title);
 
-	g_free (title_markup);
+	g_free (headline_markup);
+	g_free (preview_markup);
 	g_free (escaped_title);
 	g_free (plain_title);
 	g_free (time_str);
@@ -808,12 +825,20 @@ item_list_view_create_row (ItemListView *ilv, itemPtr item, Node *node)
 	row->state_image = gtk_image_new ();
 	row->favicon_image = gtk_image_new ();
 	row->headline_label = gtk_label_new (NULL);
+	row->preview_label = gtk_label_new (NULL);
 	row->date_label = gtk_label_new (NULL);
 
 	gtk_label_set_use_markup (GTK_LABEL (row->headline_label), TRUE);
 	gtk_label_set_xalign (GTK_LABEL (row->headline_label), 0.0);
 	gtk_label_set_wrap (GTK_LABEL (row->headline_label), FALSE);
 	gtk_label_set_ellipsize (GTK_LABEL (row->headline_label), PANGO_ELLIPSIZE_END);
+
+	gtk_label_set_use_markup (GTK_LABEL (row->preview_label), TRUE);
+	gtk_label_set_xalign (GTK_LABEL (row->preview_label), 0.0);
+	gtk_label_set_wrap (GTK_LABEL (row->preview_label), TRUE);
+	gtk_label_set_wrap_mode (GTK_LABEL (row->preview_label), PANGO_WRAP_WORD_CHAR);
+	gtk_label_set_ellipsize (GTK_LABEL (row->preview_label), PANGO_ELLIPSIZE_NONE);
+	gtk_widget_add_css_class (row->preview_label, "dim-label");
 
 	gtk_label_set_xalign (GTK_LABEL (row->date_label), 1.0);
 	gtk_widget_set_halign (row->date_label, GTK_ALIGN_END);
@@ -823,10 +848,12 @@ item_list_view_create_row (ItemListView *ilv, itemPtr item, Node *node)
 	gtk_widget_set_halign (row->state_image, GTK_ALIGN_START);
 	gtk_widget_set_halign (row->favicon_image, GTK_ALIGN_START);
 	gtk_widget_set_hexpand (row->headline_label, TRUE);
+	gtk_widget_set_hexpand (row->preview_label, TRUE);
 
 	gtk_box_append (GTK_BOX (header_box), row->headline_label);
 	gtk_box_append (GTK_BOX (header_box), row->date_label);
 	gtk_box_append (GTK_BOX (text_box), header_box);
+	gtk_box_append (GTK_BOX (text_box), row->preview_label);
 
 	gtk_box_append (GTK_BOX (box), row->state_image);
 	gtk_box_append (GTK_BOX (box), row->favicon_image);

--- a/src/ui/item_list_view.h
+++ b/src/ui/item_list_view.h
@@ -109,15 +109,6 @@ void item_list_view_set_sort_column (ItemListView *ilv, nodeViewSortType sortTyp
 void item_list_view_remove_item (ItemListView *ilv, itemPtr item);
 
 /**
- * item_list_view_enable_favicon:
- * @ilv:		the ItemListView
- * @enabled:    	TRUE if column is to be visible
- *
- * Enable the favicon column of the currently displayed itemlist.
- */
-void item_list_view_enable_favicon_column (ItemListView *ilv, gboolean enabled);
-
-/**
  * item_list_view_update_item: (skip)
  * @ilv:	the ItemListView
  * @item:	the item


### PR DESCRIPTION
Initial conversion done, now missing

- [x] sort menu / headerbar button...
- [x] sizing in wide view
- [x] text wrap in wide view
- [x] date in wide view
- [x] "important" label is truncated in wide view (maybe use icon instead)

Implementation finished. Changes to 1.16:

- wide view item title now wraps to and displays up to 150 chars
- important label moved to end of teaser text
- GtkTreeView headers are now gone and replaced with a "Sort" submenu in the item list view context menu
- no more reordering GtkTreeView headers