### PR TITLE
Serialize feed item document as HTML, not XML

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -30,6 +30,7 @@
 #include <libxml/parser.h>
 #include <libxml/entities.h>
 #include <libxml/HTMLparser.h>
+#include <libxml/HTMLtree.h>
 #include <libxml/xpath.h>
 
 #include "common.h"
@@ -168,7 +169,7 @@ xhtml_extract (xmlNodePtr xml, gint xhtmlMode, const gchar *defaultBase)
 		return NULL;
 
 	buf = xmlBufferCreate ();
-	xmlNodeDump (buf, newDoc, xmlDocGetRootElement (newDoc), 0, 0 );
+	htmlNodeDump (buf, newDoc, xmlDocGetRootElement (newDoc) );
 
 	if (xmlBufferLength(buf) > 0)
 		result = (gchar *)xmlCharStrdup ((gchar *)xmlBufferContent (buf));


### PR DESCRIPTION
Liferea extracts a document from each feed item and then serializes it to give to WebKit for rendering. However, it was serializing the document as XML (XHTML) while delivering it to the WebKit web view as HTML. This means WebKit would not parse it as intended, since there are parsing differences between HTML and XML/XHTML.

In particular, the one I noticed is that libxml serializes empty tags as self-closing tags, but in HTML the XML self-closing tag syntax is ignored. For elements where a closing tag is optional or forbidden like `img`, this doesn't matter, but for tags like `iframe` or `script` where the element is usually empty but a closing tag is required, it means the tag is never closed in the HTML syntax and so the remainder of the document ends up being children of the `iframe`. Then DOMPurify deletes the `iframe` and its children, which means it's deleted everything after the first `iframe`.

If you look at a feed with `iframe`s such as embedded videos without this patch, the post body will be cut off at the first video.

Instead, Liferea should serialize the document in the language WebKit will use to parse it.

Although this kind of difference between parsers can often be a security issue, it happens before DOMPurify runs so I think it less likely in this case.