### PR TITLE
Rather forcefully initialize networking before updating feeds

### DIFF
--- a/src/liferea_application.c
+++ b/src/liferea_application.c
@@ -143,6 +143,7 @@ on_app_startup (GApplication *gapp, gpointer user_data)
 	/* Configuration necessary for network options, so it
 	   has to be initialized before network_init() */
 	conf_init ();
+	network_init();
 
 	/* Setup update queue handling */
 	app->updateQueue = update_job_queue_get_instance ();


### PR DESCRIPTION
Since version 2.0 (but not in 2.0-RC4), liferea may on startup enter a state where the update monitor shows all feeds in "updating" state and libsoup3 keeps complaining about

````
soup_session_send_and_read_async: assertion 'SOUP_IS_SESSION (session)' failed"
````

with the feeds actually never receiving an update. See https://github.com/lwindolf/liferea/issues/1588 for what I believe to be a manifestation of this.

Before commit f6d9ecb8980f630b30508b6ea094ff267d7fe57d, this line https://github.com/lwindolf/liferea/blob/v2.0-RC4/src/feedlist.c#L268 guaranteed that the NetworkMonitor - and with it, the networking subsystem containing the soup sessions - was initalized before the updater actually ran.
After that change, I don't see how the code guarantees the NetworkMonitor to be initialized in time for the updater (but that might be as well on me, as I'm not that familiar with gtk applications). The UpdateQueues seem to assume that the soup sessions are valid from the get-go, and fail miserably if that assumption does nbot hold.

As a quick fix I added a a call to network_init() right after conf_init() - that fixes the issue for me, but is perhaps not the way this code was designed.